### PR TITLE
docs: HACS My-link install button + fix docs-only PR deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,16 @@ on:
       - 'custom_components/**'
       - 'tests/**'
       - '.github/**'
+      - '**.md'
+      - 'docs/**'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'custom_components/**'
       - 'tests/**'
       - '.github/**'
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -222,14 +222,19 @@ target:
 > **Run buttons:** snapshot, rsync, replication and cloudsync tasks also expose a one-tap
 > **Run** button on their device page, so you can trigger them without calling an action.
 
-# Install integration from Custom Repository
-1. Open HACS, click the 3-dot menu in the upper right corner and select **Custom repositories**.
-2. Add the following details:
-   * **Repository:** `https://github.com/kayl-codes/homeassistant-truenas.git`
-   * **Category:** Integration
-3. Click **Add** and download the integration.
-4. Restart Home Assistant (full restart, not quick reload).
-5. Navigate to **Settings -> Devices & services -> Add Integration** and search for **TrueNAS**.
+# Install using HACS (recommended)
+
+[![Open your Home Assistant instance and open this repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=kayl-codes&repository=homeassistant-truenas&category=integration)
+
+1. Click the **My Home Assistant** button above — it opens HACS on your own instance directly on this
+   repository. (Manual alternative: open **HACS → 3-dot menu → Custom repositories**, add
+   `https://github.com/kayl-codes/homeassistant-truenas` with **Category: Integration**.)
+2. Click **Download** to install the integration.
+3. Restart Home Assistant (full restart, not quick reload).
+4. Navigate to **Settings → Devices & services → Add Integration** and search for **TrueNAS CE**.
+
+> Once the integration is accepted into the HACS default store you can also just search for
+> **TrueNAS CE** directly in HACS — until then, use the button or the custom-repository steps above.
 
 
 Minimum requirements:


### PR DESCRIPTION
## Proposed change

Two things:

1. **README:** adds a **My Home Assistant** deep-link install button (`my.home-assistant.io/redirect/hacs_repository/...`) so users can open this repository in HACS on their own instance with a single click — no manual custom-repository entry needed. The manual custom-repository steps remain as a fallback, and the search target was corrected to **TrueNAS CE**.
2. **CI:** extends the `paths` filters in `ci.yml` to also match `**.md` and `docs/**`. Documentation-only changes previously did not trigger the required Ruff / Python Tests / Bandit / hassfest checks, so a docs-only PR could never satisfy the branch-protection ruleset (which has no bypass actors) and deadlocked. This PR is itself the first to benefit.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- The HACS default-store listing is pending in hacs/default#8704; until it lands, the button and custom-repository steps let users install immediately.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a one-click My Home Assistant HACS install flow and ensure documentation-only changes trigger required CI checks.

CI:
- Extend CI path filters so markdown and docs changes also run the required checks, preventing docs-only pull requests from being blocked by branch protection.

Documentation:
- Update installation instructions to recommend HACS with a My Home Assistant deep-link button and clarify TrueNAS CE search/use until default store listing is available.