### PR TITLE
feat: add reauth flow for invalid TrueNAS API keys

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # This file assigns code owners to automatically request reviews
-* @tomaae
+* @kayl-codes

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -74,6 +74,12 @@ from .const import (
 
 _LOGGER = getLogger(__name__)
 
+# Shared selector for the API key field, reused by every schema (initial setup,
+# reconfigure, reauth) so all three stay visually/behaviorally in sync.
+_API_KEY_SELECTOR = selector.TextSelector(
+    selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+)
+
 
 def _base_schema(truenas_config: Mapping[str, Any]) -> vol.Schema:
     """Generate base schema."""
@@ -86,9 +92,7 @@ def _base_schema(truenas_config: Mapping[str, Any]) -> vol.Schema:
         ): str,
         vol.Required(
             CONF_API_KEY, default=truenas_config.get(CONF_API_KEY, "")
-        ): selector.TextSelector(
-            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-        ),
+        ): _API_KEY_SELECTOR,
         vol.Required(
             CONF_VERIFY_SSL,
             default=truenas_config.get(CONF_VERIFY_SSL, DEFAULT_SSL_VERIFY),
@@ -141,9 +145,7 @@ def _reconfigure_schema(truenas_config: Mapping[str, Any]) -> vol.Schema:
             vol.Required(
                 CONF_HOST, default=truenas_config.get(CONF_HOST, DEFAULT_HOST)
             ): str,
-            vol.Optional(CONF_API_KEY): selector.TextSelector(
-                selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-            ),
+            vol.Optional(CONF_API_KEY): _API_KEY_SELECTOR,
             vol.Required(
                 CONF_VERIFY_SSL,
                 default=truenas_config.get(CONF_VERIFY_SSL, DEFAULT_SSL_VERIFY),
@@ -560,15 +562,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_API_KEY): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.PASSWORD
-                        )
-                    ),
-                }
-            ),
+            data_schema=vol.Schema({vol.Required(CONF_API_KEY): _API_KEY_SELECTOR}),
             errors=errors,
             description_placeholders={
                 CONF_NAME: reauth_entry.data.get(CONF_NAME, DEFAULT_DEVICE_NAME)

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -535,6 +535,46 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         if any(truenas_config.get(k) != entry_data.get(k) for k in _CONNECTION_KEYS):
             await self._validate_connection(truenas_config, errors)
 
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication triggered by an invalid API key."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ask for a new API key and validate it before updating the entry."""
+        reauth_entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            config = dict(reauth_entry.data)
+            config[CONF_API_KEY] = user_input[CONF_API_KEY]
+            await self._validate_connection(config, errors)
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_API_KEY): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                CONF_NAME: reauth_entry.data.get(CONF_NAME, DEFAULT_DEVICE_NAME)
+            },
+        )
+
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -468,6 +468,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not connected:
             if self.api.error == ERR_INVALID_KEY:
                 raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
+            _LOGGER.error("TrueNAS connection failed (error code: %s)", self.api.error)
             raise UpdateFailed(f"Error connecting to TrueNAS: {self.api.error}")
 
     # ---------------------------

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -453,20 +453,30 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.set_optimistic_running(data_path, object_id)
 
     # ---------------------------
+    #   _async_ensure_connected
+    # ---------------------------
+    async def _async_ensure_connected(self) -> None:
+        """Connect if needed, raising the appropriate coordinator error on failure."""
+        if self.api.connected():
+            return
+
+        try:
+            connected = await self.api.connect()
+        except Exception as e:
+            raise UpdateFailed(f"Error connecting to TrueNAS: {e}") from e
+
+        if not connected:
+            if self.api.error == ERR_INVALID_KEY:
+                raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
+            raise UpdateFailed(f"Error connecting to TrueNAS: {self.api.error}")
+
+    # ---------------------------
     #   _async_update_data
     # ---------------------------
     async def _async_update_data(self):
         """Update TrueNAS data."""
 
