### PR TITLE
fix: scrub timestamp sensor crashes while a scrub is running

### DIFF
--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -359,12 +359,21 @@ def fill_defaults(data, vals) -> dict:
 #   _convert_timestamp
 # ---------------------------
 def _convert_timestamp(target: dict[str, Any], name: str) -> None:
-    """Convert an int timestamp stored at target[name] into a UTC datetime."""
+    """Convert an int timestamp stored at target[name] into a UTC datetime.
+
+    Values that cannot be a real timestamp are normalized to None so timestamp
+    sensors report "unknown" instead of crashing on a non-datetime state
+    (TrueNAS sends scan.end_time = null while a scrub is running, which the
+    value spec's default turns into 0).
+    """
     value = target.get(name)
-    if isinstance(value, int) and value > 0:
-        if value > MILLIS_TIMESTAMP_THRESHOLD:
-            value = value / 1000
-        target[name] = utc_from_timestamp(value)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        target[name] = None
+        return
+
+    if value > MILLIS_TIMESTAMP_THRESHOLD:
+        value = value / 1000
+    target[name] = utc_from_timestamp(value)
 
 
 # ---------------------------

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -413,10 +413,33 @@ def test_parse_api_convert_timestamp_non_int_normalized_to_none(
     assert result["1"]["started"] is None
 
 
+def test_parse_api_convert_timestamp_negative_normalized_to_none(
+    ap: ModuleType,
+) -> None:
+    result = ap.parse_api(
+        source=[{"id": "1", "started": -1}],
+        key="id",
+        vals=[{"name": "started", "convert": "utc_from_timestamp"}],
+    )
+    assert result["1"]["started"] is None
+
+
 def test_parse_api_convert_timestamp_bool_normalized_to_none(ap: ModuleType) -> None:
     """bool is an int subclass but never a valid timestamp."""
     result = ap.parse_api(
         source=[{"id": "1", "started": True}],
+        key="id",
+        vals=[{"name": "started", "convert": "utc_from_timestamp"}],
+    )
+    assert result["1"]["started"] is None
+
+
+def test_parse_api_convert_timestamp_bool_false_normalized_to_none(
+    ap: ModuleType,
+) -> None:
+    """False is also a bool and must not be treated as a timestamp."""
+    result = ap.parse_api(
+        source=[{"id": "1", "started": False}],
         key="id",
         vals=[{"name": "started", "convert": "utc_from_timestamp"}],
     )
@@ -444,6 +467,31 @@ def test_parse_api_convert_timestamp_running_scrub_end_time_none(
         ],
     )
     assert result["1"]["scrub_end"] is None
+
+
+def test_parse_api_convert_timestamp_completed_scrub_end_time_converted(
+    ap: ModuleType,
+) -> None:
+    """Companion to the running-scrub regression: a finished scrub reports
+    end_time as {"$date": <millis>}, which must convert to a UTC datetime."""
+    result = ap.parse_api(
+        source=[
+            {
+                "id": "1",
+                "scan": {"state": "FINISHED", "end_time": {"$date": 1700000000000}},
+            }
+        ],
+        key="id",
+        vals=[
+            {
+                "name": "scrub_end",
+                "source": "scan/end_time/$date",
+                "default": 0,
+                "convert": "utc_from_timestamp",
+            }
+        ],
+    )
+    assert result["1"]["scrub_end"] == ap.utc_from_timestamp(1700000000)
 
 
 def test_parse_api_convert_human_date(ap: ModuleType) -> None:

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -393,22 +393,57 @@ def test_parse_api_key_secondary_used_when_key_missing(ap: ModuleType) -> None:
     assert result == {"abc": {"name": "pool0"}}
 
 
-def test_parse_api_convert_timestamp_zero_left_unconverted(ap: ModuleType) -> None:
+def test_parse_api_convert_timestamp_zero_normalized_to_none(ap: ModuleType) -> None:
     result = ap.parse_api(
         source=[{"id": "1", "started": 0}],
         key="id",
         vals=[{"name": "started", "convert": "utc_from_timestamp"}],
     )
