### PR TITLE
test: add unit tests for apiparser.py normalization helpers

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,8 @@ wheel = ">=0.45"
 pygithub = ">=2.6"
 homeassistant = ">=2025.4.0"
 pre-commit = ">=4.0"
+pytest = ">=8.0"
+pytest-asyncio = ">=0.24"
 
 
 [packages]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared pytest fixtures for the TrueNAS integration test suite.
+
+Several test modules exercise standalone files (``apiparser.py``, the CI
+translation validator) that are not installable packages and would otherwise
+require ``homeassistant``/``aiotruenas`` to be importable. Loading them by
+file path is centralized here so the repo layout is only encoded once, and
+failures surface as an explicit ``ImportError`` at fixture setup rather than
+a bare ``assert`` at module-import time.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_module_from_path(name: str, path: Path) -> ModuleType:
+    """Load a standalone module by file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load module {name!r} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return REPO_ROOT
+
+
+@pytest.fixture(scope="session")
+def ap() -> ModuleType:
+    """The ``custom_components.truenas_ce.apiparser`` module under test."""
+    path = REPO_ROOT / "custom_components" / "truenas_ce" / "apiparser.py"
+    return load_module_from_path("apiparser", path)
+
+
+@pytest.fixture(scope="session")
+def vt() -> ModuleType:
+    """The ``.github/validate_translations.py`` script under test."""
+    path = REPO_ROOT / ".github" / "validate_translations.py"
+    return load_module_from_path("validate_translations", path)

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -97,9 +97,22 @@ def test_from_entry_bool_missing_returns_default(ap: ModuleType) -> None:
     assert ap.from_entry_bool({}, "a", default=True) is True
 
 
+def test_from_entry_bool_none_value_uses_default(ap: ModuleType) -> None:
+    assert ap.from_entry_bool({"a": None}, "a") is False
+    assert ap.from_entry_bool({"a": None}, "a", default=True) is True
+
+
 def test_from_entry_bool_reverse(ap: ModuleType) -> None:
     assert ap.from_entry_bool({"a": True}, "a", reverse=True) is False
     assert ap.from_entry_bool({"a": "off"}, "a", reverse=True) is True
+
+
+def test_from_entry_bool_missing_key_reverse_returns_default_unchanged(
+    ap: ModuleType,
+) -> None:
+    """A missing key short-circuits to ``default``; ``reverse`` never applies to it."""
+    assert ap.from_entry_bool({}, "a", default=True, reverse=True) is True
+    assert ap.from_entry_bool({}, "a", default=False, reverse=True) is False
 
 
 # ---------------------------
@@ -128,6 +141,20 @@ def test_generate_keymap_none_when_no_key_search(ap: ModuleType) -> None:
 
 def test_generate_keymap_builds_reverse_map(ap: ModuleType) -> None:
     data = {"uid-1": {"guid": "guid-1"}, "uid-2": {}}
+    assert ap.generate_keymap(data, "guid") == {"guid-1": "uid-1"}
+
+
+def test_generate_keymap_ignores_non_dict_values(ap: ModuleType) -> None:
+    data = {"uid-1": "unexpected", "uid-2": {"guid": "guid-2"}}
+    assert ap.generate_keymap(data, "guid") == {"guid-2": "uid-2"}
+
+
+def test_generate_keymap_skips_entries_missing_key_search(ap: ModuleType) -> None:
+    data = {
+        "uid-1": {"guid": "guid-1"},
+        "uid-2": {},
+        "uid-3": {"other": "value"},
+    }
     assert ap.generate_keymap(data, "guid") == {"guid-1": "uid-1"}
 
 
@@ -237,6 +264,23 @@ def test_parse_api_skip_filter_excludes_matching(ap: ModuleType) -> None:
     assert result == {"2": {"enabled": True}}
 
 
+def test_parse_api_only_and_skip_combined_skip_wins_on_overlap(ap: ModuleType) -> None:
+    """An entry matching both ``only`` and ``skip`` is excluded: ``skip`` wins."""
+    source = [
+        {"id": "1", "type": "DISK", "enabled": False},
+        {"id": "2", "type": "DISK", "enabled": True},
+        {"id": "3", "type": "SSD", "enabled": True},
+    ]
+    result = ap.parse_api(
+        source=source,
+        key="id",
+        vals=[{"name": "type"}],
+        only=[{"key": "type", "value": "DISK"}],
+        skip=[{"name": "enabled", "value": False}],
+    )
+    assert result == {"2": {"type": "DISK"}}
+
+
 def test_parse_api_ensure_vals_adds_missing_keys(ap: ModuleType) -> None:
     result = ap.parse_api(
         source=[{"id": "1"}],
@@ -275,6 +319,12 @@ def test_parse_api_convert_timestamp_millis(ap: ModuleType) -> None:
 
 def test_parse_api_no_key_no_search_targets_root(ap: ModuleType) -> None:
     result = ap.parse_api(source=[{"total": 42}], vals=[{"name": "total"}])
+    assert result == {"total": 42}
+
+
+def test_parse_api_no_key_no_search_single_dict_targets_root(ap: ModuleType) -> None:
+    """A single-dict ``source`` behaves identically to a one-item list."""
+    result = ap.parse_api(source={"total": 42}, vals=[{"name": "total"}])
     assert result == {"total": 42}
 
 

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -7,25 +7,16 @@ HA Core integration submission.
 
 from __future__ import annotations
 
-import importlib.util
 from datetime import UTC, datetime
-from pathlib import Path
+from types import ModuleType
 
 import pytest
-
-_REPO = Path(__file__).resolve().parents[1]
-_MODULE_PATH = _REPO / "custom_components" / "truenas_ce" / "apiparser.py"
-
-_spec = importlib.util.spec_from_file_location("apiparser", _MODULE_PATH)
-assert _spec and _spec.loader
-ap = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(ap)
 
 
 # ---------------------------
 #   utc_from_timestamp / human_date_to_utc
 # ---------------------------
-def test_utc_from_timestamp() -> None:
+def test_utc_from_timestamp(ap: ModuleType) -> None:
     assert ap.utc_from_timestamp(0) == datetime(1970, 1, 1, tzinfo=UTC)
 
 
@@ -38,41 +29,41 @@ def test_utc_from_timestamp() -> None:
         (12345, None),
     ],
 )
-def test_human_date_to_utc(date_str, expected) -> None:
+def test_human_date_to_utc(ap: ModuleType, date_str, expected) -> None:
     assert ap.human_date_to_utc(date_str) == expected
 
 
 # ---------------------------
 #   from_entry
 # ---------------------------
-def test_from_entry_returns_value() -> None:
+def test_from_entry_returns_value(ap: ModuleType) -> None:
     assert ap.from_entry({"a": "b"}, "a") == "b"
 
 
-def test_from_entry_missing_returns_default() -> None:
+def test_from_entry_missing_returns_default(ap: ModuleType) -> None:
     assert ap.from_entry({"a": "b"}, "missing", default="fallback") == "fallback"
 
 
-def test_from_entry_none_entry_returns_default() -> None:
+def test_from_entry_none_entry_returns_default(ap: ModuleType) -> None:
     assert ap.from_entry(None, "a", default="fallback") == "fallback"
 
 
-def test_from_entry_nested_path() -> None:
+def test_from_entry_nested_path(ap: ModuleType) -> None:
     entry = {"scan": {"start_time": {"$date": 1700000000000}}}
     assert ap.from_entry(entry, "scan/start_time/$date") == 1700000000000
 
 
-def test_from_entry_nested_path_missing_segment() -> None:
+def test_from_entry_nested_path_missing_segment(ap: ModuleType) -> None:
     entry = {"scan": {"start_time": {}}}
     assert ap.from_entry(entry, "scan/start_time/$date", default="none") == "none"
 
 
-def test_from_entry_truncates_long_strings() -> None:
+def test_from_entry_truncates_long_strings(ap: ModuleType) -> None:
     entry = {"a": "x" * 300}
     assert ap.from_entry(entry, "a", max_len=10) == "x" * 10
 
 
-def test_from_entry_rounds_floats() -> None:
+def test_from_entry_rounds_floats(ap: ModuleType) -> None:
     entry = {"a": 1.23456}
     assert ap.from_entry(entry, "a", round_digits=2) == pytest.approx(1.23)
 
@@ -98,15 +89,15 @@ def test_from_entry_rounds_floats() -> None:
         ("unrecognized", False),
     ],
 )
-def test_from_entry_bool_coercion(value, expected) -> None:
+def test_from_entry_bool_coercion(ap: ModuleType, value, expected) -> None:
     assert ap.from_entry_bool({"a": value}, "a") is expected
 
 
-def test_from_entry_bool_missing_returns_default() -> None:
+def test_from_entry_bool_missing_returns_default(ap: ModuleType) -> None:
     assert ap.from_entry_bool({}, "a", default=True) is True
 
 
-def test_from_entry_bool_reverse() -> None:
+def test_from_entry_bool_reverse(ap: ModuleType) -> None:
     assert ap.from_entry_bool({"a": True}, "a", reverse=True) is False
     assert ap.from_entry_bool({"a": "off"}, "a", reverse=True) is True
 
@@ -114,28 +105,28 @@ def test_from_entry_bool_reverse() -> None:
 # ---------------------------
 #   get_uid / generate_keymap
 # ---------------------------
-def test_get_uid_by_key() -> None:
+def test_get_uid_by_key(ap: ModuleType) -> None:
     assert ap.get_uid({"id": "abc"}, "id", None, None, None) == "abc"
 
 
-def test_get_uid_by_key_secondary() -> None:
+def test_get_uid_by_key_secondary(ap: ModuleType) -> None:
     assert ap.get_uid({"other": "abc"}, "id", "other", None, None) == "abc"
 
 
-def test_get_uid_non_dict_entry_returns_none() -> None:
+def test_get_uid_non_dict_entry_returns_none(ap: ModuleType) -> None:
     assert ap.get_uid("not-a-dict", "id", None, None, None) is None
 
 
-def test_get_uid_via_key_search() -> None:
+def test_get_uid_via_key_search(ap: ModuleType) -> None:
     keymap = {"guid-1": "uid-1"}
     assert ap.get_uid({"guid": "guid-1"}, None, None, "guid", keymap) == "uid-1"
 
 
-def test_generate_keymap_none_when_no_key_search() -> None:
+def test_generate_keymap_none_when_no_key_search(ap: ModuleType) -> None:
     assert ap.generate_keymap({"uid-1": {"guid": "guid-1"}}, None) is None
 
 
-def test_generate_keymap_builds_reverse_map() -> None:
+def test_generate_keymap_builds_reverse_map(ap: ModuleType) -> None:
     data = {"uid-1": {"guid": "guid-1"}, "uid-2": {}}
     assert ap.generate_keymap(data, "guid") == {"guid-1": "uid-1"}
 
@@ -143,19 +134,19 @@ def test_generate_keymap_builds_reverse_map() -> None:
 # ---------------------------
 #   matches_only / can_skip
 # ---------------------------
-def test_matches_only_all_match() -> None:
+def test_matches_only_all_match(ap: ModuleType) -> None:
     only = [{"key": "type", "value": "DISK"}]
     assert ap.matches_only({"type": "DISK"}, only) is True
     assert ap.matches_only({"type": "SSD"}, only) is False
 
 
-def test_can_skip_matches_value() -> None:
+def test_can_skip_matches_value(ap: ModuleType) -> None:
     skip = [{"name": "enabled", "value": False}]
     assert ap.can_skip({"enabled": False}, skip) is True
     assert ap.can_skip({"enabled": True}, skip) is False
 
 
-def test_can_skip_missing_key_with_empty_value() -> None:
+def test_can_skip_missing_key_with_empty_value(ap: ModuleType) -> None:
     skip = [{"name": "enabled", "value": ""}]
     assert ap.can_skip({}, skip) is True
 
@@ -163,7 +154,7 @@ def test_can_skip_missing_key_with_empty_value() -> None:
 # ---------------------------
 #   fill_defaults
 # ---------------------------
-def test_fill_defaults_str_and_bool() -> None:
+def test_fill_defaults_str_and_bool(ap: ModuleType) -> None:
     vals: list[ap.ApiValueSpec] = [
         {"name": "label", "default": "n/a"},
         {"name": "enabled", "type": "bool", "default": True},
@@ -171,19 +162,19 @@ def test_fill_defaults_str_and_bool() -> None:
     assert ap.fill_defaults({}, vals) == {"label": "n/a", "enabled": True}
 
 
-def test_fill_defaults_bool_reverse() -> None:
+def test_fill_defaults_bool_reverse(ap: ModuleType) -> None:
     vals: list[ap.ApiValueSpec] = [
         {"name": "disabled", "type": "bool", "default": True, "reverse": True}
     ]
     assert ap.fill_defaults({}, vals) == {"disabled": False}
 
 
-def test_fill_defaults_does_not_overwrite_existing() -> None:
+def test_fill_defaults_does_not_overwrite_existing(ap: ModuleType) -> None:
     vals: list[ap.ApiValueSpec] = [{"name": "label", "default": "n/a"}]
     assert ap.fill_defaults({"label": "kept"}, vals) == {"label": "kept"}
 
 
-def test_fill_defaults_none_data() -> None:
+def test_fill_defaults_none_data(ap: ModuleType) -> None:
     assert ap.fill_defaults(None, [{"name": "label", "default": "n/a"}]) == {
         "label": "n/a"
     }
@@ -192,16 +183,18 @@ def test_fill_defaults_none_data() -> None:
 # ---------------------------
 #   parse_api
 # ---------------------------
-def test_parse_api_empty_source_fills_defaults() -> None:
+def test_parse_api_empty_source_fills_defaults(ap: ModuleType) -> None:
     vals: list[ap.ApiValueSpec] = [{"name": "label", "default": "n/a"}]
     assert ap.parse_api(source=None, vals=vals) == {"label": "n/a"}
 
 
-def test_parse_api_empty_source_with_key_returns_data_unchanged() -> None:
+def test_parse_api_empty_source_with_key_returns_data_unchanged(
+    ap: ModuleType,
+) -> None:
     assert ap.parse_api(data={"existing": {}}, source=[], key="id") == {"existing": {}}
 
 
-def test_parse_api_single_dict_source_is_wrapped() -> None:
+def test_parse_api_single_dict_source_is_wrapped(ap: ModuleType) -> None:
     result = ap.parse_api(
         source={"id": "1", "name": "pool0"},
         key="id",
@@ -210,7 +203,7 @@ def test_parse_api_single_dict_source_is_wrapped() -> None:
     assert result == {"1": {"name": "pool0"}}
 
 
-def test_parse_api_multiple_entries_by_key() -> None:
+def test_parse_api_multiple_entries_by_key(ap: ModuleType) -> None:
     source = [
         {"id": "1", "name": "pool0"},
         {"id": "2", "name": "pool1"},
@@ -219,7 +212,7 @@ def test_parse_api_multiple_entries_by_key() -> None:
     assert result == {"1": {"name": "pool0"}, "2": {"name": "pool1"}}
 
 
-def test_parse_api_only_filter_skips_non_matching() -> None:
+def test_parse_api_only_filter_skips_non_matching(ap: ModuleType) -> None:
     source = [{"id": "1", "type": "DISK"}, {"id": "2", "type": "SSD"}]
     result = ap.parse_api(
         source=source,
@@ -230,7 +223,7 @@ def test_parse_api_only_filter_skips_non_matching() -> None:
     assert result == {"1": {"type": "DISK"}}
 
 
-def test_parse_api_skip_filter_excludes_matching() -> None:
+def test_parse_api_skip_filter_excludes_matching(ap: ModuleType) -> None:
     source = [
         {"id": "1", "enabled": False},
         {"id": "2", "enabled": True},
@@ -244,7 +237,7 @@ def test_parse_api_skip_filter_excludes_matching() -> None:
     assert result == {"2": {"enabled": True}}
 
 
-def test_parse_api_ensure_vals_adds_missing_keys() -> None:
+def test_parse_api_ensure_vals_adds_missing_keys(ap: ModuleType) -> None:
     result = ap.parse_api(
         source=[{"id": "1"}],
         key="id",
@@ -253,7 +246,7 @@ def test_parse_api_ensure_vals_adds_missing_keys() -> None:
     assert result == {"1": {"extra": "fallback"}}
 
 
-def test_parse_api_key_search_maps_to_existing_uid() -> None:
+def test_parse_api_key_search_maps_to_existing_uid(ap: ModuleType) -> None:
     data = {"uid-1": {"guid": "guid-1", "name": "old"}}
     source = [{"guid": "guid-1", "name": "new"}]
     result = ap.parse_api(
@@ -262,7 +255,7 @@ def test_parse_api_key_search_maps_to_existing_uid() -> None:
     assert result == {"uid-1": {"guid": "guid-1", "name": "new"}}
 
 
-def test_parse_api_convert_timestamp() -> None:
+def test_parse_api_convert_timestamp(ap: ModuleType) -> None:
     result = ap.parse_api(
         source=[{"id": "1", "started": 1700000000}],
         key="id",
@@ -271,7 +264,7 @@ def test_parse_api_convert_timestamp() -> None:
     assert result["1"]["started"] == ap.utc_from_timestamp(1700000000)
 
 
-def test_parse_api_convert_timestamp_millis() -> None:
+def test_parse_api_convert_timestamp_millis(ap: ModuleType) -> None:
     result = ap.parse_api(
         source=[{"id": "1", "started": 1700000000000}],
         key="id",
@@ -280,7 +273,7 @@ def test_parse_api_convert_timestamp_millis() -> None:
     assert result["1"]["started"] == ap.utc_from_timestamp(1700000000)
 
 
-def test_parse_api_no_key_no_search_targets_root() -> None:
+def test_parse_api_no_key_no_search_targets_root(ap: ModuleType) -> None:
     result = ap.parse_api(source=[{"total": 42}], vals=[{"name": "total"}])
     assert result == {"total": 42}
 
@@ -288,7 +281,7 @@ def test_parse_api_no_key_no_search_targets_root() -> None:
 # ---------------------------
 #   fill_vals_proc (combine action)
 # ---------------------------
-def test_fill_vals_proc_combine() -> None:
+def test_fill_vals_proc_combine(ap: ModuleType) -> None:
     data = {"uid-1": {"host": "truenas", "port": "443"}}
     val_proc = [
         [
@@ -304,7 +297,7 @@ def test_fill_vals_proc_combine() -> None:
     assert result["uid-1"]["url"] == "https://truenas:443"
 
 
-def test_fill_vals_proc_unsupported_action_raises() -> None:
+def test_fill_vals_proc_unsupported_action_raises(ap: ModuleType) -> None:
     val_proc = [[{"name": "url"}, {"action": "unsupported"}]]
     with pytest.raises(ValueError, match="Unsupported action"):
         ap.fill_vals_proc({"uid-1": {}}, "uid-1", val_proc)

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -74,7 +74,7 @@ def test_from_entry_truncates_long_strings() -> None:
 
 def test_from_entry_rounds_floats() -> None:
     entry = {"a": 1.23456}
-    assert ap.from_entry(entry, "a", round_digits=2) == 1.23
+    assert ap.from_entry(entry, "a", round_digits=2) == pytest.approx(1.23)
 
 
 # ---------------------------

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -1,0 +1,310 @@
+"""Unit tests for ``custom_components.truenas_ce.apiparser``.
+
+These are pure-function tests (no Home Assistant import needed) mirroring how
+HA Core itself tests standalone helper modules, in preparation for the
+HA Core integration submission.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_MODULE_PATH = _REPO / "custom_components" / "truenas_ce" / "apiparser.py"
+
+_spec = importlib.util.spec_from_file_location("apiparser", _MODULE_PATH)
+assert _spec and _spec.loader
+ap = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ap)
+
+
+# ---------------------------
+#   utc_from_timestamp / human_date_to_utc
+# ---------------------------
+def test_utc_from_timestamp() -> None:
+    assert ap.utc_from_timestamp(0) == datetime(1970, 1, 1, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("date_str", "expected"),
+    [
+        ("Fri Mar 26 00:59:59 2100", datetime(2100, 3, 26, 0, 59, 59, tzinfo=UTC)),
+        ("not a date", None),
+        (None, None),
+        (12345, None),
+    ],
+)
+def test_human_date_to_utc(date_str, expected) -> None:
+    assert ap.human_date_to_utc(date_str) == expected
+
+
+# ---------------------------
+#   from_entry
+# ---------------------------
+def test_from_entry_returns_value() -> None:
+    assert ap.from_entry({"a": "b"}, "a") == "b"
+
+
+def test_from_entry_missing_returns_default() -> None:
+    assert ap.from_entry({"a": "b"}, "missing", default="fallback") == "fallback"
+
+
+def test_from_entry_none_entry_returns_default() -> None:
+    assert ap.from_entry(None, "a", default="fallback") == "fallback"
+
+
+def test_from_entry_nested_path() -> None:
+    entry = {"scan": {"start_time": {"$date": 1700000000000}}}
+    assert ap.from_entry(entry, "scan/start_time/$date") == 1700000000000
+
+
+def test_from_entry_nested_path_missing_segment() -> None:
+    entry = {"scan": {"start_time": {}}}
+    assert ap.from_entry(entry, "scan/start_time/$date", default="none") == "none"
+
+
+def test_from_entry_truncates_long_strings() -> None:
+    entry = {"a": "x" * 300}
+    assert ap.from_entry(entry, "a", max_len=10) == "x" * 10
+
+
+def test_from_entry_rounds_floats() -> None:
+    entry = {"a": 1.23456}
+    assert ap.from_entry(entry, "a", round_digits=2) == 1.23
+
+
+# ---------------------------
+#   from_entry_bool
+# ---------------------------
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("on", True),
+        ("YES", True),
+        ("up", True),
+        ("true", True),
+        ("1", True),
+        ("off", False),
+        ("no", False),
+        ("down", False),
+        ("false", False),
+        ("0", False),
+        ("unrecognized", False),
+    ],
+)
+def test_from_entry_bool_coercion(value, expected) -> None:
+    assert ap.from_entry_bool({"a": value}, "a") is expected
+
+
+def test_from_entry_bool_missing_returns_default() -> None:
+    assert ap.from_entry_bool({}, "a", default=True) is True
+
+
+def test_from_entry_bool_reverse() -> None:
+    assert ap.from_entry_bool({"a": True}, "a", reverse=True) is False
+    assert ap.from_entry_bool({"a": "off"}, "a", reverse=True) is True
+
+
+# ---------------------------
+#   get_uid / generate_keymap
+# ---------------------------
+def test_get_uid_by_key() -> None:
+    assert ap.get_uid({"id": "abc"}, "id", None, None, None) == "abc"
+
+
+def test_get_uid_by_key_secondary() -> None:
+    assert ap.get_uid({"other": "abc"}, "id", "other", None, None) == "abc"
+
+
+def test_get_uid_non_dict_entry_returns_none() -> None:
+    assert ap.get_uid("not-a-dict", "id", None, None, None) is None
+
+
+def test_get_uid_via_key_search() -> None:
+    keymap = {"guid-1": "uid-1"}
+    assert ap.get_uid({"guid": "guid-1"}, None, None, "guid", keymap) == "uid-1"
+
+
+def test_generate_keymap_none_when_no_key_search() -> None:
+    assert ap.generate_keymap({"uid-1": {"guid": "guid-1"}}, None) is None
+
+
+def test_generate_keymap_builds_reverse_map() -> None:
+    data = {"uid-1": {"guid": "guid-1"}, "uid-2": {}}
+    assert ap.generate_keymap(data, "guid") == {"guid-1": "uid-1"}
+
+
+# ---------------------------
+#   matches_only / can_skip
+# ---------------------------
+def test_matches_only_all_match() -> None:
+    only = [{"key": "type", "value": "DISK"}]
+    assert ap.matches_only({"type": "DISK"}, only) is True
+    assert ap.matches_only({"type": "SSD"}, only) is False
+
+
+def test_can_skip_matches_value() -> None:
+    skip = [{"name": "enabled", "value": False}]
+    assert ap.can_skip({"enabled": False}, skip) is True
+    assert ap.can_skip({"enabled": True}, skip) is False
+
+
+def test_can_skip_missing_key_with_empty_value() -> None:
+    skip = [{"name": "enabled", "value": ""}]
+    assert ap.can_skip({}, skip) is True
+
+
+# ---------------------------
+#   fill_defaults
+# ---------------------------
+def test_fill_defaults_str_and_bool() -> None:
+    vals: list[ap.ApiValueSpec] = [
+        {"name": "label", "default": "n/a"},
+        {"name": "enabled", "type": "bool", "default": True},
+    ]
+    assert ap.fill_defaults({}, vals) == {"label": "n/a", "enabled": True}
+
+
+def test_fill_defaults_bool_reverse() -> None:
+    vals: list[ap.ApiValueSpec] = [
+        {"name": "disabled", "type": "bool", "default": True, "reverse": True}
+    ]
+    assert ap.fill_defaults({}, vals) == {"disabled": False}
+
+
+def test_fill_defaults_does_not_overwrite_existing() -> None:
+    vals: list[ap.ApiValueSpec] = [{"name": "label", "default": "n/a"}]
+    assert ap.fill_defaults({"label": "kept"}, vals) == {"label": "kept"}
+
+
+def test_fill_defaults_none_data() -> None:
+    assert ap.fill_defaults(None, [{"name": "label", "default": "n/a"}]) == {
+        "label": "n/a"
+    }
+
+
+# ---------------------------
+#   parse_api
+# ---------------------------
+def test_parse_api_empty_source_fills_defaults() -> None:
+    vals: list[ap.ApiValueSpec] = [{"name": "label", "default": "n/a"}]
+    assert ap.parse_api(source=None, vals=vals) == {"label": "n/a"}
+
+
+def test_parse_api_empty_source_with_key_returns_data_unchanged() -> None:
+    assert ap.parse_api(data={"existing": {}}, source=[], key="id") == {"existing": {}}
+
+
+def test_parse_api_single_dict_source_is_wrapped() -> None:
+    result = ap.parse_api(
+        source={"id": "1", "name": "pool0"},
+        key="id",
+        vals=[{"name": "name"}],
+    )
+    assert result == {"1": {"name": "pool0"}}
+
+
+def test_parse_api_multiple_entries_by_key() -> None:
+    source = [
+        {"id": "1", "name": "pool0"},
+        {"id": "2", "name": "pool1"},
+    ]
+    result = ap.parse_api(source=source, key="id", vals=[{"name": "name"}])
+    assert result == {"1": {"name": "pool0"}, "2": {"name": "pool1"}}
+
+
+def test_parse_api_only_filter_skips_non_matching() -> None:
+    source = [{"id": "1", "type": "DISK"}, {"id": "2", "type": "SSD"}]
+    result = ap.parse_api(
+        source=source,
+        key="id",
+        vals=[{"name": "type"}],
+        only=[{"key": "type", "value": "DISK"}],
+    )
+    assert result == {"1": {"type": "DISK"}}
+
+
+def test_parse_api_skip_filter_excludes_matching() -> None:
+    source = [
+        {"id": "1", "enabled": False},
+        {"id": "2", "enabled": True},
+    ]
+    result = ap.parse_api(
+        source=source,
+        key="id",
+        vals=[{"name": "enabled", "type": "bool"}],
+        skip=[{"name": "enabled", "value": False}],
+    )
+    assert result == {"2": {"enabled": True}}
+
+
+def test_parse_api_ensure_vals_adds_missing_keys() -> None:
+    result = ap.parse_api(
+        source=[{"id": "1"}],
+        key="id",
+        ensure_vals=[{"name": "extra", "default": "fallback"}],
+    )
+    assert result == {"1": {"extra": "fallback"}}
+
+
+def test_parse_api_key_search_maps_to_existing_uid() -> None:
+    data = {"uid-1": {"guid": "guid-1", "name": "old"}}
+    source = [{"guid": "guid-1", "name": "new"}]
+    result = ap.parse_api(
+        data=data, source=source, key_search="guid", vals=[{"name": "name"}]
+    )
+    assert result == {"uid-1": {"guid": "guid-1", "name": "new"}}
+
+
+def test_parse_api_convert_timestamp() -> None:
+    result = ap.parse_api(
+        source=[{"id": "1", "started": 1700000000}],
+        key="id",
+        vals=[{"name": "started", "convert": "utc_from_timestamp"}],
+    )
+    assert result["1"]["started"] == ap.utc_from_timestamp(1700000000)
+
+
+def test_parse_api_convert_timestamp_millis() -> None:
+    result = ap.parse_api(
+        source=[{"id": "1", "started": 1700000000000}],
+        key="id",
+        vals=[{"name": "started", "convert": "utc_from_timestamp"}],
+    )
+    assert result["1"]["started"] == ap.utc_from_timestamp(1700000000)
+
+
+def test_parse_api_no_key_no_search_targets_root() -> None:
+    result = ap.parse_api(source=[{"total": 42}], vals=[{"name": "total"}])
+    assert result == {"total": 42}
+
+
+# ---------------------------
+#   fill_vals_proc (combine action)
+# ---------------------------
+def test_fill_vals_proc_combine() -> None:
+    data = {"uid-1": {"host": "truenas", "port": "443"}}
+    val_proc = [
+        [
+            {"name": "url"},
+            {"action": "combine"},
+            {"text": "https://"},
+            {"key": "host"},
+            {"text": ":"},
+            {"key": "port"},
+        ]
+    ]
+    result = ap.fill_vals_proc(data, "uid-1", val_proc)
+    assert result["uid-1"]["url"] == "https://truenas:443"
+
+
+def test_fill_vals_proc_unsupported_action_raises() -> None:
+    val_proc = [[{"name": "url"}, {"action": "unsupported"}]]
+    with pytest.raises(ValueError, match="Unsupported action"):
+        ap.fill_vals_proc({"uid-1": {}}, "uid-1", val_proc)