-        if not self.api.connected():
-            try:
-                connected = await self.api.connect()
-            except Exception as e:
-                raise UpdateFailed(f"Error connecting to TrueNAS: {e}") from e
-            if not connected:
-                if self.api.error == ERR_INVALID_KEY:
-                    raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
-                raise UpdateFailed(f"Error connecting to TrueNAS: {self.api.error}")
+        await self._async_ensure_connected()
 
         jobs = [
             self.get_systemstats,

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -460,10 +460,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if not self.api.connected():
             try:
-                await self.api.connect()
+                connected = await self.api.connect()
             except Exception as e:
                 raise UpdateFailed(f"Error connecting to TrueNAS: {e}") from e
-            if not self.api.connected() and self.api.error == ERR_INVALID_KEY:
+            if not connected and self.api.error == ERR_INVALID_KEY:
                 raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
 
         jobs = [

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -463,8 +463,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 connected = await self.api.connect()
             except Exception as e:
                 raise UpdateFailed(f"Error connecting to TrueNAS: {e}") from e
-            if not connected and self.api.error == ERR_INVALID_KEY:
-                raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
+            if not connected:
+                if self.api.error == ERR_INVALID_KEY:
+                    raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
+                raise UpdateFailed(f"Error connecting to TrueNAS: {self.api.error}")
 
         jobs = [
             self.get_systemstats,

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -34,6 +35,7 @@ from .const import (
     DEFAULT_MONITORED_GROUPS,
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
+    ERR_INVALID_KEY,
     ISSUE_MIGRATION_ROLLBACK,
     ISSUE_STATISTICS_ORPHANED,
     KILOBITS_TO_KIBIBYTES_FACTOR,
@@ -461,6 +463,8 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self.api.connect()
             except Exception as e:
                 raise UpdateFailed(f"Error connecting to TrueNAS: {e}") from e
+            if not self.api.connected() and self.api.error == ERR_INVALID_KEY:
+                raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
 
         jobs = [
             self.get_systemstats,

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -26,6 +26,13 @@
                     "dataset_passphrases": "Enter DatasetName#PassPhrase pairs (one per line, e.g. tank/encrypted#MySecret) to add or update stored passphrases. Leave empty to keep existing passphrases unchanged. Use the passphrase_remove action to delete a stored passphrase by its dataset path."
                 }
             },
+            "reauth_confirm": {
+                "title": "Reauthenticate TrueNAS",
+                "description": "The API key for \"{name}\" is no longer valid. Enter a new API key to restore the connection.",
+                "data": {
+                    "api_key": "API key"
+                }
+            },
             "migrate": {
                 "title": "Existing TrueNAS configuration found",
                 "description": "A previous TrueNAS integration was detected. You can take over its settings (host, API key and options) so you don't have to enter them again — your existing entities and their history are preserved. Or set up TrueNAS CE from scratch.",
@@ -57,7 +64,8 @@
             "passphrase_empty_name": "Empty dataset name is not allowed on line: {line}. Each line must be in the format: DatasetName#Passphrase."
         },
         "abort": {
-            "reconfigure_successful": "Reconfigure successful."
+            "reconfigure_successful": "Reconfigure successful.",
+            "reauth_successful": "Reauthentication successful."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -26,6 +26,13 @@
                     "dataset_passphrases": "DatasetName#Passphrase-Paare (eine pro Zeile, z. B. tank/encrypted#MeinGeheimnis) eingeben, um Passphrasen zu speichern oder zu aktualisieren. Leer lassen, um bestehende Passphrasen unverändert zu behalten. Zum Löschen einer gespeicherten Passphrase die Aktion passphrase_remove mit dem Dataset-Pfad verwenden."
                 }
             },
+            "reauth_confirm": {
+                "title": "TrueNAS erneut authentifizieren",
+                "description": "Der API-Schlüssel für \"{name}\" ist nicht mehr gültig. Gib einen neuen API-Schlüssel ein, um die Verbindung wiederherzustellen.",
+                "data": {
+                    "api_key": "API-Schlüssel"
+                }
+            },
             "migrate": {
                 "title": "Vorhandene TrueNAS-Konfiguration gefunden",
                 "description": "Eine frühere TrueNAS-Integration wurde erkannt. Du kannst ihre Einstellungen (Host, API-Schlüssel und Optionen) übernehmen, damit du sie nicht erneut eingeben musst — deine vorhandenen Entitäten und deren Verlauf bleiben erhalten. Oder richte TrueNAS CE von Grund auf neu ein.",
@@ -57,7 +64,8 @@
             "passphrase_empty_name": "Leerer Dataset-Name ist nicht erlaubt in Zeile: {line}. Jede Zeile muss das Format haben: DatasetName#Passphrase."
         },
         "abort": {
-            "reconfigure_successful": "Neukonfiguration erfolgreich."
+            "reconfigure_successful": "Neukonfiguration erfolgreich.",
+            "reauth_successful": "Erneute Authentifizierung erfolgreich."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -26,6 +26,13 @@
                     "dataset_passphrases": "Enter DatasetName#PassPhrase pairs (one per line, e.g. tank/encrypted#MySecret) to add or update stored passphrases. Leave empty to keep existing passphrases unchanged. Use the passphrase_remove action to delete a stored passphrase by its dataset path."
                 }
             },
+            "reauth_confirm": {
+                "title": "Reauthenticate TrueNAS",
+                "description": "The API key for \"{name}\" is no longer valid. Enter a new API key to restore the connection.",
+                "data": {
+                    "api_key": "API key"
+                }
+            },
             "migrate": {
                 "title": "Existing TrueNAS configuration found",
                 "description": "A previous TrueNAS integration was detected. You can take over its settings (host, API key and options) so you don't have to enter them again — your existing entities and their history are preserved. Or set up TrueNAS CE from scratch.",
@@ -57,7 +64,8 @@
             "passphrase_empty_name": "Empty dataset name is not allowed on line: {line}. Each line must be in the format: DatasetName#Passphrase."
         },
         "abort": {
-            "reconfigure_successful": "Reconfigure successful."
+            "reconfigure_successful": "Reconfigure successful.",
+            "reauth_successful": "Reauthentication successful."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -26,6 +26,13 @@
                     "dataset_passphrases": "Enter DatasetName#PassPhrase pairs (one per line, e.g. tank/encrypted#MySecret) to add or update stored passphrases. Leave empty to keep existing passphrases unchanged. Use the passphrase_remove action to delete a stored passphrase by its dataset path."
                 }
             },