-    assert result["1"]["started"] == 0
+    assert result["1"]["started"] is None
 
 
-def test_parse_api_convert_timestamp_non_int_left_unconverted(ap: ModuleType) -> None:
+def test_parse_api_convert_timestamp_non_int_normalized_to_none(
+    ap: ModuleType,
+) -> None:
     result = ap.parse_api(
         source=[{"id": "1", "started": "unknown"}],
         key="id",
         vals=[{"name": "started", "convert": "utc_from_timestamp"}],
     )
-    assert result["1"]["started"] == "unknown"
+    assert result["1"]["started"] is None
+
+
+def test_parse_api_convert_timestamp_bool_normalized_to_none(ap: ModuleType) -> None:
+    """bool is an int subclass but never a valid timestamp."""
+    result = ap.parse_api(
+        source=[{"id": "1", "started": True}],
+        key="id",
+        vals=[{"name": "started", "convert": "utc_from_timestamp"}],
+    )
+    assert result["1"]["started"] is None
+
+
+def test_parse_api_convert_timestamp_running_scrub_end_time_none(
+    ap: ModuleType,
+) -> None:
+    """Regression: while a scrub runs, TrueNAS sends scan.end_time = null.
+
+    The spec default (0) must become None so the timestamp sensor reports
+    "unknown" instead of crashing on an int state.
+    """
+    result = ap.parse_api(
+        source=[{"id": "1", "scan": {"state": "SCANNING", "end_time": None}}],
+        key="id",
+        vals=[
+            {
+                "name": "scrub_end",
+                "source": "scan/end_time/$date",
+                "default": 0,
+                "convert": "utc_from_timestamp",
+            }
+        ],
+    )
+    assert result["1"]["scrub_end"] is None
 
 
 def test_parse_api_convert_human_date(ap: ModuleType) -> None:


### PR DESCRIPTION
## Proposed change

While a pool scrub is running, TrueNAS reports `scan.end_time = null`. The `parse_api` value spec's `default: 0` turned that into the int `0`, which `_convert_timestamp` passed through unchanged — so the *Scrub finished* sensor (`SensorDeviceClass.TIMESTAMP`) raised `ValueError: Invalid datetime ... provides state 0:<class 'int'>` on **every 60s poll** for the entire duration of the scrub.

`_convert_timestamp` now normalizes values that cannot be a real timestamp (bool / non-int / ≤ 0) to `None`, so timestamp sensors cleanly report *unknown* until the scrub completes. A `bool` guard is needed because `bool` is an `int` subclass. The same normalization also benefits the latent (attribute-only, non-crashing) cases: cloudsync/replication/rsync job `time_started`/`time_finished` and the snapshot-task `datetime` field.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

- Verified live: with the fix synced to a running HA instance and a scrub started on a pool, the sensor shows *unknown* while `scrub_state = SCANNING` and no `ValueError` appears in the log anymore (previously one per poll).
- Tests: two existing timestamp tests updated to the new None-normalization contract, plus two new ones (bool guard, running-scrub regression with `scan.end_time = None`). 230 tests pass locally; ruff check/format and bandit clean.
- This is the pre-existing master bug already announced under *Additional information* in #34.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize invalid timestamp values to avoid crashes in TrueNAS timestamp sensors and ensure running scrubs report an unknown end time until completion.

Bug Fixes:
- Prevent scrub finished timestamp sensor from crashing while a pool scrub is running by treating null/default end times as unknown.
- Ensure other timestamp-based fields (e.g., job start/finish times and snapshot task datetimes) safely handle non-timestamp values instead of propagating invalid states.

Tests:
- Extend timestamp conversion tests to cover normalization of zero, negative, non-int, and bool values to None.
- Add regression tests for running and completed scrub end_time handling to verify correct unknown and converted datetime behavior.