### PR TITLE
ci(hacs): drop temporary `ignore: brands`

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -20,6 +20,3 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
-          # truenas_ce is not yet in home-assistant/brands; remove this once the
-          # brands PR (home-assistant/brands -> custom_integrations/truenas_ce) is merged.
-          ignore: brands


### PR DESCRIPTION
## Proposed change

Removes the temporary `ignore: brands` from the HACS Action workflow. The integration now ships its brand assets locally at `custom_components/truenas_ce/brand/` (`icon.png`, `icon@2x.png`, `dark_icon.png`, `dark_icon@2x.png`).

HACS validates the local brand directory at `custom_components/truenas_ce/brand/icon.png` (content is not in repo root) and only falls back to the `home-assistant/brands` repository when no local directory is present. A PR to `home-assistant/brands` is therefore **not required**, and the brands check can run unignored.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This is the precondition for submitting the repository to the HACS default store.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Remove the temporary `ignore: brands` configuration from the HACS Action workflow so brand validation is enforced.