--- a/tests/test_translation_parity.py
+++ b/tests/test_translation_parity.py
@@ -7,39 +7,31 @@ CI and locally.
 
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
-
-_REPO = Path(__file__).resolve().parents[1]
-_TRANSLATIONS = _REPO / "custom_components" / "truenas_ce" / "translations"
-
-_spec = importlib.util.spec_from_file_location(
-    "validate_translations", _REPO / ".github" / "validate_translations.py"
-)
-assert _spec and _spec.loader
-vt = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(vt)
+from types import ModuleType
 
 
-def _flatten(name: str) -> dict[str, object]:
-    return vt._flatten(json.loads((_TRANSLATIONS / name).read_text(encoding="utf-8")))
+def _flatten(translations_dir: Path, vt: ModuleType, name: str) -> dict[str, object]:
+    text = (translations_dir / name).read_text(encoding="utf-8")
+    return vt._flatten(json.loads(text))
 
 
-def test_all_locales_in_parity_with_en() -> None:
+def test_all_locales_in_parity_with_en(repo_root: Path, vt: ModuleType) -> None:
     """No locale may have missing/obsolete keys or placeholder drift vs en.json."""
-    reference = _flatten("en.json")
+    translations_dir = repo_root / "custom_components" / "truenas_ce" / "translations"
+    reference = _flatten(translations_dir, vt, "en.json")
     locales = [
-        p.name for p in sorted(_TRANSLATIONS.glob("*.json")) if p.name != "en.json"
+        p.name for p in sorted(translations_dir.glob("*.json")) if p.name != "en.json"
     ]
     assert locales, "expected at least one non-English locale file"
     for name in locales:
