### PR TITLE
fix: set quality_scale to bronze in manifest.json

### DIFF
--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -10,6 +10,7 @@
     "documentation": "https://github.com/kayl-codes/homeassistant-truenas",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
+    "quality_scale": "bronze",
     "requirements": [
         "aiotruenas>=1.0.0",
         "websockets>=15.0.1"


### PR DESCRIPTION
## Proposed change
All Bronze quality-scale rules in `quality_scale.yaml` are marked `done` as of PR #36, but the `quality_scale` field in `manifest.json` was never set to reflect that. This PR closes the gap.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Follow-up to PR #36, which completed the last remaining Bronze todos (action-setup, runtime-data, unique-config-entry, brands, config-flow-test-coverage) but did not set this field.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)