### PR TITLE
fix: use OptionsFlowWithReload instead of manual update listener (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ The full, curated notes for each version live on the
 Items reference the related issue/PR as `(#NN)` where applicable.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
-Minimum requirements throughout this fork: **Home Assistant 2024.8.0**, **TrueNAS 25.04**.
+Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNAS 25.04**.
+
+## [2.4.1] — Deprecated update-listener fix
+
+### Fixed
+- **HA 2026.12 deprecation — config entry update listener (#24):** the options flow now
+  reloads the config entry via `OptionsFlowWithReload` instead of a manual
+  `add_update_listener` callback, removing the `custom integration 'truenas' has an update
+  listener and should use it for scheduling a reload` warning logged on every options save
+  (would have stopped working in Home Assistant 2026.12.0). No functional change — saving
+  options or reconfiguring the integration still reloads it exactly as before.
+
+### Changed
+- **Minimum Home Assistant version raised to 2025.8.0** (from 2024.8.0): required by the
+  `OptionsFlowWithReload` API used in the fix above.
 
 ## [2.4.0] — Cron job controls & HA 2026.7 compatibility
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is a Home Assistant **custom integration** (HACS-distributed) that monitors and controls a TrueNAS device. All integration code lives under [custom_components/truenas/](custom_components/truenas/). It targets TrueNAS 25.04+ and Home Assistant 2024.8.0+, and communicates with TrueNAS exclusively over its JSON-RPC **WebSocket** API (`local_polling`, 60s interval).
+This is a Home Assistant **custom integration** (HACS-distributed) that monitors and controls a TrueNAS device. All integration code lives under [custom_components/truenas/](custom_components/truenas/). It targets TrueNAS 25.04+ and Home Assistant 2025.8.0+, and communicates with TrueNAS exclusively over its JSON-RPC **WebSocket** API (`local_polling`, 60s interval).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ target:
 
 Minimum requirements:
 * TrueNAS 25.04 or later (tested with 25.10.4)
-* Home Assistant 2024.8.0
+* Home Assistant 2025.8.0
 
 ## Using TrueNAS development branch
 If you are using development branch for TrueNAS, some features may stop working.

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -486,19 +486,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         coordinator.async_add_listener(_handle_coordinator_refresh)
     )
 
-    # Reload the entry when the user saves new options so the coordinator
-    # picks up the changed poll interval / group toggles immediately.
-    config_entry.async_on_unload(
-        config_entry.add_update_listener(_async_options_updated)
-    )
     return True
-
-
-async def _async_options_updated(
-    hass: HomeAssistant, config_entry: ConfigEntry
-) -> None:
-    """Reload the integration when options change."""
-    await hass.config_entries.async_reload(config_entry.entry_id)
 
 
 # ---------------------------

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlow,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import (
     CONF_API_KEY,
@@ -316,7 +316,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlowWithReload:
         """Return the options flow handler."""
         return TrueNASOptionsFlow()
 
@@ -587,7 +587,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 # ---------------------------
 #   TrueNASOptionsFlow
 # ---------------------------
-class TrueNASOptionsFlow(OptionsFlow):
+class TrueNASOptionsFlow(OptionsFlowWithReload):
     """Handle TrueNAS integration options."""
 
     async def async_step_init(

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -11,5 +11,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
     "requirements": ["websockets>=15.0.1"],
-    "version": "2.4.0"
+    "version": "2.4.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "TrueNAS CE",
-    "homeassistant": "2024.8.0",
+    "homeassistant": "2025.8.0",
     "render_readme": false,
     "zip_release": true,
     "filename": "truenas_ce.zip"


### PR DESCRIPTION
## Proposed change

Home Assistant logs a deprecation warning whenever the TrueNAS integration's options are saved:

```
Detected that custom integration 'truenas' has an update listener and should use it for scheduling a reload. This will stop working in Home Assistant 2026.12.0
```

Root cause: the config flow's reconfigure step calls `async_update_reload_and_abort()`, which already schedules a reload — but the integration *also* registers a manual `config_entry.add_update_listener(...)` that reloads the entry itself. HA detects this redundant double-reload pattern and warns; it will stop being supported in HA 2026.12.0.

Fix: switch `TrueNASOptionsFlow` to `homeassistant.config_entries.OptionsFlowWithReload` (HA's built-in automatic-reload mechanism for options flows) and remove the now-redundant manual update listener + reload function from `__init__.py`.

No functional change — saving options or reconfiguring the integration still reloads it exactly as before; verified live (see test plan).

Fixes #24

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Raises the minimum supported Home Assistant version to **2025.8.0** (from 2024.8.0), since that's when `OptionsFlowWithReload` was introduced (home-assistant/core#146910). Updated `hacs.json`, `README.md` and `CLAUDE.md` accordingly.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Use Home Assistant’s built-in options flow reload mechanism and bump the minimum supported HA version.

Bug Fixes:
- Eliminate deprecated manual config entry update listener by switching the TrueNAS options flow to OptionsFlowWithReload, resolving the deprecation warning on options save.

Enhancements:
- Raise the minimum supported Home Assistant version to 2025.8.0 and document the new requirement across changelog, README, and contributor guidance files.
- Increment the integration version to 2.4.1 in the manifest and changelog.