### PR TITLE
Add quality_scale.yaml and adopt mypy --strict typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,30 @@ jobs:
           pip install pytest
           pytest
 
+  mypy:
+    name: Mypy strict typing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python 3.14
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Generate Requirements lists
+        run: |
+          python3 .github/generate_requirements.py
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements_tests.txt
+          pip install mypy
+      - name: Run mypy (strict, per pyproject.toml)
+        run: mypy
+
   security:
     name: Security check - Bandit
     needs: [tests]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,12 @@ ruff check .            # lint (rules E, F, W, I, UP, ASYNC; py313, line-length 
 ruff format --check .   # formatting check; drop --check to auto-format
 bandit -r custom_components/truenas_ce   # security scan (part of CI)
 pytest                  # unit tests (tests/); pyproject.toml sets pythonpath=["."] so `custom_components` resolves
+mypy                    # strict typing (config in pyproject.toml, scoped to custom_components/truenas_ce; part of CI)
 ```
 
 - Ruff's `target-version` stays **py313** (Ruff 0.15.13's `py314` formatter is buggy — it collapses `except (A, B):` into invalid `except A, B:` — so don't bump it until that's fixed upstream). CI itself now runs on **Python 3.14**, because Home Assistant Core requires `>=3.14.2` from release 2026.5.x onward; `homeassistant` is only a test dependency here, but pinning CI below that threshold silently pulled in a stale, pre-3.14 release lacking newer `homeassistant.const` members.
 - CI also runs Home Assistant **hassfest** validation and HACS validation on push/PR.
-- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas` — pinned to a commit SHA via a `git+https://github.com/kayl-codes/aiotruenas` URL until a tagged/PyPI release exists — plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
+- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas>=1.0.0` from PyPI plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
 - Bumping the release: `version` in [manifest.json](custom_components/truenas_ce/manifest.json) is the source of truth (`.github/update_version.py` updates it during release).
 - A [.pre-commit-config.yaml](.pre-commit-config.yaml) mirrors the CI Ruff checks locally; run `pre-commit install` once after cloning to enable it.
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ec77df5c27a49e879a7629265170b43c96e9b31b1c8a3e5a71d9810209e8b7f4"
+            "sha256": "2522cb0bff6c498f46fdea304ef98cd775ba9f393fb1d50b3f428a0ffac05b01"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -639,19 +639,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96",
-                "sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c"
+                "sha256:2b31ab1a0eb1cee01d0363b8ee5e68b45dff2c8f99e7b53aca11c9f7b591a794",
+                "sha256:e58e0704805f720b94e40a56588eadd6da05d3693bde78b573116b11ae56710f"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.43.46"
+            "version": "==1.43.49"
         },
         "botocore": {
             "hashes": [
-                "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533",
-                "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60"
+                "sha256:16b6838ac2fbbab85fb265c1f2e37906527aca07f461b1d293d3f8ab82f992dc",
+                "sha256:7de02863c95b8008b1400c92a1a00996f25ad38944c07f7b620949f8798d1fdf"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.43.46"
+            "version": "==1.43.49"
         },
         "btsocket": {
             "hashes": [
@@ -773,6 +773,14 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==2.1.0"
+        },
+        "cfgv": {
+            "hashes": [
+                "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0",
+                "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==3.5.0"
         },
         "charset-normalizer": {
             "hashes": [
@@ -943,6 +951,114 @@
             ],
             "version": "==2.3.3"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.4.6"
+        },
+        "coverage": {
+            "extras": [
+                "toml"
+            ],
+            "hashes": [
+                "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2",
+                "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e",
+                "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db",
+                "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf",
+                "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c",
+                "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8",
+                "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443",
+                "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a",
+                "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145",
+                "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9",
+                "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2",
+                "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376",
+                "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138",
+                "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578",
+                "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c",
+                "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88",
+                "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036",
+                "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c",
+                "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071",
+                "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a",
+                "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d",
+                "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b",
+                "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a",
+                "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b",
+                "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050",
+                "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846",
+                "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d",
+                "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1",
+                "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660",
+                "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40",
+                "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026",
+                "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0",
+                "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b",
+                "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0",
+                "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa",
+                "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d",
+                "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658",
+                "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89",
+                "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072",
+                "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199",
+                "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446",
+                "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743",
+                "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7",
+                "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1",
+                "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287",
+                "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5",
+                "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be",
+                "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688",
+                "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934",
+                "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7",
+                "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440",
+                "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984",
+                "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc",
+                "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d",
+                "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098",
+                "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6",
+                "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629",
+                "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b",
+                "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee",
+                "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f",
+                "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1",
+                "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad",
+                "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3",
+                "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9",
+                "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3",
+                "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a",
+                "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296",
+                "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1",
+                "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd",
+                "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73",
+                "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f",
+                "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0",
+                "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6",
+                "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5",
+                "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1",
+                "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589",
+                "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688",
+                "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487",
+                "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9",
+                "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd",
+                "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee",
+                "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d",
+                "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d",
+                "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb",
+                "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a",
+                "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328",
+                "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635",
+                "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188",
+                "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c",
+                "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243",
+                "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==7.15.2"
+        },
         "cronsim": {
             "hashes": [
                 "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e"
@@ -1005,6 +1121,13 @@
             "markers": "python_version >= '3.9' and python_full_version not in '3.9.0, 3.9.1'",
             "version": "==48.0.1"
         },
+        "distlib": {
+            "hashes": [
+                "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b",
+                "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed"
+            ],
+            "version": "==0.4.3"
+        },
         "envs": {
             "hashes": [
                 "sha256:4a1fcf85e4d4443e77c348ff7cdd3bfc4c0178b181d447057de342e4172e5ed1",
@@ -1012,6 +1135,14 @@
             ],
             "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==1.4"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:1774e682dbe443bd60f9609162fc596e2c80dc84ffc2957068953406d0520090",
+                "sha256:40632998f0772e64183bb819f086a1b9def6be1090cf1dcb9d45f46806ef279b"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==3.30.0"
         },
         "fnv-hash-fast": {
             "hashes": [
@@ -1458,6 +1589,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.0.4"
         },
+        "identify": {
+            "hashes": [
+                "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a",
+                "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.6.19"
+        },
         "idna": {
             "hashes": [
                 "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2",
@@ -1472,6 +1611,14 @@
                 "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4"
             ],
             "version": "==0.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730",
+                "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.3.0"
         },
         "jinja2": {
             "hashes": [
@@ -1954,55 +2101,55 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:01f24bd465a09077c8d64be8f19a6646db467a55490fd315fe7871afe6bb9645",
-                "sha256:0823d7f273f3b4a49df7573eac271ddbf77a0e5f53e24d294a4f0f77ad22e1d7",
-                "sha256:1f6c3d76853071409ac58fc0aadfb276a22af5f190fdaa02152a858088a39ebd",
-                "sha256:2529017942b951cc43db2e2712b71cc3aa7e9d90567630c03ed63d430aeec61a",
-                "sha256:2cdd99d48590dce6f6b7f1961eda75386364398fcdaad86923bc0f0231bf9baf",
-                "sha256:30a430bf26fe8cf372f3933fbd83e633d6561868803645a20e4e6d4523f52a3b",
-                "sha256:3df226d2a0ae2c3b03845af217800a68e2965d4b14914c99b78d3a2c8ae23299",
-                "sha256:484a2be712b245ac6e89847141f1f50c612b0a924aa25917e63e6cfcf4da07cd",
-                "sha256:511320b17467402e2906130e185abffffa3d7648aff1444fc2abb61f4c8a087d",
-                "sha256:5a906bfc9c4c5de3ece6dc4726f8076d56ce9be1720baf0c6f84e926c10262a4",
-                "sha256:6257bd4b4c0ae2148548b869a1ff3758e38645b92c8fe65eca401866c3c551c1",
-                "sha256:68f5b7f7f755200f68c7181e3dfb28be9858162257690e539759c9f57721e388",
-                "sha256:6965829a6d847a0925f51149472bbeb7a39332fb4801972fdfd9cedd9f8d43a4",
-                "sha256:6968f27347ef539c443ddfd6897e79db525ddb8c856aa8fbf14c34f310ca5193",
-                "sha256:6efab25fa3568569fda06928743382900860c48be9200c1758ef5ce94b532714",
-                "sha256:6fc0e98b95e31755ca06d89f75fafa7820fbb3ea2caace6d83cba17625cd0acb",
-                "sha256:7589f370b33dcdd95708f5340f13a67c2c49140957f934b42ef63064d343cca0",
-                "sha256:78d201accfafce3801d978f2b8dbbd473a9ce364cc0a0dfd9192fe47d977e129",
-                "sha256:80923e6d6e7878291f537ee11052f974954c20cb569798429a5dc265eb780b47",
-                "sha256:91df92625cb3452758f27f4965b000fb05ad89b00c282cc3430a7bd6b0e5389e",
-                "sha256:97d21f3a1582ef30d0b77f9ca3ad88b4263f3c5aea9e7380cb5d7175160aec7e",
-                "sha256:996abf2f0bebf572556c60720e8dc0cf5292b64060fa68d7f2bc9caa48e01b6f",
-                "sha256:9e0899b13da1e4ba44b880550f247402ce90ffecc71c54b220bcbe7ecb34f394",
-                "sha256:b0179a3a0b833f724a65f22613607cf7ea941ab17ec34fa283f8d6dfe21d9fa9",
-                "sha256:b48092132c7b0ef4322773fecae62fc5b0bc339be348badeec8af502122a4a51",
-                "sha256:bc73a5b4d40e8a3e6b12ef82eb0c90430964e34016a36c2aff4e3bfe37ba41f0",
-                "sha256:bdaa177e80cc3292824d4ef3670b5b58771ee8d57c290e0c9c89e7968212332c",
-                "sha256:c2c967a7685fa93fcf1a778b3ebe76e756b28ba14655f539d7b61ff3da69352a",
-                "sha256:c39bdb7ceab252d15011e26d3a254b4aaa3bbf121b551febfa301df9b0c69abe",
-                "sha256:d3abaeec02cdc72e30a147d99eb81852b6b745a2c8d19607e25241d79b1abbce",
-                "sha256:d42893d15894fd34f395090e2d78315ba7c637d5ee221683e02893f578c2f548",
-                "sha256:d4452c955caf14e28bb046cbd0c3671272e6381630a8b81b0da9713558148890",
-                "sha256:d58655a60e823b1a4c9ebcda072897fb0193c2f3e6f8e7c433e152aa4cb00233",
-                "sha256:d59a4b80351ec92e5f7415fcdd008bd77fcbefc7adf9cbc7ffe4eb9f71617734",
-                "sha256:d78a0fc90704894bc9948d78affad14b882b08183a7c30412d185748aaa9418b",
-                "sha256:daeaf5287091d68f674c91416cabab0f80f36e347ed17fded38d7ebde682e9d1",
-                "sha256:db34595464869f474708e769413d1d739fc33a69850f253757b9a4cc20bc1fec",
-                "sha256:dc361340732ce7108fa0308812caf02bb6868f16112f1efd35bcad88badf3327",
-                "sha256:dfa22b3ae862ac1ce76f5976ddd402651b5f090bcfd49c6d0484b8983a29eaf8",
-                "sha256:ea6fe1a30f3e7dc574d641497ffead2428046b0f8bc5804d13b4e4392fdc317b",
-                "sha256:ec287c2381898c652bf8ff79448627fe1a9ee76d22005181fac7315a485c7108",
-                "sha256:ecc138da861e932d1344214da4bae866b21900a9c2778824b51fe2fb47f5180e",
-                "sha256:f8d97940a0259e09c219903579720b2df12170c0c3a3b3799837c1fb63deb44e",
-                "sha256:fb0a020dc68480d40e484675558ed637140df1ccbf896a81ba68bca85f2b50a0",
-                "sha256:fc53553996aca2094216ad9306a6f06c5265d206c1bcb54dd367560bd3557825"
+                "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491",
+                "sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762",
+                "sha256:09abd66d8685e73f8f7d17b847c3e104d9a7b164a8706ea87d6c96a3d45816d5",
+                "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654",
+                "sha256:13b1b16e2fa39f3b2e33fb1c468abc7a69369fa2e886b4b87b5afc81472325cd",
+                "sha256:1c6c6bf687b17f90dbfcad95b960d32eaa0154c00da45f03ab50bf8952e047fe",
+                "sha256:1fa8d916ac3b705af733c4c1e6c9ebe38fd0d52beb15b105c3e8355b55e6ecdc",
+                "sha256:28e1e2af8cd8fff551fd30f2fe4b03fb76764ac8b1ba6c6a1bd00ad32b412db3",
+                "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5",
+                "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329",
+                "sha256:37fa4de896a84e2dc9200d91e614c22563b43d1a266789d4bbac7b22ebe6192b",
+                "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3",
+                "sha256:3dd0bed92c4bdec57c42505b96416fb9e6a5aa7be84d2809bcd5f2ecec2860d7",
+                "sha256:3e77244df3843048c3f927182916730e40c124cbaa43905c1fb86cb382aa0805",
+                "sha256:4359424140d985192c778c1ce2c114a10c1ca58a381ed79cfa70d37df94b299f",
+                "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e",
+                "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7",
+                "sha256:5e91adad1ca81742ac7ef9893959911df867752206b37135185e88dfb3c89494",
+                "sha256:691fdc37132b1ae628d834f672e74de83462d9fb4aff621835767fb43a8dd373",
+                "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88",
+                "sha256:6f99ec626e3c3a2f7c0b22c5b90ddb5dabb1c18729c971e9bdaca1f1766d2cee",
+                "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2",
+                "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757",
+                "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a",
+                "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b",
+                "sha256:85c5385b93012ffa3b31479ab579aef5415f4f3a32c6cf1ae07a984d2a0ff461",
+                "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97",
+                "sha256:944c665d984157cb96a679dfb7a4a81dd1d36b24b9c284b699514e6e626b82d4",
+                "sha256:9559ab18a9c9957dfa3004ab57cd4bac5f26a724329a9584e583367f0c2e1117",
+                "sha256:982e3d53dd23d0a4cef67dd66791fdbede0cf38f9eb617bf47663554c51e1e36",
+                "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac",
+                "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5",
+                "sha256:aec15d465d477558fd842757b487849007311cf3897849cdda0e3162ac0ac556",
+                "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c",
+                "sha256:b352b7e49f5e6576009e8df730e1ff4f915cb565b851b396d2ffe2f5a6f5da88",
+                "sha256:b5cd2f027a972a4a5f2278a11fac9747f5f81a53a30b714d74950b6807e55568",
+                "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595",
+                "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f",
+                "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1",
+                "sha256:de121747278144fc9ae7caa2e978cf5df12aebc82933182f5b3b86081a30baef",
+                "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6",
+                "sha256:ea317b060ce83e26050f8f9e4d7d6bf44ed7597c8ff9990bccffbb9d1d8522db",
+                "sha256:f1b3a98dfd21058bc759bb3337d5d1f61d0fdf9f3cf9c00f4291790fb5427bff",
+                "sha256:f4ed18f111bfe2d599bca7468e7f9251042c1c2118f762c8de2766a56d773c60",
+                "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==2.2.0"
+            "version": "==2.3.0"
         },
         "mypy-extensions": {
             "hashes": [
@@ -2011,6 +2158,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.1.0"
+        },
+        "nodeenv": {
+            "hashes": [
+                "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827",
+                "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==1.10.0"
         },
         "orjson": {
             "hashes": [
@@ -2204,6 +2359,31 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==12.2.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7",
+                "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.10.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9",
+                "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==4.6.0"
         },
         "propcache": {
             "hashes": [
@@ -2483,6 +2663,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==2.9.1"
         },
+        "pygments": {
+            "hashes": [
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
+        },
         "pyjwt": {
             "extras": [
                 "crypto"
@@ -2547,6 +2735,33 @@
             ],
             "version": "==0.1.6.3"
         },
+        "pytest": {
+            "hashes": [
+                "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313",
+                "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==9.1.1"
+        },
+        "pytest-asyncio": {
+            "hashes": [
+                "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1",
+                "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==1.4.0"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2",
+                "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==7.1.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
@@ -2554,6 +2769,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
+        },
+        "python-discovery": {
+            "hashes": [
+                "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3",
+                "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.4.4"
         },
         "python-slugify": {
             "hashes": [
@@ -3027,6 +3250,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.11.25"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128",
+                "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==21.6.1"
         },
         "voluptuous": {
             "hashes": [

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+    callback,
+)
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -45,14 +52,14 @@ from .const import (
     SIGNAL_UPDATE_SENSORS,
 )
 from .coordinator import TrueNASCoordinator
-from .entity import _is_uid_excluded, format_unique_id
+from .entity import TrueNASEntityDescription, _is_uid_excluded, format_unique_id
 from .helper import alert_action, scaled_data_unit
 from .migration import (
     async_adopt_legacy_entities,
     async_notify_migration_result,
     finalize_legacy_adoption,
 )
-from .sensor_types import SENSOR_TYPES
+from .sensor_types import SENSOR_TYPES, TrueNASSensorEntityDescription
 from .switch_types import SENSOR_TYPES as SWITCH_SENSOR_TYPES
 from .update_types import SENSOR_TYPES as UPDATE_SENSOR_TYPES
 
@@ -96,14 +103,20 @@ def _migrate_data_size_units(
             _migrate_description(ent_reg, coordinator, inst, description, binary)
 
 
-def _migrate_description(ent_reg, coordinator, inst, description, binary) -> None:
+def _migrate_description(
+    ent_reg: er.EntityRegistry,
+    coordinator: TrueNASCoordinator,
+    inst: str,
+    description: TrueNASSensorEntityDescription,
+    binary: bool,
+) -> None:
     """Force units for all entities produced by a single DATA_SIZE description."""
-    data = coordinator.ds.get(description.data_path)
+    data = coordinator.ds.get(description.data_path or "")
     if not isinstance(data, dict):
         return
 
     if not description.data_reference:
-        value = data.get(description.data_attribute)
+        value = data.get(description.data_attribute or "")
         _force_entity_unit(ent_reg, inst, description, None, value, binary)
         return
 
@@ -121,7 +134,14 @@ def _migrate_description(ent_reg, coordinator, inst, description, binary) -> Non
         )
 
 
-def _force_entity_unit(ent_reg, inst, description, reference, value, binary) -> None:
+def _force_entity_unit(
+    ent_reg: er.EntityRegistry,
+    inst: str,
+    description: TrueNASSensorEntityDescription,
+    reference: Any,
+    value: Any,
+    binary: bool,
+) -> None:
     """Write the magnitude-appropriate display unit of one entity to the registry."""
     entity_id = ent_reg.async_get_entity_id(
         "sensor", DOMAIN, format_unique_id(inst, description.key, reference)
@@ -151,7 +171,10 @@ def _handle_keyless(
 
 
 def _referenced_unique_ids(
-    inst: str, description, data: dict, honor_exclude: bool = True
+    inst: str,
+    description: TrueNASEntityDescription,
+    data: dict[str, Any],
+    honor_exclude: bool = True,
 ) -> set[str]:
     """Unique_ids the integration would create for one referenced description.
 
@@ -204,7 +227,7 @@ def _collect_active_unique_ids(
             _handle_keyless(base, is_disabled_group, active, live_bases)
             continue
 
-        data = coordinator.data.get(description.data_path)
+        data = coordinator.data.get(description.data_path or "")
 
         if not data and not is_disabled_group:
             # Transient empty fetch for an enabled group → protect entities.
@@ -277,7 +300,7 @@ def _cleanup_orphaned_entities(
 # ---------------------------
 def _get_coordinator(
     hass: HomeAssistant, entry_id: str | None
-) -> tuple[str | None, dict]:
+) -> tuple[str | None, dict[str, str]]:
     """Resolve coordinator; return (entry_id, error_dict) or (entry_id, {})."""
     coords = hass.data.get(DOMAIN, {})
     if not coords:
@@ -303,7 +326,7 @@ def _get_coordinator(
     return entry_id, {}
 
 
-async def _handle_alert_list(hass: HomeAssistant, call) -> dict:
+async def _handle_alert_list(hass: HomeAssistant, call: ServiceCall) -> dict[str, Any]:
     """List all TrueNAS alerts with selectable properties."""
     entry_id, error = _get_coordinator(hass, call.data.get(SERVICE_ALERT_CONFIG_ENTRY))
     if error:
@@ -324,7 +347,7 @@ async def _handle_alert_list(hass: HomeAssistant, call) -> dict:
     return {"alerts": filtered}
 
 
-async def _handle_alert_dismiss(hass: HomeAssistant, call) -> None:
+async def _handle_alert_dismiss(hass: HomeAssistant, call: ServiceCall) -> None:
     """Dismiss a TrueNAS alert by UUID."""
     entry_id, error = _get_coordinator(hass, call.data.get(SERVICE_ALERT_CONFIG_ENTRY))
     if error:
@@ -338,7 +361,7 @@ async def _handle_alert_dismiss(hass: HomeAssistant, call) -> None:
     await alert_action(coordinator, uuid, "dismiss")
 
 
-async def _handle_alert_restore(hass: HomeAssistant, call) -> None:
+async def _handle_alert_restore(hass: HomeAssistant, call: ServiceCall) -> None:
     """Restore a TrueNAS alert by UUID."""
     entry_id, error = _get_coordinator(hass, call.data.get(SERVICE_ALERT_CONFIG_ENTRY))
     if error:
@@ -352,10 +375,10 @@ async def _handle_alert_restore(hass: HomeAssistant, call) -> None:
     await alert_action(coordinator, uuid, "restore")
 
 
-async def _handle_passphrase_remove(hass: HomeAssistant, call) -> None:
+async def _handle_passphrase_remove(hass: HomeAssistant, call: ServiceCall) -> None:
     """Remove a stored dataset passphrase by dataset path."""
     entry_id, error = _get_coordinator(hass, call.data.get(SERVICE_CONFIG_ENTRY))
-    if error:
+    if error or entry_id is None:
         raise ServiceValidationError(error.get("error", _UNKNOWN_ERROR))
 
     dataset_path = call.data.get(SERVICE_PASSPHRASE_DATASET_PATH, "").strip()
@@ -377,10 +400,12 @@ async def _handle_passphrase_remove(hass: HomeAssistant, call) -> None:
     )
 
 
-async def _handle_passphrase_list(hass: HomeAssistant, call) -> dict:
+async def _handle_passphrase_list(
+    hass: HomeAssistant, call: ServiceCall
+) -> dict[str, Any]:
     """Return the dataset names that have a stored passphrase (no values)."""
     entry_id, error = _get_coordinator(hass, call.data.get(SERVICE_CONFIG_ENTRY))
-    if error:
+    if error or entry_id is None:
         return {"datasets": [], **error}
 
     config_entry = hass.config_entries.async_get_entry(entry_id)
@@ -412,7 +437,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Register alert services (domain-level, instance-specific) once.
     if not hass.services.has_service(DOMAIN, SERVICE_ALERT_DISMISS):
 
-        async def _alert_dismiss_handler(call) -> None:
+        async def _alert_dismiss_handler(call: ServiceCall) -> None:
             await _handle_alert_dismiss(hass, call)
 
         hass.services.async_register(
@@ -423,7 +448,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
     if not hass.services.has_service(DOMAIN, SERVICE_ALERT_RESTORE):
 
-        async def _alert_restore_handler(call) -> None:
+        async def _alert_restore_handler(call: ServiceCall) -> None:
             await _handle_alert_restore(hass, call)
 
         hass.services.async_register(
@@ -434,7 +459,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
     if not hass.services.has_service(DOMAIN, SERVICE_ALERT_LIST):
 
-        async def _alert_list_handler(call) -> dict:
+        async def _alert_list_handler(call: ServiceCall) -> ServiceResponse:
             return await _handle_alert_list(hass, call)
 
         hass.services.async_register(
@@ -442,11 +467,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             SERVICE_ALERT_LIST,
             _alert_list_handler,
             schema=SCHEMA_SERVICE_ALERT_LIST,
-            supports_response=True,
+            supports_response=SupportsResponse.OPTIONAL,
         )
     if not hass.services.has_service(DOMAIN, SERVICE_PASSPHRASE_REMOVE):
 
-        async def _passphrase_remove_handler(call) -> None:
+        async def _passphrase_remove_handler(call: ServiceCall) -> None:
             await _handle_passphrase_remove(hass, call)
 
         hass.services.async_register(
@@ -457,7 +482,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
     if not hass.services.has_service(DOMAIN, SERVICE_PASSPHRASE_LIST):
 
-        async def _passphrase_list_handler(call) -> dict:
+        async def _passphrase_list_handler(call: ServiceCall) -> ServiceResponse:
             return await _handle_passphrase_list(hass, call)
 
         hass.services.async_register(
@@ -465,7 +490,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             SERVICE_PASSPHRASE_LIST,
             _passphrase_list_handler,
             schema=SCHEMA_SERVICE_PASSPHRASE_LIST,
-            supports_response=True,
+            supports_response=SupportsResponse.OPTIONAL,
         )
 
     # Re-attach the freed legacy entity_ids now that the new entities exist, then

--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -222,7 +222,7 @@ class TrueNASAPI:
         self,
         service: str,
         params: dict[str, Any] | list[Any] | None = None,
-    ) -> list | dict | str | None:
+    ) -> Any:
         """Retrieve data from TrueNAS."""
         if not self.connected() and not await self.connect():
             return None

--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -1,6 +1,6 @@
 """API parser for JSON APIs."""
 
-from collections.abc import Hashable
+from collections.abc import Hashable, Mapping
 from datetime import UTC, datetime
 from logging import getLogger
 from typing import Any, TypedDict
@@ -126,7 +126,12 @@ def _coerce_bool(value: Any, default: bool) -> bool:
 # ---------------------------
 #   from_entry_bool
 # ---------------------------
-def from_entry_bool(entry, param, default=False, reverse=False) -> bool:
+def from_entry_bool(
+    entry: dict[str, Any] | None,
+    param: str,
+    default: bool = False,
+    reverse: bool = False,
+) -> bool:
     """Validate and return a bool value from an API dict."""
     ret = _resolve_source(entry, param)
     if ret is _MISSING:
@@ -139,20 +144,20 @@ def from_entry_bool(entry, param, default=False, reverse=False) -> bool:
 # ---------------------------
 #   _str_default / _bool_default / _spec_default
 # ---------------------------
-def _str_default(val: dict[str, Any]) -> Any:
+def _str_default(val: Mapping[str, Any]) -> Any:
     """Return the default for a string-typed value spec."""
     if "default_val" in val and val["default_val"] in val:
         return val[val["default_val"]]
     return val.get("default", "")
 
 
-def _bool_default(val: dict[str, Any]) -> bool:
+def _bool_default(val: Mapping[str, Any]) -> bool:
     """Return the default for a bool-typed value spec."""
     default = val.get("default", False)
     return not default if val.get("reverse", False) else default
 
 
-def _spec_default(val: dict[str, Any]) -> Any:
+def _spec_default(val: Mapping[str, Any]) -> Any:
     """Return the configured default value for a value spec."""
     if val.get("type", "str") == "bool":
         return _bool_default(val)
@@ -164,7 +169,7 @@ def _spec_default(val: dict[str, Any]) -> Any:
 # ---------------------------
 def parse_api(
     data: dict[str, Any] | None = None,
-    source: dict[str, Any] | list[dict[str, Any]] | None = None,
+    source: dict[str, Any] | list[Any] | str | None = None,
     key: str | None = None,
     key_secondary: str | None = None,
     key_search: str | None = None,
@@ -179,6 +184,9 @@ def parse_api(
         data = {}
     if isinstance(source, dict):
         source = [source]
+    elif isinstance(source, str):
+        # A bare string is a malformed API payload; treat it like no source.
+        source = None
 
     if not source:
         return _empty_source_result(data, key, key_search, vals)
@@ -278,12 +286,18 @@ def _apply_entry(
 # ---------------------------
 #   get_uid
 # ---------------------------
-def get_uid(entry, key, key_secondary, key_search, keymap) -> str | None:
+def get_uid(
+    entry: Any,
+    key: str | None,
+    key_secondary: str | None,
+    key_search: str | None,
+    keymap: dict[Hashable, str] | None,
+) -> str | None:
     """Get UID for data list."""
     if not isinstance(entry, dict):
         return None
 
-    uid = None
+    uid: str | None = None
     if not key_search:
         if key is not None and key in entry:
             uid = entry[key]
@@ -322,7 +336,7 @@ def matches_only(entry: dict[str, Any], only: list[dict[str, Any]]) -> bool:
 # ---------------------------
 #   can_skip
 # ---------------------------
-def can_skip(entry, skip) -> bool:
+def can_skip(entry: dict[str, Any], skip: list[dict[str, Any]]) -> bool:
     """Return True if at least one variable matches."""
     ret = False
     for val in skip:
@@ -340,7 +354,9 @@ def can_skip(entry, skip) -> bool:
 # ---------------------------
 #   fill_defaults
 # ---------------------------
-def fill_defaults(data, vals) -> dict:
+def fill_defaults(
+    data: dict[str, Any] | None, vals: list[ApiValueSpec] | None
+) -> dict[str, Any]:
     """Fill defaults if source is not present."""
     if data is None:
         data = {}
@@ -382,7 +398,7 @@ def _convert_human_date(target: dict[str, Any], name: str) -> None:
 #   _set_val
 # ---------------------------
 def _set_val(
-    target: dict[str, Any], entry: dict[str, Any], val: dict[str, Any]
+    target: dict[str, Any], entry: dict[str, Any], val: Mapping[str, Any]
 ) -> None:
     """Resolve a single value spec into target."""
     name = val["name"]
@@ -404,9 +420,14 @@ def _set_val(
 # ---------------------------
 #   fill_vals
 # ---------------------------
-def fill_vals(data, entry, uid, vals) -> dict:
+def fill_vals(
+    data: dict[str, Any],
+    entry: dict[str, Any],
+    uid: str | None,
+    vals: list[ApiValueSpec],
+) -> dict[str, Any]:
     """Fill all data."""
-    target = data[uid] if uid is not None else data
+    target: dict[str, Any] = data[uid] if uid is not None else data
     for val in vals:
         _set_val(target, entry, val)
 
@@ -416,12 +437,14 @@ def fill_vals(data, entry, uid, vals) -> dict:
 # ---------------------------
 #   fill_ensure_vals
 # ---------------------------
-def fill_ensure_vals(data, uid, ensure_vals) -> dict:
+def fill_ensure_vals(
+    data: dict[str, Any], uid: str | None, ensure_vals: list[ApiValueSpec]
+) -> dict[str, Any]:
     """Add required keys which are not available in data."""
     if uid is not None and uid not in data:
         data[uid] = {}
 
-    target = data[uid] if uid is not None else data
+    target: dict[str, Any] = data[uid] if uid is not None else data
     for val in ensure_vals:
         name = val["name"]
         if name not in target:
@@ -484,9 +507,11 @@ def _process_val_sub(
 # ---------------------------
 #   fill_vals_proc
 # ---------------------------
-def fill_vals_proc(data, uid, vals_proc) -> dict:
+def fill_vals_proc(
+    data: dict[str, Any], uid: str | None, vals_proc: list[list[dict[str, Any]]]
+) -> dict[str, Any]:
     """Add custom keys."""
-    target = data[uid] if uid is not None else data
+    target: dict[str, Any] = data[uid] if uid is not None else data
 
     for val_sub in vals_proc:
         name, value = _process_val_sub(target, val_sub)

--- a/custom_components/truenas_ce/binary_sensor.py
+++ b/custom_components/truenas_ce/binary_sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -12,11 +13,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .binary_sensor_types import (  # noqa: F401
     SENSOR_SERVICES,
     SENSOR_TYPES,
+    TrueNASBinarySensorEntityDescription,
 )
 from .const import VIRT_INSTANCE_STOP_OPTIONS
 from .entity import TrueNASEntity, async_add_entities
 
 _LOGGER = getLogger(__name__)
+
+# Updates are centralized in the coordinator; entity actions may run unlimited.
+PARALLEL_UPDATES = 0
 
 _LOG_SERVICE_INVALID = "Service %s (%s) invalid"
 _LOG_SERVICE_NOT_RUNNING = "Service %s (%s) is not running"
@@ -47,6 +52,8 @@ async def async_setup_entry(
 class TrueNASBinarySensor(TrueNASEntity, BinarySensorEntity):
     """Define an TrueNAS Binary Sensor."""
 
+    entity_description: TrueNASBinarySensorEntityDescription
+
     @property
     def is_on(self) -> bool | None:
         """Return true if device is on.
@@ -54,7 +61,8 @@ class TrueNASBinarySensor(TrueNASEntity, BinarySensorEntity):
         Uses .get() so a transient API failure that empties the coordinator data
         degrades the state to unknown instead of raising a KeyError mid-update.
         """
-        return self._data.get(self.entity_description.data_is_on)
+        value: bool | None = self._data.get(self.entity_description.data_is_on)
+        return value
 
     @property
     def icon(self) -> str | None:
@@ -74,7 +82,7 @@ class TrueNASBinarySensor(TrueNASEntity, BinarySensorEntity):
 class TrueNASVMBinarySensor(TrueNASBinarySensor):
     """Define a TrueNAS VM Binary Sensor."""
 
-    async def start(self, overcommit: bool = False):
+    async def start(self, overcommit: bool = False) -> None:
         """Start a VM."""  # vm.start
         tmp_vm = await self.coordinator.api.query("vm.get_instance", [self._data["id"]])
 
@@ -95,7 +103,7 @@ class TrueNASVMBinarySensor(TrueNASBinarySensor):
             "vm.start", [self._data["id"], {"overcommit": overcommit}]
         )
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop a VM."""
         tmp_vm = await self.coordinator.api.query("vm.get_instance", [self._data["id"]])
 
@@ -116,7 +124,7 @@ class TrueNASVMBinarySensor(TrueNASBinarySensor):
             "vm.stop", [self._data["id"], {"force": True, "force_after_timeout": True}]
         )
 
-    async def restart(self):
+    async def restart(self) -> None:
         """Restart a VM."""  # vm.restart
         # A restart always applies (no state guard): it stops and starts again.
         await self.coordinator.api.query("vm.restart", [self._data["id"]])
@@ -149,7 +157,7 @@ class TrueNASContainerBinarySensor(TrueNASBinarySensor):
         instance = instances[0] if isinstance(instances, list) and instances else None
         return instance.get("status") if isinstance(instance, dict) else None
 
-    async def start(self):
+    async def start(self) -> None:
         """Start a container."""  # virt.instance.start
         # Only skip when positively running; if the status is unknown, proceed.
         if await self._current_status() == "RUNNING":
@@ -159,7 +167,7 @@ class TrueNASContainerBinarySensor(TrueNASBinarySensor):
         await self.coordinator.api.query("virt.instance.start", [self._data["id"]])
         await self.coordinator.async_request_refresh()
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop a container."""  # virt.instance.stop
         # Only skip when positively not running; if unknown, proceed.
         status = await self._current_status()
@@ -172,7 +180,7 @@ class TrueNASContainerBinarySensor(TrueNASBinarySensor):
         )
         await self.coordinator.async_request_refresh()
 
-    async def restart(self):
+    async def restart(self) -> None:
         """Restart a container."""  # virt.instance.restart
         # A restart always applies (no state guard): it stops and starts again.
         await self.coordinator.api.query(
@@ -187,14 +195,17 @@ class TrueNASContainerBinarySensor(TrueNASBinarySensor):
 class TrueNASServiceBinarySensor(TrueNASBinarySensor):
     """Define a TrueNAS Service Binary Sensor."""
 
-    async def _get_service(self):
+    async def _get_service(self) -> dict[str, Any] | None:
         """Return the latest service state from the API."""
         services = await self.coordinator.api.query(
             "service.query", [[["id", "=", self._data["id"]]]]
         )
-        return services[0] if isinstance(services, list) and services else None
+        service: dict[str, Any] | None = (
+            services[0] if isinstance(services, list) and services else None
+        )
+        return service
 
-    async def start(self):
+    async def start(self) -> None:
         """Start a Service."""
         tmp_service = await self._get_service()
 
@@ -214,7 +225,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
 
         await self.coordinator.async_refresh()
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop a Service."""
         tmp_service = await self._get_service()
 
@@ -233,7 +244,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
         await self.coordinator.api.query("service.stop", [self._data["service"]])
         await self.coordinator.async_refresh()
 
-    async def restart(self):
+    async def restart(self) -> None:
         """Restart a Service."""
         tmp_service = await self._get_service()
 
@@ -253,7 +264,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
 
         await self.coordinator.async_refresh()
 
-    async def reload(self):
+    async def reload(self) -> None:
         """Reload a Service."""
         tmp_service = await self._get_service()
 
@@ -280,7 +291,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
 class TrueNASAppBinarySensor(TrueNASBinarySensor):
     """Define a TrueNAS Applications Binary Sensor."""
 
-    async def start(self):
+    async def start(self) -> None:
         """Start an App."""
         tmp_app = await self.coordinator.api.query(
             "app.get_instance", [self._data["id"]]
@@ -298,7 +309,7 @@ class TrueNASAppBinarySensor(TrueNASBinarySensor):
 
         await self.coordinator.api.query("app.start", [self._data["id"]])
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop an App."""
         tmp_app = await self.coordinator.api.query(
             "app.get_instance", [self._data["id"]]

--- a/custom_components/truenas_ce/binary_sensor_types.py
+++ b/custom_components/truenas_ce/binary_sensor_types.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, NamedTuple
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntityDescription,
 )
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import EntityCategory
 
 from .const import (
     SCHEMA_SERVICE_APP_START,
@@ -37,6 +37,7 @@ from .const import (
     SERVICE_VM_START,
     SERVICE_VM_STOP,
 )
+from .entity import TrueNASEntityDescription
 
 DEVICE_ATTRIBUTES_POOL = (
     "path",
@@ -107,21 +108,15 @@ DEVICE_ATTRIBUTES_DIRECTORYSERVICE = (
 )
 
 
-@dataclass
-class TrueNASBinarySensorEntityDescription(BinarySensorEntityDescription):
+@dataclass(frozen=True, kw_only=True)
+class TrueNASBinarySensorEntityDescription(
+    BinarySensorEntityDescription, TrueNASEntityDescription
+):
     """Class describing entities."""
 
     icon_enabled: str | None = None
     icon_disabled: str | None = None
-    ha_group: str | None = None
-    ha_connection: str | None = None
-    ha_connection_value: str | None = None
-    data_path: str | None = None
     data_is_on: str = "available"
-    data_name: str | None = None
-    data_uid: str | None = None
-    data_reference: str | None = None
-    data_attributes_list: list[str] = field(default_factory=list)
     func: str = "TrueNASBinarySensor"
 
 

--- a/custom_components/truenas_ce/button.py
+++ b/custom_components/truenas_ce/button.py
@@ -6,16 +6,16 @@ from logging import getLogger
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .button_types import (  # noqa: F401
     SENSOR_SERVICES,
     SENSOR_TYPES,
+    TrueNASButtonEntityDescription,
 )
 from .const import (
     API_POOL_SCRUB_SCRUB,
@@ -36,6 +36,9 @@ from .entity import (
 )
 
 _LOGGER = getLogger(__name__)
+
+# Updates are centralized in the coordinator; entity actions may run unlimited.
+PARALLEL_UPDATES = 0
 
 
 # ---------------------------
@@ -76,11 +79,14 @@ async def async_setup_entry(
 class TrueNASButton(TrueNASEntity, ButtonEntity):
     """Define a TrueNAS run button (one-tap trigger for an on-demand task)."""
 
+    entity_description: TrueNASButtonEntityDescription
+
     async def async_press(self) -> None:
         """Trigger the configured JSON-RPC method for this object."""
         method = self.entity_description.api_method
+        data_path = self.entity_description.data_path
         object_id = self._data.get("id")
-        if not method or object_id is None:
+        if not method or not data_path or object_id is None:
             _LOGGER.warning(
                 "TrueNAS button %s has no api_method or object id; skipping",
                 self.entity_id,
@@ -88,9 +94,7 @@ class TrueNASButton(TrueNASEntity, ButtonEntity):
             return
 
         # Trigger the run and show RUNNING immediately (re-synced on next poll).
-        await self.coordinator.async_run_task(
-            method, object_id, self.entity_description.data_path
-        )
+        await self.coordinator.async_run_task(method, object_id, data_path)
 
 
 # ---------------------------
@@ -125,7 +129,7 @@ class TrueNASPoolScrubButton(TrueNASButton):
             )
             return
         self.coordinator.set_optimistic_running(
-            self.entity_description.data_path, task_id
+            self.entity_description.data_path or "", task_id
         )
         _LOGGER.debug(
             "TrueNAS scrub button %s: started scrub for pool %r",

--- a/custom_components/truenas_ce/button_types.py
+++ b/custom_components/truenas_ce/button_types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, NamedTuple
 
 from homeassistant.components.button import ButtonEntityDescription
@@ -14,24 +14,17 @@ from .const import (
     API_RSYNCTASK_RUN,
     API_SNAPSHOTTASK_RUN,
 )
+from .entity import TrueNASEntityDescription
 
 # Run buttons mirror the on-demand "*_run" actions, but as one-tap controls on the
 # task's device page. Each carries the JSON-RPC method to call with the object id.
 
 
-@dataclass
-class TrueNASButtonEntityDescription(ButtonEntityDescription):
+@dataclass(frozen=True, kw_only=True)
+class TrueNASButtonEntityDescription(ButtonEntityDescription, TrueNASEntityDescription):
     """Class describing TrueNAS button entities."""
 
     api_method: str | None = None
-    ha_group: str | None = None
-    ha_connection: str | None = None
-    ha_connection_value: str | None = None
-    data_path: str | None = None
-    data_name: str | None = None
-    data_uid: str | None = None
-    data_reference: str | None = None
-    data_attributes_list: list[str] = field(default_factory=list)
     func: str = "TrueNASButton"
 
 

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
 
 from .api import TrueNASAPI
@@ -257,7 +257,7 @@ def _map_error_to_ha(errorcode: str) -> str:
 #   configured_instances
 # ---------------------------
 @callback
-def configured_instances(hass):
+def configured_instances(hass: HomeAssistant) -> set[str]:
     """Return a set of configured instances."""
     return {
         entry.data[CONF_NAME] for entry in hass.config_entries.async_entries(DOMAIN)
@@ -369,7 +369,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_migrate()
 
         truenas_config = self.truenas_config
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is None and not truenas_config.get(CONF_HOST):
             default_host = await self.hass.async_add_executor_job(_guess_ip)
@@ -529,7 +529,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _check_connection_if_changed(
         self,
         truenas_config: dict[str, Any],
-        entry_data: dict[str, Any],
+        entry_data: Mapping[str, Any],
         errors: dict[str, str],
     ) -> None:
         """Run connection test only when transport-relevant settings changed."""

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -3,6 +3,7 @@
 import voluptuous as vol
 from homeassistant.const import Platform
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import VolDictType
 
 PLATFORMS = [
     Platform.SENSOR,
@@ -99,19 +100,19 @@ TO_REDACT = {
 CONF_DATASET_PASSPHRASES = "dataset_passphrases"  # nosec B105 # NOSONAR
 
 SERVICE_CLOUDSYNC_RUN = "cloudsync_run"
-SCHEMA_SERVICE_CLOUDSYNC_RUN = {}
+SCHEMA_SERVICE_CLOUDSYNC_RUN: VolDictType = {}
 
 SERVICE_CLOUDSYNC_ABORT = "cloudsync_abort"
-SCHEMA_SERVICE_CLOUDSYNC_ABORT = {}
+SCHEMA_SERVICE_CLOUDSYNC_ABORT: VolDictType = {}
 
 SERVICE_RSYNC_RUN = "rsync_run"
-SCHEMA_SERVICE_RSYNC_RUN = {}
+SCHEMA_SERVICE_RSYNC_RUN: VolDictType = {}
 
 SERVICE_REPLICATION_RUN = "replication_run"
-SCHEMA_SERVICE_REPLICATION_RUN = {}
+SCHEMA_SERVICE_REPLICATION_RUN: VolDictType = {}
 
 SERVICE_DATASET_SNAPSHOT = "dataset_snapshot"
-SCHEMA_SERVICE_DATASET_SNAPSHOT = {}
+SCHEMA_SERVICE_DATASET_SNAPSHOT: VolDictType = {}
 
 SERVICE_DATASET_LOCK = "dataset_lock"
 SERVICE_DATASET_UNLOCK = "dataset_unlock"
@@ -153,7 +154,7 @@ SCHEMA_SERVICE_PASSPHRASE_LIST = vol.Schema(
 )
 
 SERVICE_SNAPSHOTTASK_RUN = "snapshottask_run"
-SCHEMA_SERVICE_SNAPSHOTTASK_RUN = {}
+SCHEMA_SERVICE_SNAPSHOTTASK_RUN: VolDictType = {}
 
 # JSON-RPC methods for on-demand "run" triggers, shared by the run buttons
 # (button_types.py) and the *_run sensor actions (sensor.py) so the method name
@@ -167,13 +168,13 @@ API_POOL_SCRUB_SCRUB = "pool.scrub.scrub"
 SCRUB_ACTION_START = "START"
 
 SERVICE_SYSTEM_REBOOT = "system_reboot"
-SCHEMA_SERVICE_SYSTEM_REBOOT = {}
+SCHEMA_SERVICE_SYSTEM_REBOOT: VolDictType = {}
 
 SERVICE_SYSTEM_SHUTDOWN = "system_shutdown"
-SCHEMA_SERVICE_SYSTEM_SHUTDOWN = {}
+SCHEMA_SERVICE_SYSTEM_SHUTDOWN: VolDictType = {}
 
 SERVICE_SYSTEM_REFRESH = "system_refresh"
-SCHEMA_SERVICE_SYSTEM_REFRESH = {}
+SCHEMA_SERVICE_SYSTEM_REFRESH: VolDictType = {}
 
 SERVICE_ALERT_DISMISS = "alert_dismiss"
 SERVICE_ALERT_RESTORE = "alert_restore"
@@ -284,13 +285,13 @@ GROUP_DATA_PATHS: dict[str, set[str]] = {
 }
 
 SERVICE_SERVICE_START = "service_start"
-SCHEMA_SERVICE_SERVICE_START = {}
+SCHEMA_SERVICE_SERVICE_START: VolDictType = {}
 SERVICE_SERVICE_STOP = "service_stop"
-SCHEMA_SERVICE_SERVICE_STOP = {}
+SCHEMA_SERVICE_SERVICE_STOP: VolDictType = {}
 SERVICE_SERVICE_RESTART = "service_restart"
-SCHEMA_SERVICE_SERVICE_RESTART = {}
+SCHEMA_SERVICE_SERVICE_RESTART: VolDictType = {}
 SERVICE_SERVICE_RELOAD = "service_reload"
-SCHEMA_SERVICE_SERVICE_RELOAD = {}
+SCHEMA_SERVICE_SERVICE_RELOAD: VolDictType = {}
 
 SERVICE_VM_START = "vm_start"
 SERVICE_VM_START_OVERCOMMIT = "overcommit"
@@ -298,16 +299,16 @@ SCHEMA_SERVICE_VM_START = {
     vol.Optional(SERVICE_VM_START_OVERCOMMIT, default=False): cv.boolean
 }
 SERVICE_VM_STOP = "vm_stop"
-SCHEMA_SERVICE_VM_STOP = {}
+SCHEMA_SERVICE_VM_STOP: VolDictType = {}
 SERVICE_VM_RESTART = "vm_restart"
-SCHEMA_SERVICE_VM_RESTART = {}
+SCHEMA_SERVICE_VM_RESTART: VolDictType = {}
 
 SERVICE_CONTAINER_START = "container_start"
-SCHEMA_SERVICE_CONTAINER_START = {}
+SCHEMA_SERVICE_CONTAINER_START: VolDictType = {}
 SERVICE_CONTAINER_STOP = "container_stop"
-SCHEMA_SERVICE_CONTAINER_STOP = {}
+SCHEMA_SERVICE_CONTAINER_STOP: VolDictType = {}
 SERVICE_CONTAINER_RESTART = "container_restart"
-SCHEMA_SERVICE_CONTAINER_RESTART = {}
+SCHEMA_SERVICE_CONTAINER_RESTART: VolDictType = {}
 
 # Options passed to virt.instance.stop / virt.instance.restart: force a hard
 # stop (force=True) with no graceful-shutdown wait (timeout=-1). Kept here so the
@@ -315,9 +316,9 @@ SCHEMA_SERVICE_CONTAINER_RESTART = {}
 VIRT_INSTANCE_STOP_OPTIONS = {"force": True, "timeout": -1}
 
 SERVICE_APP_START = "app_start"
-SCHEMA_SERVICE_APP_START = {}
+SCHEMA_SERVICE_APP_START: VolDictType = {}
 SERVICE_APP_STOP = "app_stop"
-SCHEMA_SERVICE_APP_STOP = {}
+SCHEMA_SERVICE_APP_STOP: VolDictType = {}
 
 ERROR_API_FORMAT = "TrueNAS %s API error: %s"
 ICON_GAUGE = "mdi:gauge"

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, TypeGuard
 
-from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.statistics import list_statistic_ids
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -21,12 +21,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.recorder import get_instance
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 from homeassistant.util import slugify
 
 from .api import TrueNASAPI
-from .apiparser import parse_api
+from .apiparser import ApiValueSpec, parse_api
 from .const import (
     BEHAVIOR_SKIP_DISABLED_CRONJOBS,
     CONF_BEHAVIORS,
@@ -66,7 +67,7 @@ _NETDATA_GRAPHS = "reporting.netdata_graphs"
 
 # Field mapping shared by ``pool.query`` and ``boot.get_state`` (the boot-pool
 # reports the same top-level shape, so both are parsed with these lists).
-_POOL_VALS = [
+_POOL_VALS: list[ApiValueSpec] = [
     {"name": "guid", "default": 0},
     {"name": "id", "default": 0},
     {"name": "name", "default": "unknown"},
@@ -108,7 +109,7 @@ _POOL_VALS = [
         "default": 0,
     },
 ]
-_POOL_ENSURE_VALS = [
+_POOL_ENSURE_VALS: list[ApiValueSpec] = [
     {"name": "available", "default": 0.0},
     {"name": "total", "default": 0.0},
     {"name": "usage", "default": 0.0},
@@ -119,7 +120,7 @@ _POOL_ENSURE_VALS = [
 ]
 
 # Job-progress fields shared by the cloudsync, replication and rsync queries.
-_JOB_PROGRESS_VALS = [
+_JOB_PROGRESS_VALS: list[ApiValueSpec] = [
     {
         "name": "time_started",
         "source": "job/time_started/$date",
@@ -143,13 +144,13 @@ _JOB_PROGRESS_VALS = [
 # Cloudsync and rsync report their status via the last job (job/state).
 # Replication has its own persistent ``state`` object (``state/state``) — the
 # value shown in the TrueNAS WebUI — and overrides this (see get_replication, #34).
-_JOB_STATUS_VALS = [
+_JOB_STATUS_VALS: list[ApiValueSpec] = [
     {"name": "state", "source": "job/state", "default": "unknown"},
     *_JOB_PROGRESS_VALS,
 ]
 
 # Certificate expiry monitoring (certificate.query).
-_CERTIFICATE_VALS = [
+_CERTIFICATE_VALS: list[ApiValueSpec] = [
     {"name": "id", "default": 0},
     {"name": "name", "default": "unknown"},
     {"name": "cert_type", "default": "unknown"},
@@ -368,7 +369,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.name = config_entry.data[CONF_NAME]
         self.host = config_entry.data[CONF_HOST]
 
-        self.ds = {
+        self.ds: dict[str, dict[str, Any]] = {
             "interface": {},
             "disk": {},
             "pool": {},
@@ -404,7 +405,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._systemstats_errored: dict[str, datetime] = {}
         self._systemstats_error_cooldown = timedelta(minutes=10)
-        self._disk_temp_graph = None
+        self._disk_temp_graph: str | None = None
         self._ups_graphs: set[str] | None = None
         self.datasets_hass_device_id = None
         self.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
@@ -491,7 +492,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   _async_update_data
     # ---------------------------
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, Any]:
         """Update TrueNAS data."""
 
         await self._async_ensure_connected()
@@ -520,7 +521,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if self.api.connected():
 
-            async def _run_job(job):
+            async def _run_job(job: Callable[[], Awaitable[None]]) -> None:
                 try:
                     await job()
                 except Exception as err:
@@ -938,7 +939,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # No new version in status object, keep current
             self._reset_update_status()
 
-    def _updatecheck_process_new_version(self, new_version_obj: dict) -> None:
+    def _updatecheck_process_new_version(self, new_version_obj: dict[str, Any]) -> None:
         """Process new version data for updatecheck."""
         self.ds["system_info"]["update_version"] = new_version_obj["version"]
         self.ds["system_info"]["update_available"] = True
@@ -1022,11 +1023,11 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ]
 
     async def _fetch_stat_graphs(
-        self, graph_names: list[str], graph_query: dict
-    ) -> list:
+        self, graph_names: list[str], graph_query: dict[str, Any]
+    ) -> list[Any]:
         """Query each stat graph, returning combined data and tracking failures."""
         reporting_path = _NETDATA_GRAPH
-        tmp_graph: list = []
+        tmp_graph: list[Any] = []
         failed_graphs: list[str] = []
 
         for graph_name in graph_names:
@@ -1064,7 +1065,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 newly_failed_graphs,
             )
 
-    def _process_system_stat(self, item: dict) -> None:
+    def _process_system_stat(self, item: dict[str, Any]) -> None:
         """Process a single system statistic item."""
         name = item.get("name")
         if not name:
@@ -1092,7 +1093,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             self._handle_unknown_stat(name)
 
-    def _process_cputemp(self, item: dict) -> None:
+    def _process_cputemp(self, item: dict[str, Any]) -> None:
         """Store the CPU temperature from a cputemp graph item."""
         mean_vals = item.get("aggregations", {}).get("mean", {})
         valid_means = [v for v in mean_vals.values() if isinstance(v, (int, float))]
@@ -1100,7 +1101,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             round(max(valid_means), 2) if valid_means else None
         )
 
-    def _process_memory_stat(self, item: dict) -> None:
+    def _process_memory_stat(self, item: dict[str, Any]) -> None:
         """Store memory totals and usage percentage from a memory graph item."""
         self.ds["system_info"]["memory-total_value"] = round(
             self.ds["system_info"].get("physmem", 0)
@@ -1137,7 +1138,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ", ".join(sorted(near_misses)),
             )
 
-    def _process_system_stat_interface(self, item: dict, tmp_etc: str) -> None:
+    def _process_system_stat_interface(
+        self, item: dict[str, Any], tmp_etc: str
+    ) -> None:
         """Process interface system statistics."""
         tmp_arr = ("rx", "tx")
         legend = item.get("legend")
@@ -1176,7 +1179,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   _systemstats_process
     # ---------------------------
-    def _systemstats_process(self, arr, graph, t) -> None:
+    def _systemstats_process(
+        self, arr: str | tuple[str, ...], graph: dict[str, Any], t: str
+    ) -> None:
         arr = (arr,) if isinstance(arr, str) else tuple(arr)
         aggregations = graph.get("aggregations")
         legend = graph.get("legend")
@@ -1209,7 +1214,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             info[tmp_var] = round(tmp_val, 2)
 
-    def _store_stat_defaults(self, t: str, arr: tuple) -> None:
+    def _store_stat_defaults(self, t: str, arr: tuple[str, ...]) -> None:
         """Store zeroed defaults when a statistic graph has no aggregations."""
         info = self.ds["system_info"]
         for tmp_load in arr:
@@ -1650,7 +1655,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 temps,
             )
 
-    def _is_valid_disk_temperature_payload(self, temps: Any) -> bool:
+    def _is_valid_disk_temperature_payload(
+        self, temps: Any
+    ) -> TypeGuard[dict[str, Any]]:
         """Validate the shape of the disk temperature API payload.
 
         Delegates specific value validation to per-disk mapping.
@@ -1730,7 +1737,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return ""
 
-    def _collect_disk_temp(self, entry: dict, temps: dict[str, float]) -> None:
+    def _collect_disk_temp(
+        self, entry: dict[str, Any], temps: dict[str, float]
+    ) -> None:
         """Extract a single disk's median temperature into temps."""
         identifier = entry.get("identifier")
         mean = entry.get("aggregations", {}).get("mean", {})
@@ -2332,7 +2341,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Rebuild the dict instead of mutating it while iterating, so disabled
         # cronjobs are dropped without needing a list() copy of the items.
-        filtered_cronjobs: dict = {}
+        filtered_cronjobs: dict[str, Any] = {}
         for uid, vals in self.ds["cronjob"].items():
             if skip_disabled and not vals.get("enabled", True):
                 continue

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from asyncio import Lock
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from logging import getLogger
 from typing import Any
 
@@ -12,8 +13,9 @@ from homeassistant.const import ATTR_ATTRIBUTION, CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_platform as ep
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
@@ -56,19 +58,41 @@ def format_device_identifier(inst: str, hostname: str) -> str:
 
 
 # ---------------------------
+#   TrueNASEntityDescription
+# ---------------------------
+@dataclass(frozen=True, kw_only=True)
+class TrueNASEntityDescription(EntityDescription):
+    """Fields shared by the entity descriptions of every TrueNAS platform."""
+
+    ha_group: str | None = None
+    ha_connection: str | None = None
+    ha_connection_value: str | None = None
+    data_path: str | None = None
+    data_name: str | None = None
+    data_uid: str | None = None
+    data_reference: str | None = None
+    data_attributes_list: tuple[str, ...] = ()
+    func: str = ""
+
+
+# ---------------------------
 #   Entity discovery helpers
 # ---------------------------
-def _skip_keyless_description(entity_description, data) -> bool:
+def _skip_keyless_description(
+    entity_description: TrueNASEntityDescription, data: dict[str, Any]
+) -> bool:
     """Return True if a keyless description has no value to expose."""
-    attr_name = getattr(
+    attr_name: str | None = getattr(
         entity_description,
         "data_attribute",
         getattr(entity_description, "data_is_on", None),
     )
-    return bool(attr_name) and data.get(attr_name) is None
+    if not attr_name:
+        return False
+    return data.get(attr_name) is None
 
 
-def _is_uid_excluded(entity_description, vals) -> bool:
+def _is_uid_excluded(entity_description: TrueNASEntityDescription, vals: Any) -> bool:
     """Return True if a referenced object is excluded from entity creation.
 
     Honors an optional ``data_exclude`` (key, value) on the description, e.g. to
@@ -83,12 +107,16 @@ def _is_uid_excluded(entity_description, vals) -> bool:
 
 
 def _new_referenced_entities(
-    coordinator, entity_description, data, dispatcher, seen: set[str]
-) -> list:
+    coordinator: TrueNASCoordinator,
+    entity_description: TrueNASEntityDescription,
+    data: Any,
+    dispatcher: Mapping[str, Callable[..., Any]],
+    seen: set[str],
+) -> list[TrueNASEntity]:
     """Collect new per-uid entities for one referenced (multi-object) description."""
     behaviors = coordinator.config_entry.options.get(CONF_BEHAVIORS, DEFAULT_BEHAVIORS)
     apply_exclude = BEHAVIOR_REMOVE_INACTIVE_NIC in behaviors
-    new_entities: list = []
+    new_entities: list[TrueNASEntity] = []
     for uid in data:
         # data is a mapping of uid -> values for reference descriptions;
         # fall back to treating the iterated item itself as the values.
@@ -101,17 +129,20 @@ def _new_referenced_entities(
 
 
 def _collect_new_entities(
-    coordinator, descriptions, dispatcher, seen: set[str]
-) -> list:
+    coordinator: TrueNASCoordinator,
+    descriptions: Sequence[TrueNASEntityDescription],
+    dispatcher: Mapping[str, Callable[..., Any]],
+    seen: set[str],
+) -> list[TrueNASEntity]:
     """Return entity objects whose unique_id is not in ``seen`` yet.
 
     ``seen`` is the set of unique_ids already registered for this config entry;
     only genuinely new objects (e.g. a freshly attached disk) are returned, so
     existing entities are never re-added.
     """
-    new_entities: list = []
+    new_entities: list[TrueNASEntity] = []
     for entity_description in descriptions:
-        data = coordinator.data.get(entity_description.data_path)
+        data = coordinator.data.get(entity_description.data_path or "")
         if data is None:
             continue
 
@@ -126,7 +157,9 @@ def _collect_new_entities(
     return new_entities
 
 
-def _append_if_new(obj, seen: set[str], new_entities: list) -> None:
+def _append_if_new(
+    obj: TrueNASEntity, seen: set[str], new_entities: list[TrueNASEntity]
+) -> None:
     """Append the entity to the batch when its unique_id has not been seen yet."""
     if obj.unique_id not in seen:
         seen.add(obj.unique_id)
@@ -134,8 +167,10 @@ def _append_if_new(obj, seen: set[str], new_entities: list) -> None:
 
 
 async def async_add_entities(
-    hass: HomeAssistant, config_entry: ConfigEntry, dispatcher: dict[str, Callable]
-):
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    dispatcher: Mapping[str, Callable[..., Any]],
+) -> None:
     """Set up the platform and register dynamic entity discovery.
 
     On every coordinator refresh only entities that are not already loaded on the
@@ -217,14 +252,15 @@ async def async_add_entities(
 class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
     """Define entity."""
 
+    entity_description: TrueNASEntityDescription
     _attr_has_entity_name = True
 
     def __init__(
         self,
         coordinator: TrueNASCoordinator,
-        entity_description,
+        entity_description: TrueNASEntityDescription,
         uid: str | None = None,
-    ):
+    ) -> None:
         """Initialize entity."""
         super().__init__(coordinator)
         self.entity_description = entity_description
@@ -236,8 +272,8 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
 
     def _refresh_data(self) -> None:
         """Refresh cached data from the coordinator for this entity."""
-        data = self.coordinator.data.get(self.entity_description.data_path, {})
-        self._data = data.get(self._uid, {}) if self._uid else data
+        data = self.coordinator.data.get(self.entity_description.data_path or "", {})
+        self._data: dict[str, Any] = data.get(self._uid, {}) if self._uid else data
         if self._uid and not self._data:
             _LOGGER.debug(
                 "Data for UID %s is missing or empty in %s",
@@ -253,22 +289,25 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
     @property
     def name(self) -> str | None:
         """Return the name for this entity."""
+        # Descriptions set name to a str or None (never UNDEFINED); normalize so
+        # an entity without its own name falls back to the device name instead
+        # of showing "None".
+        desc_name = self.entity_description.name
+        if not isinstance(desc_name, str):
+            desc_name = None
+
         if not self._uid:
-            # Return the raw name (may be None) so an entity without its own
-            # name falls back to the device name instead of showing "None".
-            return self.entity_description.name
+            return desc_name
 
         data_value = None
-        if self._data is not None and getattr(
-            self.entity_description, "data_name", None
-        ):
+        if self._data is not None and self.entity_description.data_name:
             data_value = self._data.get(self.entity_description.data_name)
 
         if data_value is None:
             data_value = str(self._uid)
 
-        if self.entity_description.name:
-            return f"{data_value} {self.entity_description.name}"
+        if desc_name:
+            return f"{data_value} {desc_name}"
 
         return f"{data_value}"
 
@@ -276,7 +315,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
     def unique_id(self) -> str:
         """Return a unique id for this entity."""
         if self._uid:
-            data_ref = getattr(self.entity_description, "data_reference", None)
+            data_ref = self.entity_description.data_reference
             value = self._data.get(data_ref) if self._data and data_ref else None
             reference = value if value is not None else self._uid
             return format_unique_id(self._inst, self.entity_description.key, reference)
@@ -286,16 +325,17 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return a description for device registry."""
+        ha_group = self.entity_description.ha_group or ""
         dev_connection = DOMAIN
-        dev_connection_value = f"{self._inst}_{self.entity_description.ha_group}"
-        dev_group = self.entity_description.ha_group
-        if self.entity_description.ha_group == "System":
+        dev_connection_value = f"{self._inst}_{ha_group}"
+        dev_group = ha_group
+        if ha_group == "System":
             dev_connection_value = format_device_identifier(
                 self._inst, self.coordinator.data["system_info"]["hostname"]
             )
 
-        if self.entity_description.ha_group.startswith("data__"):
-            dev_group = self.entity_description.ha_group[6:]
+        if ha_group.startswith("data__"):
+            dev_group = ha_group[6:]
             if dev_group in self._data:
                 dev_group = self._data[dev_group]
                 dev_connection_value = dev_group
@@ -310,7 +350,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
                 connection_val = self._data.get(data_key, "unknown")
                 dev_connection_value = f"{self._inst}_{connection_val}"
 
-        if self.entity_description.ha_group == "System":
+        if ha_group == "System":
             http_scheme = "https" if self.coordinator.api.scheme == "wss" else "http"
             return DeviceInfo(
                 connections={(dev_connection, f"{dev_connection_value}")},
@@ -358,38 +398,43 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             f"({self.entity_id})"
         )
 
-    async def start(self):
+    async def start(self) -> None:
         """Run function."""
         self._raise_unsupported("start")
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop function."""
         self._raise_unsupported("stop")
 
-    async def restart(self):
+    async def restart(self) -> None:
         """Restart function."""
         self._raise_unsupported("restart")
 
-    async def reload(self):
+    async def reload(self) -> None:
         """Reload function."""
         self._raise_unsupported("reload")
 
-    async def snapshot(self):
+    async def snapshot(self) -> None:
         """Snapshot function."""
         self._raise_unsupported("snapshot")
 
-    async def lock(self, **kwargs):
+    async def lock(self, force_umount: bool = False) -> None:
         """Lock function."""
         self._raise_unsupported("lock")
 
-    async def unlock(self, **kwargs):
+    async def unlock(
+        self,
+        passphrase: str | None = None,
+        recursive: bool = False,
+        force: bool = False,
+    ) -> None:
         """Unlock function."""
         self._raise_unsupported("unlock")
 
-    async def passphrase_set(self, **kwargs):
+    async def passphrase_set(self, passphrase: str) -> None:
         """Store passphrase function."""
         self._raise_unsupported("passphrase_set")
 
-    async def refresh(self):
+    async def refresh(self) -> None:
         """Refresh function."""
         self._raise_unsupported("refresh")

--- a/custom_components/truenas_ce/migration.py
+++ b/custom_components/truenas_ce/migration.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import os
 from logging import getLogger
+from typing import Any
 
 from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry, ConfigEntryDisabler
@@ -76,7 +77,7 @@ _BACKUP_VERSION = 1
 # ---------------------------
 async def async_adopt_legacy_entities(
     hass: HomeAssistant, config_entry: ConfigEntry
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """Release the legacy entities' entity_ids for adoption by this entry.
 
     Returns the list of freed records for :func:`finalize_legacy_adoption` to
@@ -88,7 +89,7 @@ async def async_adopt_legacy_entities(
         return []
 
     legacy_entry = _find_legacy_entry(hass, config_entry)
-    records: list[dict] = []
+    records: list[dict[str, Any]] = []
     backup_key: str | None = None
 
     if legacy_entry is not None:
@@ -117,7 +118,9 @@ async def async_adopt_legacy_entities(
     return records
 
 
-def finalize_legacy_adoption(hass: HomeAssistant, records: list[dict]) -> None:
+def finalize_legacy_adoption(
+    hass: HomeAssistant, records: list[dict[str, Any]]
+) -> None:
     """Re-attach the freed legacy entity_ids to the new entities.
 
     Called after the platforms have been set up so the new (``truenas_ce``)
@@ -157,7 +160,7 @@ def _find_legacy_entry(
 
 def _collect_legacy_records(
     ent_reg: er.EntityRegistry, legacy_entry: ConfigEntry
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """Snapshot every registry entry of the legacy config entry (read-only)."""
     return [
         {
@@ -173,7 +176,9 @@ def _collect_legacy_records(
     ]
 
 
-def _remove_legacy_entities(ent_reg: er.EntityRegistry, records: list[dict]) -> None:
+def _remove_legacy_entities(
+    ent_reg: er.EntityRegistry, records: list[dict[str, Any]]
+) -> None:
     """Free the recorded entity_ids for adoption.
 
     Removing the registry entry frees its entity_id and any user overrides but
@@ -188,7 +193,7 @@ async def _write_migration_backup(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     legacy_entry: ConfigEntry,
-    records: list[dict],
+    records: list[dict[str, Any]],
 ) -> str | None:
     """Write a human-readable safety snapshot before the registry is mutated.
 
@@ -197,7 +202,9 @@ async def _write_migration_backup(
     migration. Returns the ``.storage`` key on success, else ``None``.
     """
     timestamp = dt_util.utcnow().strftime("%Y%m%d_%H%M%S")
-    store = Store(hass, _BACKUP_VERSION, f"{_BACKUP_KEY_PREFIX}_{timestamp}")
+    store: Store[dict[str, Any]] = Store(
+        hass, _BACKUP_VERSION, f"{_BACKUP_KEY_PREFIX}_{timestamp}"
+    )
     payload = {
         "created": dt_util.utcnow().isoformat(),
         "ce_entry_id": config_entry.entry_id,
@@ -252,7 +259,7 @@ def _persist_migration_state(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     legacy_entry: ConfigEntry | None,
-    records: list[dict],
+    records: list[dict[str, Any]],
     backup_key: str | None,
 ) -> None:
     """Store the idempotency flag, reverse map and legacy snapshot on the entry."""
@@ -273,7 +280,7 @@ def _persist_migration_state(
 
 
 def _remap_and_restore(
-    ent_reg: er.EntityRegistry, pairs: list[tuple[str, str, dict]]
+    ent_reg: er.EntityRegistry, pairs: list[tuple[str, str, dict[str, Any]]]
 ) -> None:
     """Move each entity from its current id onto its target id, then restore overrides.
 
@@ -287,7 +294,7 @@ def _remap_and_restore(
     by the entity's final id matching the recorder statistics, so only the end
     state matters.
     """
-    parked: list[tuple[str, str, dict]] = []
+    parked: list[tuple[str, str, dict[str, Any]]] = []
     counter = 0
     for current_id, target_id, record in pairs:
         if current_id == target_id:
@@ -325,10 +332,10 @@ def _temp_entity_id(
 
 
 def _restore_overrides(
-    ent_reg: er.EntityRegistry, entity_id: str, record: dict
+    ent_reg: er.EntityRegistry, entity_id: str, record: dict[str, Any]
 ) -> None:
     """Re-apply the user's name/icon/area/disabled overrides to an adopted entity."""
-    updates: dict[str, object] = {}
+    updates: dict[str, Any] = {}
     if record.get(_R_NAME):
         updates["name"] = record[_R_NAME]
     if record.get(_R_ICON):
@@ -345,7 +352,7 @@ def _restore_overrides(
 #   Post-migration notification
 # ---------------------------
 def async_notify_migration_result(
-    hass: HomeAssistant, config_entry: ConfigEntry, records: list[dict]
+    hass: HomeAssistant, config_entry: ConfigEntry, records: list[dict[str, Any]]
 ) -> None:
     """Surface a one-time success notification after a legacy adoption.
 
@@ -395,7 +402,7 @@ def async_notify_migration_result(
 
 
 def _classify_reconnection(
-    ent_reg: er.EntityRegistry, records: list[dict]
+    ent_reg: er.EntityRegistry, records: list[dict[str, Any]]
 ) -> tuple[int, list[str], list[str]]:
     """Split adopted records into reconnected / pending / mismatched buckets.
 

--- a/custom_components/truenas_ce/quality_scale.yaml
+++ b/custom_components/truenas_ce/quality_scale.yaml
@@ -1,0 +1,131 @@
+rules:
+  # Bronze
+  action-setup:
+    status: todo
+    comment: |
+      Domain-level alert/passphrase services are registered in
+      async_setup_entry (guarded by has_service); move them to async_setup so
+      they validate config-entry state at call time instead.
+  appropriate-polling: done
+  brands:
+    status: todo
+    comment: |
+      No home-assistant/brands entry for the truenas_ce domain yet
+      (custom_integrations/truenas_ce). Planned for the core-readiness phase.
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage:
+    status: todo
+    comment: |
+      tests/test_config_flow.py covers the pure helpers and validation logic;
+      full flow coverage (user/migrate/reauth/reconfigure/options steps) needs
+      pytest-homeassistant-custom-component, which is currently blocked on the
+      Windows dev machine (its plugin imports fcntl).
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions:
+    status: todo
+    comment: README lacks an explicit removal/uninstall section.
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data:
+    status: todo
+    comment: |
+      The coordinator is stored in hass.data[DOMAIN][entry_id]; migrate to
+      config_entry.runtime_data with a typed ConfigEntry alias.
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry:
+    status: todo
+    comment: |
+      The config flow only rejects duplicate instance *names*
+      (configured_instances); the same host can still be added twice under a
+      different name. Match on host or a system identifier instead.
+
+  # Silver
+  action-exceptions:
+    status: todo
+    comment: |
+      Unsupported entity actions correctly raise ServiceValidationError, but a
+      failed API call inside an action (query returns None) does not raise
+      HomeAssistantError yet.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable:
+    status: done
+    comment: Handled by DataUpdateCoordinator (logs once on failure/recovery).
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage:
+    status: todo
+    comment: |
+      api.py/apiparser.py are at 100 %, coordinator.py and the config-flow
+      helpers are covered, but the platform modules (sensor, binary_sensor,
+      switch, button, update, entity) are not tested yet; overall coverage is
+      below the required 95 %.
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery:
+    status: todo
+    comment: |
+      TrueNAS advertises via mDNS; evaluate zeroconf discovery for the config
+      flow.
+  discovery-update-info:
+    status: todo
+    comment: Follows the discovery rule.
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations:
+    status: todo
+    comment: |
+      Scattered hints exist (reverse-proxy/Cloudflare section); consolidate a
+      dedicated known-limitations section in the README.
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices: done
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations:
+    status: todo
+    comment: |
+      Only the diagnostic buttons use translation_key; the remaining entities
+      carry hard-coded English names in their descriptions.
+  exception-translations:
+    status: todo
+    comment: |
+      ServiceValidationError/HomeAssistantError are raised with literal
+      English messages instead of translation_domain/translation_key.
+  icon-translations:
+    status: todo
+    comment: Icons are set via the entity descriptions; no icons.json yet.
+  reconfiguration-flow: done
+  repair-issues: done
+  stale-devices:
+    status: done
+    comment: |
+      Orphaned entities and empty devices are removed on every setup
+      (_cleanup_orphaned_entities); recorder statistics get a repair issue.
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: |
+      aiotruenas speaks JSON-RPC over its own `websockets` connection; there
+      is no aiohttp/httpx session to inject.
+  strict-typing:
+    status: done
+    comment: |
+      aiotruenas is PEP 561 compliant (ships py.typed) and the integration
+      passes mypy --strict (configured in pyproject.toml).

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -32,10 +32,14 @@ from .helper import alert_action, scaled_data_unit
 from .sensor_types import (  # noqa: F401
     SENSOR_SERVICES,
     SENSOR_TYPES,
+    TrueNASSensorEntityDescription,
 )
 
 _LOGGER = getLogger(__name__)
 _UNKNOWN_DATASET = "<unknown>"
+
+# Updates are centralized in the coordinator; entity actions may run unlimited.
+PARALLEL_UPDATES = 0
 
 # Middleware job polling for dataset lock/unlock operations.
 JOB_POLL_INTERVAL = 1
@@ -76,12 +80,14 @@ async def async_setup_entry(
 class TrueNASSensor(TrueNASEntity, SensorEntity):
     """Define an TrueNAS sensor."""
 
+    entity_description: TrueNASSensorEntityDescription
+
     def __init__(
         self,
         coordinator: TrueNASCoordinator,
-        entity_description,
+        entity_description: TrueNASSensorEntityDescription,
         uid: str | None = None,
-    ):
+    ) -> None:
         super().__init__(coordinator, entity_description, uid)
         self._attr_suggested_unit_of_measurement = (
             self.entity_description.suggested_unit_of_measurement
@@ -98,7 +104,7 @@ class TrueNASSensor(TrueNASEntity, SensorEntity):
                 ),
             )
             value = (
-                self._data.get(self.entity_description.data_attribute)
+                self._data.get(self.entity_description.data_attribute or "")
                 if self._data
                 else None
             )
@@ -114,7 +120,10 @@ class TrueNASSensor(TrueNASEntity, SensorEntity):
         Uses .get() so a transient API failure that empties the coordinator data
         degrades the state to unknown instead of raising a KeyError mid-update.
         """
-        return self._data.get(self.entity_description.data_attribute)
+        value: StateType | date | datetime | Decimal = self._data.get(
+            self.entity_description.data_attribute or ""
+        )
+        return value
 
     @property
     def native_unit_of_measurement(self) -> str | None:
@@ -123,7 +132,8 @@ class TrueNASSensor(TrueNASEntity, SensorEntity):
             if self.entity_description.native_unit_of_measurement.startswith("data__"):
                 uom = self.entity_description.native_unit_of_measurement[6:]
                 if uom in self._data:
-                    return self._data[uom]
+                    data_uom: str | None = self._data[uom]
+                    return data_uom
 
             return self.entity_description.native_unit_of_measurement
 
@@ -142,7 +152,9 @@ class TrueNASCertExpirySensor(TrueNASSensor):
     @property
     def native_value(self) -> StateType:
         """Return days or fractional years depending on magnitude."""
-        days = self._data.get(self.entity_description.data_attribute)
+        days: float | None = self._data.get(
+            self.entity_description.data_attribute or ""
+        )
         if days is None:
             return None
         if days >= 365:
@@ -152,7 +164,9 @@ class TrueNASCertExpirySensor(TrueNASSensor):
     @property
     def native_unit_of_measurement(self) -> UnitOfTime:
         """Switch unit between days and years based on the raw value."""
-        days = self._data.get(self.entity_description.data_attribute)
+        days: float | None = self._data.get(
+            self.entity_description.data_attribute or ""
+        )
         if days is not None and days >= 365:
             return UnitOfTime.YEARS
         return UnitOfTime.DAYS
@@ -199,7 +213,7 @@ class TrueNASUptimeSensor(TrueNASSensor):
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the value reported by the sensor."""
-        val = self._data.get(self.entity_description.data_attribute)
+        val = self._data.get(self.entity_description.data_attribute or "")
         if isinstance(val, (int, float)) and val > 0:
             return utc_from_timestamp(val)
         return None
@@ -260,7 +274,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
             f"on {self.coordinator.host}: {reason}"
         )
 
-    async def _poll_job(self, job_id: int) -> dict | None:
+    async def _poll_job(self, job_id: int) -> dict[str, Any] | None:
         """Fetch a single middleware job by id."""
         jobs = await self.coordinator.api.query(
             "core.get_jobs", [[["id", "=", job_id]]]
@@ -269,7 +283,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
             jobs = jobs[0] if jobs else None
         return jobs if isinstance(jobs, dict) else None
 
-    def _job_finished(self, job: dict, action: str) -> bool:
+    def _job_finished(self, job: dict[str, Any], action: str) -> bool:
         """Return True if the job succeeded, raise on failure, False if running."""
         state = job.get("state")
         if state == "SUCCESS":
@@ -279,7 +293,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
             raise HomeAssistantError(self._action_error(action, reason))
         return False
 
-    async def _wait_for_job(self, job_id: int, action: str) -> dict:
+    async def _wait_for_job(self, job_id: int, action: str) -> dict[str, Any]:
         """Poll a middleware job until it succeeds, fails or times out."""
         missing = 0
         try:
@@ -304,7 +318,9 @@ class TrueNASDatasetSensor(TrueNASSensor):
                 self._action_error(action, "timed out waiting for completion")
             ) from err
 
-    async def _run_dataset_job(self, method: str, payload: list, action: str) -> Any:
+    async def _run_dataset_job(
+        self, method: str, payload: list[Any], action: str
+    ) -> Any:
         """Start a dataset middleware job, wait for it, and return its result."""
         job_id = await self.coordinator.api.query(method, payload)
         if not isinstance(job_id, int):

--- a/custom_components/truenas_ce/sensor_types.py
+++ b/custom_components/truenas_ce/sensor_types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, NamedTuple
 
 from homeassistant.components.sensor import (
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    EntityCategory,
     UnitOfDataRate,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -20,7 +21,6 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
 )
-from homeassistant.helpers.entity import EntityCategory
 
 from .const import (
     ICON_GAUGE,
@@ -50,6 +50,7 @@ from .const import (
     SERVICE_SYSTEM_REFRESH,
     SERVICE_SYSTEM_SHUTDOWN,
 )
+from .entity import TrueNASEntityDescription
 
 # Icons reused by several entity descriptions.
 ICON_MEMORY = "mdi:memory"
@@ -203,19 +204,11 @@ DEVICE_ATTRIBUTES_DIRECTORYSERVICE = (
 )
 
 
-@dataclass
-class TrueNASSensorEntityDescription(SensorEntityDescription):
+@dataclass(frozen=True, kw_only=True)
+class TrueNASSensorEntityDescription(SensorEntityDescription, TrueNASEntityDescription):
     """Class describing entities."""
 
-    ha_group: str | None = None
-    ha_connection: str | None = None
-    ha_connection_value: str | None = None
-    data_path: str | None = None
     data_attribute: str | None = None
-    data_name: str | None = None
-    data_uid: str | None = None
-    data_reference: str | None = None
-    data_attributes_list: list[str] = field(default_factory=list)
     # Optional (key, value): skip creating an entity for a referenced object
     # whose data[key] == value (e.g. don't create traffic sensors for a
     # network interface whose link is down).

--- a/custom_components/truenas_ce/switch.py
+++ b/custom_components/truenas_ce/switch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -11,9 +12,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import TrueNASEntity
 from .entity import async_add_entities as setup_entities
-from .switch_types import SENSOR_SERVICES, SENSOR_TYPES  # noqa: F401
+from .switch_types import (  # noqa: F401
+    SENSOR_SERVICES,
+    SENSOR_TYPES,
+    TrueNASSwitchEntityDescription,
+)
 
 _LOGGER = getLogger(__name__)
+
+# Updates are centralized in the coordinator; entity actions may run unlimited.
+PARALLEL_UPDATES = 0
 
 
 # ---------------------------
@@ -39,10 +47,12 @@ async def async_setup_entry(
 class _TrueNASSwitch(TrueNASEntity, SwitchEntity):
     """Shared base for all TrueNAS switch entities."""
 
+    entity_description: TrueNASSwitchEntityDescription
+
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return self._data.get(self.entity_description.data_is_on, False)
+        return bool(self._data.get(self.entity_description.data_is_on, False))
 
 
 # ---------------------------
@@ -53,14 +63,14 @@ class _TrueNASEnableSwitch(_TrueNASSwitch):
 
     _update_method: str
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.coordinator.api.query(
             self._update_method, [self._data["id"], {"enabled": True}]
         )
         await self.coordinator.async_request_refresh()
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.api.query(
             self._update_method, [self._data["id"], {"enabled": False}]
@@ -74,12 +84,12 @@ class _TrueNASEnableSwitch(_TrueNASSwitch):
 class TrueNASServiceSwitch(_TrueNASSwitch):
     """Define a TrueNAS Service Switch."""
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.coordinator.api.query("service.start", [self._data["service"]])
         await self.coordinator.async_request_refresh()
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.api.query("service.stop", [self._data["service"]])
         await self.coordinator.async_request_refresh()

--- a/custom_components/truenas_ce/switch_types.py
+++ b/custom_components/truenas_ce/switch_types.py
@@ -2,24 +2,19 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.switch import SwitchEntityDescription
 
+from .entity import TrueNASEntityDescription
 
-@dataclass
-class TrueNASSwitchEntityDescription(SwitchEntityDescription):
+
+@dataclass(frozen=True, kw_only=True)
+class TrueNASSwitchEntityDescription(SwitchEntityDescription, TrueNASEntityDescription):
     """Class describing entities."""
 
-    ha_group: str | None = None
-    ha_connection: str | None = None
-    ha_connection_value: str | None = None
-    data_path: str | None = None
     data_is_on: str = "running"
-    data_name: str | None = None
-    data_uid: str | None = None
-    data_reference: str | None = None
-    data_attributes_list: list[str] = field(default_factory=list)
     func: str = "TrueNASServiceSwitch"
 
 
@@ -34,7 +29,7 @@ SENSOR_TYPES: tuple[TrueNASSwitchEntityDescription, ...] = (
         data_name="display_name",
         data_uid=None,
         data_reference="id",
-        data_attributes_list=["enable", "state"],
+        data_attributes_list=("enable", "state"),
         func="TrueNASServiceSwitch",
     ),
     TrueNASSwitchEntityDescription(
@@ -63,4 +58,4 @@ SENSOR_TYPES: tuple[TrueNASSwitchEntityDescription, ...] = (
     ),
 )
 
-SENSOR_SERVICES: tuple = ()
+SENSOR_SERVICES: tuple[Any, ...] = ()

--- a/custom_components/truenas_ce/update.py
+++ b/custom_components/truenas_ce/update.py
@@ -16,10 +16,17 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import TrueNASCoordinator
 from .entity import TrueNASEntity, async_add_entities
-from .update_types import SENSOR_SERVICES, SENSOR_TYPES  # noqa: F401
+from .update_types import (  # noqa: F401
+    SENSOR_SERVICES,
+    SENSOR_TYPES,
+    TrueNASUpdateEntityDescription,
+)
 
 _LOGGER = getLogger(__name__)
 DEVICE_UPDATE = "device_update"
+
+# Updates are centralized in the coordinator; entity actions may run unlimited.
+PARALLEL_UPDATES = 0
 
 
 # ---------------------------
@@ -44,15 +51,16 @@ async def async_setup_entry(
 class TrueNASUpdate(TrueNASEntity, UpdateEntity):
     """Define an TrueNAS Update Sensor."""
 
+    entity_description: TrueNASUpdateEntityDescription
     TYPE = DEVICE_UPDATE
     _attr_device_class = UpdateDeviceClass.FIRMWARE
 
     def __init__(
         self,
         coordinator: TrueNASCoordinator,
-        entity_description,
+        entity_description: TrueNASUpdateEntityDescription,
         uid: str | None = None,
-    ):
+    ) -> None:
         """Set up device update entity."""
         super().__init__(coordinator, entity_description, uid)
 
@@ -73,7 +81,9 @@ class TrueNASUpdate(TrueNASEntity, UpdateEntity):
     async def options_updated(self) -> None:
         """No action needed."""
 
-    async def async_install(self, _version: str, backup: bool, **kwargs: Any) -> None:
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
         """Install the latest available update.
 
         The version parameter is currently ignored; TrueNAS API only supports
@@ -88,10 +98,15 @@ class TrueNASUpdate(TrueNASEntity, UpdateEntity):
         await self.coordinator.async_refresh()
 
     @property
-    def in_progress(self) -> int | bool:
-        """Update installation progress."""
+    def in_progress(self) -> bool:
+        """Return whether an update installation is running."""
+        return self._data.get("update_state") == "RUNNING"
+
+    @property
+    def update_percentage(self) -> int | None:
+        """Update installation progress percentage."""
         if self._data.get("update_state") != "RUNNING":
-            return False
+            return None
 
         return int(self._data.get("update_progress", 0))
 
@@ -102,14 +117,15 @@ class TrueNASUpdate(TrueNASEntity, UpdateEntity):
 class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
     """Define an TrueNAS App Update Sensor."""
 
+    entity_description: TrueNASUpdateEntityDescription
     TYPE = DEVICE_UPDATE
 
     def __init__(
         self,
         coordinator: TrueNASCoordinator,
-        entity_description,
+        entity_description: TrueNASUpdateEntityDescription,
         uid: str | None = None,
-    ):
+    ) -> None:
         """Set up device update entity."""
         super().__init__(coordinator, entity_description, uid)
 
@@ -128,16 +144,18 @@ class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
         compose apps there is no catalog version (latest_version is "unknown"),
         so reflect availability explicitly when an image update is pending.
         """
-        installed = self._data.get("version")
+        installed: str | None = self._data.get("version")
         if not self._data.get("update_available"):
             return installed
 
-        latest = self._data.get("latest_version")
+        latest: str | None = self._data.get("latest_version")
         if not latest or latest in ("unknown", installed):
             return f"{installed} (image update)" if installed else "image update"
         return latest
 
-    async def async_install(self, _version: str, backup: bool, **kwargs: Any) -> None:
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
         """Install an update."""
         app_data = self.coordinator.data.get("app", {}).get(self._data["id"], {})
         if app_data.get("state") != "RUNNING":

--- a/custom_components/truenas_ce/update_types.py
+++ b/custom_components/truenas_ce/update_types.py
@@ -2,26 +2,20 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.update import UpdateEntityDescription
 
+from .entity import TrueNASEntityDescription
 
-@dataclass
-class TrueNASUpdateEntityDescription(UpdateEntityDescription):
+
+@dataclass(frozen=True, kw_only=True)
+class TrueNASUpdateEntityDescription(UpdateEntityDescription, TrueNASEntityDescription):
     """Class describing entities."""
 
-    ha_group: str | None = None
-    ha_connection: str | None = None
-    ha_connection_value: str | None = None
     title: str | None = None
-    data_path: str | None = None
     data_attribute: str = "available"
-    data_name: str | None = None
-    data_uid: str | None = None
-    data_reference: str | None = None
-    data_attributes_list: tuple[str, ...] = field(default_factory=tuple)
-    func: str | None = None
 
 
 SENSOR_TYPES: tuple[TrueNASUpdateEntityDescription, ...] = (
@@ -56,4 +50,4 @@ SENSOR_TYPES: tuple[TrueNASUpdateEntityDescription, ...] = (
     ),
 )
 
-SENSOR_SERVICES: tuple = ()
+SENSOR_SERVICES: tuple[Any, ...] = ()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,9 @@ warn_unreachable = true
 asyncio_mode = "auto"
 testpaths = ["tests"]
 pythonpath = ["."]
+filterwarnings = [
+    # aiohttp deprecation triggered inside Home Assistant core's http component
+    # (HomeAssistantApplication subclasses web.Application) — not our code;
+    # HA core filters the same warning in its own test config.
+    "ignore:Inheritance class HomeAssistantApplication from web.Application is discouraged:DeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,12 @@ line-length = 88
 select = ["E", "F", "W", "I", "UP", "ASYNC"]
 ignore = []
 
+[tool.mypy]
+python_version = "3.14"
+files = ["custom_components/truenas_ce"]
+strict = true
+warn_unreachable = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]


### PR DESCRIPTION
## Proposed change

Prepares the integration for Home Assistant quality-scale tracking (core-readiness phase 2):

- **New `quality_scale.yaml`** with an honest rating of every Bronze→Platinum rule. The manifest `quality_scale` field is intentionally **not** set yet — 6 Bronze rules are still `todo` (action-setup, brands, config-flow-test-coverage, docs-removal-instructions, runtime-data, unique-config-entry); the YAML serves as the tracking backlog for them. `inject-websession` is `exempt` (aiotruenas manages its own websockets connection, no aiohttp session).
- **`mypy --strict`: 366 → 0 errors** across all 21 modules. Config lives in `pyproject.toml`, enforced by a new `mypy` job in `ci.yml`. Key structural piece: a new shared `TrueNASEntityDescription` base (`frozen=True, kw_only=True`) that all five platform description classes inherit from; `api.query()` is now honestly typed `Any` (the existing defensive `isinstance` guards remain the safety net).
- **`PARALLEL_UPDATES = 0`** in all five platform modules (Silver rule).
- **Small real fixes that fell out of strict typing** (intentional behavior changes):
  - `update.py`: `in_progress` returned an `int`, which current HA removed — now `in_progress -> bool` plus a new `update_percentage -> int | None`, so system-update progress renders correctly again.
  - `supports_response=True` → `SupportsResponse.OPTIONAL` (2×, `__init__.py`; identical behavior, correct enum type).
  - `parse_api`: a bare-string `source` (malformed API payload) is now treated like no source instead of being iterated character-wise.
  - Canonical imports: `EntityCategory` from `homeassistant.const`, `DeviceInfo` from `helpers.device_registry`, `get_instance` from `homeassistant.helpers.recorder`.
- `CLAUDE.md` updated (mypy command documented, stale aiotruenas git-SHA-pin description corrected to the PyPI requirement). `Pipfile.lock` refreshed via `pipenv install --dev` (mypy toolchain).

## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Live-tested on a real HA instance (working-tree sync + restart + MCP log check + spot functional checks). The only log finding was a pre-existing master bug unrelated to this branch (pool scrub-finished timestamp sensor receives int `0` while a scrub is running — will be fixed in a separate PR).

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce strict typing and shared entity description base for the TrueNAS integration, add quality_scale tracking, and refine update and service behavior while wiring mypy into CI.

New Features:
- Add quality_scale.yaml to track Home Assistant quality scale compliance for the TrueNAS integration.

Bug Fixes:
- Adjust update entities to report in-progress state as a boolean and expose progress percentage separately so firmware update progress displays correctly.
- Treat malformed bare-string API payloads as missing source in parse_api instead of iterating over characters.

Enhancements:
- Introduce a shared frozen TrueNASEntityDescription base used across sensor, binary sensor, switch, button, and update entity descriptions for consistent metadata handling.
- Tighten typing across the integration to satisfy mypy --strict, including more precise type hints, typed coordinator data structures, and safer service handlers.
- Set PARALLEL_UPDATES = 0 across platforms to align with Home Assistant Silver rule expectations and centralize update coordination.
- Refine service response configuration to use SupportsResponse.OPTIONAL for alert and passphrase list services.
- Improve entity naming and device info handling to avoid "None" names and better normalize group/connection values.
- Clarify documentation in CLAUDE.md about mypy usage, Python version in CI, and runtime dependency sourcing from PyPI instead of a git SHA.

Build:
- Configure mypy with strict settings in pyproject.toml and add a dedicated mypy job to the GitHub Actions CI workflow.

Documentation:
- Document strict typing workflow and updated dependency model in CLAUDE.md and add quality_scale.yaml comments explaining rule status and future work.