### PR TITLE
fix(#16): prevent frozen disk temperature history

### DIFF
--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -1547,12 +1547,15 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if netdata_temps:
             self._apply_netdata_disk_temps(netdata_temps)
 
-        if missing_disks := [
+        # When netdata is unavailable (returns None) refresh all disks via the
+        # API so a temperature set at boot doesn't stay frozen indefinitely.
+        fallback_disks = [
             uid
             for uid, vals in self.ds["disk"].items()
-            if vals.get("temperature") is None
-        ]:
-            self._fallback_disk_temperatures(missing_disks, bool(netdata_temps))
+            if vals.get("temperature") is None or netdata_temps is None
+        ]
+        if fallback_disks:
+            self._fallback_disk_temperatures(fallback_disks, bool(netdata_temps))
 
     def _apply_netdata_disk_temps(self, netdata_temps: dict[str, float]) -> None:
         """Map netdata temperatures to disk entities."""

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
         "TrueNASUptimeSensor": TrueNASUptimeSensor,
         "TrueNASCloudsyncSensor": TrueNASCloudsyncSensor,
         "TrueNASDatasetSensor": TrueNASDatasetSensor,
+        "TrueNASDiskSensor": TrueNASDiskSensor,
         "TrueNASRsyncSensor": TrueNASRsyncSensor,
         "TrueNASReplicationSensor": TrueNASReplicationSensor,
         "TrueNASSnapshotTaskSensor": TrueNASSnapshotTaskSensor,
@@ -124,6 +125,19 @@ class TrueNASSensor(TrueNASEntity, SensorEntity):
             return self.entity_description.native_unit_of_measurement
 
         return None
+
+
+# ---------------------------
+#   TrueNASDiskSensor
+# ---------------------------
+class TrueNASDiskSensor(TrueNASSensor):
+    """Disk temperature sensor.
+
+    force_update ensures HA records every poll value even when the temperature
+    is stable, so the history graph never appears frozen.
+    """
+
+    _attr_force_update = True
 
 
 # ---------------------------

--- a/custom_components/truenas_ce/sensor_types.py
+++ b/custom_components/truenas_ce/sensor_types.py
@@ -453,6 +453,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         data_uid=None,
         data_reference="identifier",
         data_attributes_list=DEVICE_ATTRIBUTES_DISK,
+        func="TrueNASDiskSensor",
     ),
     TrueNASSensorEntityDescription(
         key="pool_free",


### PR DESCRIPTION
## Proposed change

Fixes two related bugs that caused disk temperature sensors to appear static in Home Assistant history graphs.

**Bug 1 — coordinator: stale boot-time temperatures**

The `disk.temperatures` API fallback only triggered for disks whose temperature was still `None`. After the first successful fetch at startup, the fallback was never called again. If netdata became unavailable (e.g. after a TrueNAS update), temperatures stayed frozen at their boot-time values indefinitely with no warning in the logs.

Fix: when `_disk_temps_from_netdata()` returns `None` (netdata unavailable), the API fallback now runs for **all** disks, not just those still at `None`.

**Bug 2 — sensor: no history recorded for stable temperatures**

Without `force_update`, Home Assistant only writes a new recorder entry when a sensor value changes. A server at thermal equilibrium can hold the same temperature across many consecutive polls — the history graph appears flat/frozen even though the integration is actively fetching data.

Fix: disk temperature sensors now use a dedicated `TrueNASDiskSensor` class with `_attr_force_update = True`, ensuring every poll result is recorded as a new history point.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional information

Verified on TrueNAS 25.10.4 + HA 2026.6: after this fix `last_reported` advances on every coordinator poll (60 s) and disk temperature values show a continuous history graph.

Closes #16

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (`ruff check`, `ruff format --check`, `bandit`)
- [x] Tests have been added to cover the fix (N/A — no test suite yet)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Ensure disk temperature sensors maintain accurate, non-frozen history in Home Assistant by improving fallback behavior when Netdata is unavailable and introducing a dedicated disk sensor type with forced history updates.

Bug Fixes:
- Refresh all disk temperatures via the API when Netdata is unavailable so boot-time temperatures do not remain frozen.
- Force Home Assistant to record every disk temperature poll result so stable temperatures still generate history entries.

Enhancements:
- Introduce a dedicated TrueNASDiskSensor entity type for disk temperature reporting and wire it into disk sensor descriptions.