+            "reauth_confirm": {
+                "title": "Reautenticar TrueNAS",
+                "description": "La clave API de \"{name}\" ya no es válida. Introduzca una nueva clave API para restablecer la conexión.",
+                "data": {
+                    "api_key": "Clave API"
+                }
+            },
             "migrate": {
                 "title": "Se encontró una configuración de TrueNAS existente",
                 "description": "Se detectó una integración de TrueNAS anterior. Puede adoptar sus ajustes (anfitrión, clave API y opciones) para no tener que introducirlos de nuevo — sus entidades existentes y su historial se conservan. O configure TrueNAS CE desde cero.",
@@ -57,7 +64,8 @@
             "passphrase_empty_name": "Empty dataset name is not allowed on line: {line}. Each line must be in the format: DatasetName#Passphrase."
         },
         "abort": {
-            "reconfigure_successful": "Reconfiguración exitosa."
+            "reconfigure_successful": "Reconfiguración exitosa.",
+            "reauth_successful": "Reautenticación exitosa."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -26,6 +26,13 @@
                     "dataset_passphrases": "Enter DatasetName#PassPhrase pairs (one per line, e.g. tank/encrypted#MySecret) to add or update stored passphrases. Leave empty to keep existing passphrases unchanged. Use the passphrase_remove action to delete a stored passphrase by its dataset path."
                 }
             },
+            "reauth_confirm": {
+                "title": "Reautenticar TrueNAS",
+                "description": "A chave API de \"{name}\" não é mais válida. Insira uma nova chave API para restaurar a conexão.",
+                "data": {
+                    "api_key": "Chave API"
+                }
+            },
             "migrate": {
                 "title": "Configuração existente do TrueNAS encontrada",
                 "description": "Uma integração TrueNAS anterior foi detectada. Você pode adotar suas configurações (host, chave API e opções) para não precisar inseri-las novamente — suas entidades existentes e seu histórico são preservados. Ou configure o TrueNAS CE do zero.",
@@ -57,7 +64,8 @@
             "passphrase_empty_name": "Empty dataset name is not allowed on line: {line}. Each line must be in the format: DatasetName#Passphrase."
         },
         "abort": {
-            "reconfigure_successful": "Reconfiguração bem-sucedida."
+            "reconfigure_successful": "Reconfiguração bem-sucedida.",
+            "reauth_successful": "Reautenticação bem-sucedida."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -26,6 +26,13 @@
                     "dataset_passphrases": "Enter DatasetName#PassPhrase pairs (one per line, e.g. tank/encrypted#MySecret) to add or update stored passphrases. Leave empty to keep existing passphrases unchanged. Use the passphrase_remove action to delete a stored passphrase by its dataset path."
                 }
             },
