### PR TITLE
fix(sonar): replace pytz with stdlib datetime.UTC (S6890)

### DIFF
--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -1,11 +1,9 @@
 """API parser for JSON APIs."""
 
 from collections.abc import Hashable
-from datetime import datetime
+from datetime import UTC, datetime
 from logging import getLogger
 from typing import Any, TypedDict
-
-from pytz import utc
 
 _LOGGER = getLogger(__name__)
 
@@ -49,7 +47,7 @@ class ApiValueSpec(TypedDict, total=False):
 # ---------------------------
 def utc_from_timestamp(timestamp: float) -> datetime:
     """Return a UTC time from a timestamp."""
-    return datetime.fromtimestamp(timestamp, tz=utc)
+    return datetime.fromtimestamp(timestamp, tz=UTC)
 
 
 # ---------------------------
@@ -64,7 +62,7 @@ def human_date_to_utc(date_str: Any) -> datetime | None:
     if not isinstance(date_str, str):
         return None
     try:
-        return datetime.strptime(date_str, "%a %b %d %H:%M:%S %Y").replace(tzinfo=utc)
+        return datetime.strptime(date_str, "%a %b %d %H:%M:%S %Y").replace(tzinfo=UTC)
     except (ValueError, AttributeError):
         _LOGGER.debug("Failed to parse certificate date: %s", date_str)
         return None


### PR DESCRIPTION
## Proposed change

Removes the `pytz` dependency from `apiparser.py` and replaces it with the built-in `datetime.UTC` alias (Python 3.11+, target is 3.13).

- `from pytz import utc` → `from datetime import UTC, datetime`
- All `timezone.utc` / `tzinfo=utc` usages replaced with `UTC`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional information

Fixes SonarCloud CRITICAL finding **python:S6890** — *"Don't use pytz module with Python 3.9 and later."*

`pytz` was not listed as a runtime dependency in `manifest.json`, so there is no installation impact.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass (`ruff check`, `ruff format --check`, `bandit`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Replace use of the third-party pytz UTC timezone with the standard library datetime.UTC alias in the TrueNAS API parser.

Bug Fixes:
- Resolve SonarCloud rule python:S6890 by avoiding pytz with modern Python versions in the API timestamp and date parsing utilities.

Enhancements:
- Simplify timezone handling in API parsing utilities by relying on the built-in datetime.UTC instead of an external dependency.