-        assert vt._validate(_flatten(name), reference) == [], (
+        assert vt._validate(_flatten(translations_dir, vt, name), reference) == [], (
             f"{name} is out of parity with en.json"
         )
 
 
-def test_validator_detects_drift() -> None:
+def test_validator_detects_drift(vt: ModuleType) -> None:
     """The validator must flag missing keys, obsolete keys and placeholder drift."""
     reference = {"a": "x", "b": "{count} items"}
     broken = {"b": "keine Platzhalter", "c": "extra"}


### PR DESCRIPTION
## Proposed change
First step of the test-suite build-out ahead of the HA Core integration submission (see [[truenas-core-integration-roadmap]] internally — no public issue). Adds unit tests for `apiparser.py`, the central normalization helper used by nearly every coordinator `get_*` method. Tests load the module directly via `importlib.util.spec_from_file_location`, bypassing the package `__init__.py` chain — so no `homeassistant`/`aiotruenas` install is required to run them, matching the existing `tests/test_translation_parity.py` pattern.

Covers: `utc_from_timestamp`/`human_date_to_utc`, `from_entry`/`from_entry_bool`, `get_uid`/`generate_keymap`, `matches_only`/`can_skip`, `fill_defaults`, `parse_api` (including key/key_search resolution, only/skip filters, ensure_vals, timestamp conversion), and `fill_vals_proc` (combine action).

Also adds `pytest-asyncio>=0.24` to the Pipfile dev-packages (`pytest` was already listed but the async marker/mode wasn't available yet).

Follow-up modules (`config_flow.py` → `coordinator.py` → `api.py`) will each get their own small branch/PR rather than one large one.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
No `tests/` directory existed previously; the `pytest` step in CI was commented out. This PR adds the directory and the first test module but does not yet re-enable the CI pytest step — that's a follow-up once more modules are covered (or can be done now if preferred).

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a shared pytest fixture setup and new unit tests for the TrueNAS API normalization helpers, improving test coverage without requiring Home Assistant or aiotruenas to be installed.

New Features:
- Introduce unit tests for the apiparser normalization helpers covering timestamp conversion, entry extraction, UID handling, filters, default filling, API parsing, and value post-processing.

Enhancements:
- Refactor translation parity tests to use shared fixtures for repository root and validator module loading, centralizing path-based module imports.

Build:
- Add pytest and pytest-asyncio as development dependencies in the Pipfile to support the new test suite.

Tests:
- Create a tests directory with shared pytest fixtures for loading standalone modules by file path and add the initial test module for apiparser.