+            "reauth_confirm": {
+                "title": "Повторная аутентификация TrueNAS",
+                "description": "Ключ API для \"{name}\" больше недействителен. Введите новый ключ API, чтобы восстановить соединение.",
+                "data": {
+                    "api_key": "Ключ API"
+                }
+            },
             "migrate": {
                 "title": "Обнаружена существующая конфигурация TrueNAS",
                 "description": "Обнаружена предыдущая интеграция TrueNAS. Вы можете перенять её настройки (хост, ключ API и параметры), чтобы не вводить их заново — ваши существующие сущности и их история сохраняются. Либо настройте TrueNAS CE с нуля.",
@@ -57,7 +64,8 @@
             "passphrase_empty_name": "Empty dataset name is not allowed on line: {line}. Each line must be in the format: DatasetName#Passphrase."
         },
         "abort": {
-            "reconfigure_successful": "Перенастройка выполнена успешно."
+            "reconfigure_successful": "Перенастройка выполнена успешно.",
+            "reauth_successful": "Повторная аутентификация выполнена успешно."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -26,6 +26,13 @@
                     "dataset_passphrases": "Enter DatasetName#PassPhrase pairs (one per line, e.g. tank/encrypted#MySecret) to add or update stored passphrases. Leave empty to keep existing passphrases unchanged. Use the passphrase_remove action to delete a stored passphrase by its dataset path."
                 }
             },
+            "reauth_confirm": {
+                "title": "Opätovná autentifikácia TrueNAS",
+                "description": "API kľúč pre \"{name}\" už nie je platný. Zadajte nový API kľúč na obnovenie pripojenia.",
+                "data": {
+                    "api_key": "API kľúč"
+                }
+            },
             "migrate": {
                 "title": "Nájdená existujúca konfigurácia TrueNAS",
                 "description": "Bola zistená predchádzajúca integrácia TrueNAS. Môžete prevziať jej nastavenia (hostiteľ, kľúč API a možnosti), aby ste ich nemuseli zadávať znova — vaše existujúce entity a ich história sa zachovajú. Alebo nastavte TrueNAS CE od začiatku.",
@@ -57,7 +64,8 @@
             "passphrase_empty_name": "Empty dataset name is not allowed on line: {line}. Each line must be in the format: DatasetName#Passphrase."
         },
         "abort": {
-            "reconfigure_successful": "Rekonfigurácia úspešná."
+            "reconfigure_successful": "Rekonfigurácia úspešná.",
+            "reauth_successful": "Opätovná autentifikácia úspešná."
         }
     },
     "options": {


### PR DESCRIPTION
## Proposed change

Adds a Home Assistant reauth flow that triggers automatically when the TrueNAS API key becomes invalid. Previously an invalid/revoked key just left the integration silently unavailable; now the coordinator raises `ConfigEntryAuthFailed`, which HA surfaces as a Repair issue and offers a guided reauth config-flow step to enter a new key without removing/re-adding the integration.

Also fixes CODEOWNERS to point to `@kayl-codes` (was stale).

## Type of change

- [ ] Bugfix
- [x] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Live-tested against the real TrueNAS instance: temporarily invalidated the stored API key, confirmed a Repair issue (`config_entry_reauth_truenas_ce_<entry_id>`, severity error) was created, then restored the original key and confirmed the repair cleared and the integration returned to normal operation.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Add automatic reauthentication handling for invalid TrueNAS API keys and adjust related configuration, error handling, and ownership metadata.

New Features:
- Introduce a reauthentication config flow that prompts users to enter a new TrueNAS API key when the existing key becomes invalid.

Enhancements:
- Refactor the config flow to reuse a shared password selector for the API key field across initial setup, reconfiguration, and reauth forms.
- Update the data coordinator to centralize connection handling and surface invalid API keys as authentication failures instead of generic update errors.

Chores:
- Update CODEOWNERS and localization strings to reflect the new reauth flow and current maintainer.