### PR TITLE
test: add unit tests for platform modules (Silver test-coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           pip install pytest-homeassistant-custom-component
       - name: Test with pytest
-        run: pytest
+        run: pytest --cov=custom_components/truenas_ce --cov-report=term-missing
 
   mypy:
     name: Mypy strict typing

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .ruff_cache/
+.coverage
 
 # GitHub Copilot & IDE spezifisch
 .github/copilot-instructions/

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -10,7 +10,7 @@
     "documentation": "https://github.com/kayl-codes/homeassistant-truenas",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
-    "quality_scale": "bronze",
+    "quality_scale": "silver",
     "requirements": [
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"

--- a/custom_components/truenas_ce/quality_scale.yaml
+++ b/custom_components/truenas_ce/quality_scale.yaml
@@ -73,10 +73,12 @@ rules:
     status: done
     comment: |
       CI (pytest --cov, which includes the hass-fixture-based flow/service
-      tests skipped on this repo's Windows dev machine) reports 95 % overall
-      coverage, meeting the Silver requirement. Remaining gaps are the
-      TrueNASCoordinator.__init__ hass wiring and a couple of entity-discovery
-      edge branches in entity.py, none of which are reachable from pure unit
+      tests skipped on this repo's Windows dev machine) reports 99 % overall
+      coverage, well above the Silver requirement. The remaining handful of
+      lines are a couple of unreachable defensive branches in coordinator.py
+      (parse_api/​_unwrap_app_stats_message already guarantee the shapes they
+      guard against) and two multi-config-entry edge branches in
+      entity.async_add_entities, none of which are reachable from pure unit
       tests without a running Home Assistant core.
 
   # Gold

--- a/custom_components/truenas_ce/quality_scale.yaml
+++ b/custom_components/truenas_ce/quality_scale.yaml
@@ -70,12 +70,14 @@ rules:
   parallel-updates: done
   reauthentication-flow: done
   test-coverage:
-    status: todo
+    status: done
     comment: |
-      api.py/apiparser.py are at 100 %, coordinator.py and the config-flow
-      helpers are covered, but the platform modules (sensor, binary_sensor,
-      switch, button, update, entity) are not tested yet; overall coverage is
-      below the required 95 %.
+      CI (pytest --cov, which includes the hass-fixture-based flow/service
+      tests skipped on this repo's Windows dev machine) reports 95 % overall
+      coverage, meeting the Silver requirement. Remaining gaps are the
+      TrueNASCoordinator.__init__ hass wiring and a couple of entity-discovery
+      edge branches in entity.py, none of which are reachable from pure unit
+      tests without a running Home Assistant core.
 
   # Gold
   devices: done

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -1,0 +1,83 @@
+"""Shared test doubles for platform-module unit tests.
+
+These build a lightweight stand-in for ``TrueNASCoordinator`` (a real
+``DataUpdateCoordinator`` subclass) so entity classes can be constructed and
+exercised without a running ``HomeAssistant`` core instance, mirroring the
+``BaseCoordinatorEntity.__init__`` contract (it only stores ``coordinator``
+and ``coordinator_context``, no hass access at construction time).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.const import CONF_HOST, CONF_NAME
+
+DEFAULT_SYSTEM_INFO: dict[str, Any] = {
+    "hostname": "truenas.local",
+    "system_product": "TrueNAS Mini",
+    "system_manufacturer": "iXsystems",
+    "version": "TrueNAS-25.10.4",
+}
+
+
+def make_config_entry(
+    *,
+    name: str = "TrueNAS",
+    host: str = "truenas.local",
+    data: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,
+) -> SimpleNamespace:
+    """Build a minimal stand-in for a ConfigEntry."""
+    entry_data = {CONF_NAME: name, CONF_HOST: host, **(data or {})}
+    return SimpleNamespace(
+        entry_id="test-entry-id",
+        data=entry_data,
+        options=options or {},
+        async_get_entry=MagicMock(return_value=None),
+    )
+
+
+def make_coordinator(
+    *,
+    data: dict[str, Any] | None = None,
+    config_entry: SimpleNamespace | None = None,
+    api_error: str = "",
+    api_scheme: str = "ws",
+    host: str = "truenas.local",
+) -> SimpleNamespace:
+    """Build a minimal stand-in for TrueNASCoordinator.
+
+    Only the attributes actually touched by entity.py/sensor.py/binary_sensor.py/
+    switch.py/button.py/update.py are provided; add more as new tests need them.
+    """
+    ds = {"system_info": dict(DEFAULT_SYSTEM_INFO), **(data or {})}
+    entry = config_entry or make_config_entry(host=host)
+    api = SimpleNamespace(
+        query=AsyncMock(return_value=None),
+        error=api_error,
+        scheme=api_scheme,
+    )
+    return SimpleNamespace(
+        data=ds,
+        ds=ds,
+        config_entry=entry,
+        api=api,
+        host=host,
+        hass=SimpleNamespace(
+            config_entries=SimpleNamespace(
+                async_get_entry=MagicMock(return_value=None),
+                async_update_entry=MagicMock(),
+            )
+        ),
+        last_update_success=True,
+        orphaned_statistics=[],
+        async_refresh=AsyncMock(),
+        async_request_refresh=AsyncMock(),
+        async_run_task=AsyncMock(),
+        set_optimistic_running=MagicMock(),
+        async_clear_orphaned_statistics=AsyncMock(),
+        raise_migration_rollback_issue=MagicMock(),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # POSIX-only fcntl module and crashes every local pytest run on this repo's
 # Windows dev machine, so it must never be installed there.
 collect_ignore_glob: list[str] = (
-    ["test_config_flow_flows.py", "test_services.py"]
+    ["test_config_flow_flows.py", "test_services.py", "test_entity_setup.py"]
     if importlib.util.find_spec("pytest_homeassistant_custom_component") is None
     else []
 )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,314 @@
+"""Unit tests for binary_sensor.py."""
+
+from __future__ import annotations
+
+from _fakes import make_coordinator
+
+from custom_components.truenas_ce.binary_sensor import (
+    TrueNASAppBinarySensor,
+    TrueNASBinarySensor,
+    TrueNASContainerBinarySensor,
+    TrueNASServiceBinarySensor,
+    TrueNASVMBinarySensor,
+)
+from custom_components.truenas_ce.binary_sensor_types import (
+    TrueNASBinarySensorEntityDescription,
+)
+from custom_components.truenas_ce.const import VIRT_INSTANCE_STOP_OPTIONS
+
+_DESC = TrueNASBinarySensorEntityDescription(
+    key="k", name="N", data_path="vm", data_is_on="running"
+)
+_ICON_DESC = TrueNASBinarySensorEntityDescription(
+    key="k",
+    name="N",
+    data_path="vm",
+    data_is_on="running",
+    icon_enabled="mdi:on",
+    icon_disabled="mdi:off",
+)
+
+
+def _make(cls, data: dict, path: str = "vm", desc=None):
+    description = desc or TrueNASBinarySensorEntityDescription(
+        key="k", name="N", data_path=path, data_is_on="running"
+    )
+    coordinator = make_coordinator(data={path: {"o1": data}})
+    return cls(coordinator, description, "o1")
+
+
+def test_is_on_true() -> None:
+    sensor = _make(TrueNASBinarySensor, {"running": True})
+    assert sensor.is_on is True
+
+
+def test_is_on_none_when_missing() -> None:
+    sensor = _make(TrueNASBinarySensor, {})
+    assert sensor.is_on is None
+
+
+def test_icon_none_when_not_configured() -> None:
+    sensor = _make(TrueNASBinarySensor, {"running": True})
+    assert sensor.icon is None
+
+
+def test_icon_enabled() -> None:
+    sensor = _make(TrueNASBinarySensor, {"running": True}, desc=_ICON_DESC)
+    assert sensor.icon == "mdi:on"
+
+
+def test_icon_disabled() -> None:
+    sensor = _make(TrueNASBinarySensor, {"running": False}, desc=_ICON_DESC)
+    assert sensor.icon == "mdi:off"
+
+
+# ---------------------------
+#   TrueNASVMBinarySensor
+# ---------------------------
+def _make_vm(data: dict) -> TrueNASVMBinarySensor:
+    return _make(TrueNASVMBinarySensor, {"id": 1, "name": "vm1", **data}, path="vm")
+
+
+async def test_vm_start_invalid_state_logs_and_returns() -> None:
+    vm = _make_vm({})
+    vm.coordinator.api.query.return_value = {"status": {}}
+    await vm.start()
+    vm.coordinator.api.query.assert_awaited_once()
+
+
+async def test_vm_start_not_stopped_returns() -> None:
+    vm = _make_vm({})
+    vm.coordinator.api.query.return_value = {"status": {"state": "RUNNING"}}
+    await vm.start()
+    vm.coordinator.api.query.assert_awaited_once_with("vm.get_instance", [1])
+
+
+async def test_vm_start_success() -> None:
+    vm = _make_vm({})
+    vm.coordinator.api.query.side_effect = [{"status": {"state": "STOPPED"}}, None]
+    await vm.start(overcommit=True)
+    assert vm.coordinator.api.query.await_count == 2
+    vm.coordinator.api.query.assert_awaited_with("vm.start", [1, {"overcommit": True}])
+
+
+async def test_vm_stop_invalid_state_logs_and_returns() -> None:
+    vm = _make_vm({})
+    vm.coordinator.api.query.return_value = None
+    await vm.stop()
+    vm.coordinator.api.query.assert_awaited_once()
+
+
+async def test_vm_stop_not_running_returns() -> None:
+    vm = _make_vm({})
+    vm.coordinator.api.query.return_value = {"status": {"state": "STOPPED"}}
+    await vm.stop()
+    vm.coordinator.api.query.assert_awaited_once()
+
+
+async def test_vm_stop_success() -> None:
+    vm = _make_vm({})
+    vm.coordinator.api.query.side_effect = [{"status": {"state": "RUNNING"}}, None]
+    await vm.stop()
+    vm.coordinator.api.query.assert_awaited_with(
+        "vm.stop", [1, {"force": True, "force_after_timeout": True}]
+    )
+
+
+async def test_vm_restart_always_calls_and_refreshes() -> None:
+    vm = _make_vm({})
+    await vm.restart()
+    vm.coordinator.api.query.assert_awaited_once_with("vm.restart", [1])
+    vm.coordinator.async_request_refresh.assert_awaited_once()
+
+
+# ---------------------------
+#   TrueNASContainerBinarySensor
+# ---------------------------
+def _make_container(data: dict | None = None) -> TrueNASContainerBinarySensor:
+    return _make(
+        TrueNASContainerBinarySensor,
+        {"id": "c1", "name": "ct1", **(data or {})},
+        path="container",
+    )
+
+
+async def test_container_current_status_returns_status() -> None:
+    ct = _make_container()
+    ct.coordinator.api.query.return_value = [{"status": "RUNNING"}]
+    assert await ct._current_status() == "RUNNING"
+
+
+async def test_container_current_status_handles_query_exception() -> None:
+    ct = _make_container()
+    ct.coordinator.api.query.side_effect = RuntimeError("boom")
+    assert await ct._current_status() is None
+
+
+async def test_container_start_already_running_skips() -> None:
+    ct = _make_container()
+    ct.coordinator.api.query.return_value = [{"status": "RUNNING"}]
+    await ct.start()
+    ct.coordinator.api.query.assert_awaited_once()
+
+
+async def test_container_start_success() -> None:
+    ct = _make_container()
+    ct.coordinator.api.query.side_effect = [[{"status": "STOPPED"}], None]
+    await ct.start()
+    ct.coordinator.api.query.assert_awaited_with("virt.instance.start", ["c1"])
+    ct.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_container_stop_not_running_skips() -> None:
+    ct = _make_container()
+    ct.coordinator.api.query.return_value = [{"status": "STOPPED"}]
+    await ct.stop()
+    ct.coordinator.api.query.assert_awaited_once()
+
+
+async def test_container_stop_success() -> None:
+    ct = _make_container()
+    ct.coordinator.api.query.side_effect = [[{"status": "RUNNING"}], None]
+    await ct.stop()
+    ct.coordinator.api.query.assert_awaited_with(
+        "virt.instance.stop", ["c1", VIRT_INSTANCE_STOP_OPTIONS]
+    )
+    ct.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_container_restart_always_calls_and_refreshes() -> None:
+    ct = _make_container()
+    await ct.restart()
+    ct.coordinator.api.query.assert_awaited_once_with(
+        "virt.instance.restart", ["c1", VIRT_INSTANCE_STOP_OPTIONS]
+    )
+    ct.coordinator.async_request_refresh.assert_awaited_once()
+
+
+# ---------------------------
+#   TrueNASServiceBinarySensor
+# ---------------------------
+def _make_service(data: dict | None = None) -> TrueNASServiceBinarySensor:
+    return _make(
+        TrueNASServiceBinarySensor,
+        {"id": 4, "service": "ssh", **(data or {})},
+        path="service",
+    )
+
+
+async def test_service_start_invalid_state_returns() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.return_value = [{}]
+    await svc.start()
+    svc.coordinator.api.query.assert_awaited_once()
+
+
+async def test_service_start_not_stopped_returns() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.return_value = [{"state": "RUNNING"}]
+    await svc.start()
+    svc.coordinator.api.query.assert_awaited_once()
+
+
+async def test_service_start_success() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.side_effect = [[{"state": "STOPPED"}], None]
+    await svc.start()
+    svc.coordinator.api.query.assert_awaited_with("service.start", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_service_stop_not_running_returns() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.return_value = [{"state": "STOPPED"}]
+    await svc.stop()
+    svc.coordinator.api.query.assert_awaited_once()
+
+
+async def test_service_stop_success() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
+    await svc.stop()
+    svc.coordinator.api.query.assert_awaited_with("service.stop", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_service_restart_stopped_returns() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.return_value = [{"state": "STOPPED"}]
+    await svc.restart()
+    svc.coordinator.api.query.assert_awaited_once()
+
+
+async def test_service_restart_success() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
+    await svc.restart()
+    svc.coordinator.api.query.assert_awaited_with("service.restart", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_service_reload_stopped_returns() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.return_value = [{"state": "STOPPED"}]
+    await svc.reload()
+    svc.coordinator.api.query.assert_awaited_once()
+
+
+async def test_service_reload_success() -> None:
+    svc = _make_service()
+    svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
+    await svc.reload()
+    svc.coordinator.api.query.assert_awaited_with("service.reload", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+# ---------------------------
+#   TrueNASAppBinarySensor
+# ---------------------------
+def _make_app(data: dict | None = None) -> TrueNASAppBinarySensor:
+    return _make(
+        TrueNASAppBinarySensor, {"id": "a1", "name": "app1", **(data or {})}, path="app"
+    )
+
+
+async def test_app_start_invalid_state_returns() -> None:
+    app = _make_app()
+    app.coordinator.api.query.return_value = None
+    await app.start()
+    app.coordinator.api.query.assert_awaited_once()
+
+
+async def test_app_start_already_running_returns() -> None:
+    app = _make_app()
+    app.coordinator.api.query.return_value = {"state": "RUNNING"}
+    await app.start()
+    app.coordinator.api.query.assert_awaited_once()
+
+
+async def test_app_start_success() -> None:
+    app = _make_app()
+    app.coordinator.api.query.side_effect = [{"state": "STOPPED"}, None]
+    await app.start()
+    app.coordinator.api.query.assert_awaited_with("app.start", ["a1"])
+
+
+async def test_app_stop_invalid_state_returns() -> None:
+    app = _make_app()
+    app.coordinator.api.query.return_value = None
+    await app.stop()
+    app.coordinator.api.query.assert_awaited_once()
+
+
+async def test_app_stop_not_running_returns() -> None:
+    app = _make_app()
+    app.coordinator.api.query.return_value = {"state": "STOPPED"}
+    await app.stop()
+    app.coordinator.api.query.assert_awaited_once()
+
+
+async def test_app_stop_success() -> None:
+    app = _make_app()
+    app.coordinator.api.query.side_effect = [{"state": "RUNNING"}, None]
+    await app.stop()
+    app.coordinator.api.query.assert_awaited_with("app.stop", ["a1"])

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,133 @@
+"""Unit tests for button.py."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import make_coordinator
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.truenas_ce.button import (
+    TrueNASButton,
+    TrueNASMigrationRollbackButton,
+    TrueNASPoolScrubButton,
+    TrueNASRefreshButton,
+    TrueNASStatisticsCleanupButton,
+)
+from custom_components.truenas_ce.button_types import TrueNASButtonEntityDescription
+from custom_components.truenas_ce.const import MIGRATION_LEGACY_ENTRY_ID
+
+_RUN_DESC = TrueNASButtonEntityDescription(
+    key="rsynctask_run", name="Run", data_path="rsynctask", api_method="rsynctask.run"
+)
+
+
+def _make_button(*, data: dict | None = None, description=None) -> TrueNASButton:
+    coordinator = make_coordinator(data={"rsynctask": {"t1": (data or {})}})
+    return TrueNASButton(coordinator, description or _RUN_DESC, "t1")
+
+
+async def test_async_press_missing_method_logs_and_skips() -> None:
+    desc = TrueNASButtonEntityDescription(
+        key="k", name="Run", data_path="rsynctask", api_method=None
+    )
+    button = _make_button(data={"id": 1}, description=desc)
+    await button.async_press()
+    button.coordinator.async_run_task.assert_not_awaited()
+
+
+async def test_async_press_missing_object_id_logs_and_skips() -> None:
+    button = _make_button(data={})
+    await button.async_press()
+    button.coordinator.async_run_task.assert_not_awaited()
+
+
+async def test_async_press_triggers_run_task() -> None:
+    button = _make_button(data={"id": 7})
+    await button.async_press()
+    button.coordinator.async_run_task.assert_awaited_once_with(
+        "rsynctask.run", 7, "rsynctask"
+    )
+
+
+def _make_scrub_button(*, data: dict | None = None) -> TrueNASPoolScrubButton:
+    desc = TrueNASButtonEntityDescription(
+        key="scrub_run", name="Run", data_path="snapshottask"
+    )
+    coordinator = make_coordinator(data={"snapshottask": {"t1": (data or {})}})
+    return TrueNASPoolScrubButton(coordinator, desc, "t1")
+
+
+async def test_scrub_button_missing_pool_name_skips() -> None:
+    button = _make_scrub_button(data={"id": 1, "enabled": True})
+    await button.async_press()
+    button.coordinator.api.query.assert_not_awaited()
+
+
+async def test_scrub_button_disabled_skips() -> None:
+    button = _make_scrub_button(data={"pool_name": "tank", "id": 1, "enabled": False})
+    await button.async_press()
+    button.coordinator.api.query.assert_not_awaited()
+
+
+async def test_scrub_button_success_sets_optimistic_running() -> None:
+    button = _make_scrub_button(data={"pool_name": "tank", "id": 5, "enabled": True})
+    button.coordinator.api.query.return_value = 123
+    await button.async_press()
+    button.coordinator.api.query.assert_awaited_once_with(
+        "pool.scrub.scrub", ["tank", "START"]
+    )
+    button.coordinator.set_optimistic_running.assert_called_once_with("snapshottask", 5)
+
+
+async def test_scrub_button_failure_raises() -> None:
+    button = _make_scrub_button(data={"pool_name": "tank", "id": 5, "enabled": True})
+    button.coordinator.api.query.return_value = None
+    button.coordinator.api.error = "middleware down"
+    with pytest.raises(HomeAssistantError, match="middleware down"):
+        await button.async_press()
+
+
+def test_statistics_cleanup_button_init_and_available() -> None:
+    coordinator = make_coordinator()
+    button = TrueNASStatisticsCleanupButton(coordinator)
+    assert button.unique_id == "truenas-statistics_cleanup"
+    assert button.available is False
+    coordinator.orphaned_statistics = ["sensor.truenas_old"]
+    assert button.available is True
+
+
+async def test_statistics_cleanup_button_press_clears_statistics() -> None:
+    coordinator = make_coordinator()
+    button = TrueNASStatisticsCleanupButton(coordinator)
+    await button.async_press()
+    coordinator.async_clear_orphaned_statistics.assert_awaited_once()
+
+
+def test_migration_rollback_button_available_false_without_legacy_id() -> None:
+    coordinator = make_coordinator()
+    button = TrueNASMigrationRollbackButton(coordinator)
+    button.hass = coordinator.hass
+    assert button.available is False
+
+
+def test_migration_rollback_button_available_true_when_legacy_entry_exists() -> None:
+    coordinator = make_coordinator(data={}, config_entry=None)
+    coordinator.config_entry.data[MIGRATION_LEGACY_ENTRY_ID] = "legacy-1"
+    coordinator.hass.config_entries.async_get_entry.return_value = object()
+    button = TrueNASMigrationRollbackButton(coordinator)
+    button.hass = coordinator.hass
+    assert button.available is True
+
+
+async def test_migration_rollback_button_press_raises_issue() -> None:
+    coordinator = make_coordinator()
+    button = TrueNASMigrationRollbackButton(coordinator)
+    await button.async_press()
+    coordinator.raise_migration_rollback_issue.assert_called_once()
+
+
+async def test_refresh_button_press_refreshes_coordinator() -> None:
+    coordinator = make_coordinator()
+    button = TrueNASRefreshButton(coordinator)
+    await button.async_press()
+    coordinator.async_refresh.assert_awaited_once()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -73,8 +73,11 @@ def test_text_to_passphrases_duplicate_datasets_last_wins() -> None:
 
 
 def test_text_to_passphrases_skips_blank_lines() -> None:
-    text = "\n  \ntank/data#secret1\n\n"
-    assert _text_to_passphrases(text) == {"tank/data": "secret1"}
+    text = "\n  \ntank/data#secret1\n\ntank/backup#secret2\n\n"
+    assert _text_to_passphrases(text) == {
+        "tank/data": "secret1",
+        "tank/backup": "secret2",
+    }
 
 
 @pytest.mark.parametrize("text", ["", "   \n  "])

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -508,11 +508,30 @@ def test_systemstats_process_falls_back_to_defaults_without_aggregations() -> No
     assert coord.ds["system_info"]["cpu_cpu"] == pytest.approx(0.0)
 
 
+def test_systemstats_process_skips_legend_var_not_in_arr() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    graph = {
+        "legend": ["shortterm", "other"],
+        "aggregations": {"mean": {"shortterm": 1.0, "other": 99.0}},
+    }
+    coord._systemstats_process(("shortterm",), graph, "load")
+    assert coord.ds["system_info"]["load_shortterm"] == pytest.approx(1.0)
+    assert "load_other" not in coord.ds["system_info"]
+
+
 def test_store_stat_value_arcsize_uses_dedicated_key() -> None:
     coord = _bare_coordinator()
     coord.ds = {"system_info": {}}
     coord._store_stat_value("arcsize", "size", 12.345)
     assert coord.ds["system_info"]["cache_size-arc_value"] == pytest.approx(12.35)
+
+
+def test_store_stat_value_cpu_uses_prefixed_key() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._store_stat_value("cpu", "cpu", 12.345)
+    assert coord.ds["system_info"]["cpu_cpu"] == pytest.approx(12.35)
 
 
 def test_store_stat_value_memory_only_stores_available() -> None:
@@ -522,6 +541,13 @@ def test_store_stat_value_memory_only_stores_available() -> None:
     assert coord.ds["system_info"]["memory-free_value"] == 100
     coord._store_stat_value("memory", "used", 50.0)
     assert "memory-used" not in coord.ds["system_info"]
+
+
+def test_store_stat_value_unknown_type_stores_raw_key() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._store_stat_value("diskstats", "reads", 12.345)
+    assert coord.ds["system_info"]["reads"] == pytest.approx(12.35)
 
 
 # ---------------------------
@@ -834,6 +860,21 @@ async def test_start_app_stats_keeps_existing_sub_when_no_apps() -> None:
     coord.api.subscribe_events.assert_not_awaited()
     assert coord._app_stats_sub_id == "sub-old"
     assert coord._app_stats_event_name == 'app.stats:{"interval": 60}'
+
+
+async def test_get_app_stats_clears_when_containers_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app_stats": {"stale-app": {"cpu": 1}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.stop_app_stats = AsyncMock()
+    coord._app_stats_sub_id = "sub-1"
+
+    await coord.get_app_stats()
+
+    coord.stop_app_stats.assert_awaited_once_with(force=True)
+    assert coord.ds["app_stats"] == {}
 
 
 async def test_get_app_stats_does_nothing_when_disconnected_mid_call() -> None:
@@ -1774,6 +1815,22 @@ async def test_get_systeminfo_returns_early_when_disconnected_after_parse() -> N
     coord._handle_update_job.assert_not_awaited()
 
 
+async def test_get_systeminfo_returns_early_disconnected_after_update_job() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {}}
+    coord.api = MagicMock()
+    # Connected for the pre-update-job check, disconnected right after.
+    coord.api.connected = MagicMock(side_effect=[True, False])
+    coord.api.query = AsyncMock(return_value={"version": "25.04.1"})
+    coord._handle_update_job = AsyncMock()
+    coord._parse_version = MagicMock()
+
+    await coord.get_systeminfo()
+
+    coord._handle_update_job.assert_awaited_once()
+    coord._parse_version.assert_not_called()
+
+
 async def test_handle_update_job_noop_without_jobid() -> None:
     coord = _bare_coordinator()
     coord.ds = {"system_info": {"update_jobid": 0}}
@@ -1920,6 +1977,76 @@ def test_process_system_stat_ignores_missing_name() -> None:
     coord._process_system_stat({})  # must not raise
 
 
+def test_process_system_stat_dispatches_cputemp() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    item = {"name": "cputemp", "aggregations": {"mean": {"core0": 40.0}}}
+    with patch.object(coord, "_process_cputemp") as mock:
+        coord._process_system_stat(item)
+    mock.assert_called_once_with(item)
+
+
+def test_process_system_stat_dispatches_cpu_and_rounds_usage() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._process_system_stat({"name": "cpu"})
+    # No aggregations/legend -> _store_stat_defaults zeroes cpu_cpu, which then
+    # feeds cpu_usage.
+    assert coord.ds["system_info"]["cpu_usage"] == pytest.approx(0.0)
+
+
+def test_process_system_stat_dispatches_interface_for_known_identifier() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {"eth0": {}}}
+    coord._process_system_stat(
+        {"name": "interface", "identifier": "eth0", "legend": "not-a-list"}
+    )
+    assert coord.ds["interface"]["eth0"]["rx"] == 0.0
+    assert coord.ds["interface"]["eth0"]["tx"] == 0.0
+
+
+def test_process_system_stat_ignores_interface_for_unknown_identifier() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {}}
+    coord._process_system_stat({"name": "interface", "identifier": "eth99"})
+    assert coord.ds["interface"] == {}
+
+
+def test_process_system_stat_dispatches_memory() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {"physmem": 1000}}
+    coord._process_system_stat(
+        {
+            "name": "memory",
+            "legend": ["available"],
+            "aggregations": {"mean": {"available": 250.0}},
+        }
+    )
+    assert coord.ds["system_info"]["memory-free_value"] == 250
+
+
+def test_process_system_stat_dispatches_arcsize() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._process_system_stat(
+        {
+            "name": "arcsize",
+            "legend": ["size"],
+            "aggregations": {"mean": {"size": 12.345}},
+        }
+    )
+    assert coord.ds["system_info"]["cache_size-arc_value"] == pytest.approx(12.35)
+
+
+def test_process_system_stat_dispatches_unknown_name() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord.host = "truenas.local"
+    coord._unknown_system_stat_names = set()
+    coord._process_system_stat({"name": "weird_stat"})
+    assert "weird_stat" in coord._unknown_system_stat_names
+
+
 def test_process_cputemp_stores_max_mean() -> None:
     coord = _bare_coordinator()
     coord.ds = {"system_info": {}}
@@ -1977,6 +2104,18 @@ def test_process_system_stat_interface_zeroes_on_invalid_legend() -> None:
     assert coord.ds["interface"]["eth0"]["tx"] == 0.0
 
 
+def test_process_system_stat_interface_zeroes_when_mean_not_dict() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {"eth0": {}}}
+    item = {
+        "legend": ["received", "sent"],
+        "aggregations": {"mean": "not-a-dict"},
+    }
+    coord._process_system_stat_interface(item, "eth0")
+    assert coord.ds["interface"]["eth0"]["rx"] == 0.0
+    assert coord.ds["interface"]["eth0"]["tx"] == 0.0
+
+
 async def test_get_systemstats_returns_early_without_graph_names() -> None:
     coord = _bare_coordinator()
     coord.ds = {"interface": {}}
@@ -1991,6 +2130,20 @@ async def test_get_systemstats_returns_early_without_graph_names() -> None:
     coord.api.query = AsyncMock()
     await coord.get_systemstats()
     coord.api.query.assert_not_awaited()
+
+
+async def test_get_systemstats_returns_when_fetch_yields_no_graphs() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {}, "system_info": {}}
+    coord._is_virtual = True
+    coord._systemstats_errored = {}
+    coord.host = "truenas.local"
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    await coord.get_systemstats()
+    assert coord.ds["system_info"] == {}
 
 
 async def test_get_systemstats_processes_returned_graphs() -> None:
@@ -2068,6 +2221,35 @@ async def test_get_pool_uses_dataset_mountpoint_match() -> None:
     assert coord.ds["pool"]["g1"]["fragmentation"] == 12
 
 
+async def test_get_pool_falls_back_to_name_match_when_no_mountpoint() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "pool": {},
+        # mountpoint "unknown" is excluded from the mountpoint lookup, forcing
+        # the fallback match by dataset id == pool name.
+        "dataset": {"tank": {"mountpoint": "unknown", "available": 40, "used": 60}},
+    }
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "guid": "g1",
+                    "name": "tank",
+                    "path": "/mnt/tank",
+                    "fragmentation": "12",
+                    "topology": {},
+                }
+            ],
+            None,  # boot.get_state
+        ]
+    )
+    await coord.get_pool()
+    assert coord.ds["pool"]["g1"]["available"] == 40
+    assert coord.ds["pool"]["g1"]["total"] == 100
+
+
 async def test_get_pool_returns_early_when_disconnected() -> None:
     coord = _bare_coordinator()
     coord.ds = {"pool": {}, "dataset": {}}
@@ -2113,6 +2295,17 @@ async def test_get_dataset_empty_when_group_not_monitored() -> None:
     coord.api.query.assert_not_awaited()
 
 
+async def test_get_dataset_returns_early_when_no_datasets_found() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"dataset": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_DATASETS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[])
+    await coord.get_dataset()
+    assert coord.ds["dataset"] == {}
+
+
 async def test_get_dataset_parses_when_monitored() -> None:
     coord = _bare_coordinator()
     coord.ds = {"dataset": {}}
@@ -2124,6 +2317,39 @@ async def test_get_dataset_parses_when_monitored() -> None:
     )
     await coord.get_dataset()
     assert "tank" in coord.ds["dataset"]
+
+
+async def test_update_disk_temperatures_applies_netdata_and_falls_back() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"disk": {"d1": {"temperature": 40}, "d2": {"temperature": None}}}
+    coord._disk_temps_from_netdata = AsyncMock(return_value={"sda": 40.0})
+    coord._build_disk_name_map = MagicMock(return_value={"sda": "d1"})
+    coord._apply_netdata_temps = MagicMock()
+    coord._fallback_disk_temperatures = AsyncMock()
+
+    await coord._update_disk_temperatures()
+
+    coord._build_disk_name_map.assert_called_once()
+    coord._apply_netdata_temps.assert_called_once_with({"sda": 40.0}, {"sda": "d1"})
+    coord._fallback_disk_temperatures.assert_awaited_once_with(["d2"], True)
+
+
+async def test_update_disk_temperatures_falls_back_for_all_without_netdata() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"disk": {"d1": {"temperature": 40}, "d2": {"temperature": None}}}
+    coord._disk_temps_from_netdata = AsyncMock(return_value=None)
+    coord._build_disk_name_map = MagicMock()
+    coord._apply_netdata_temps = MagicMock()
+    coord._fallback_disk_temperatures = AsyncMock()
+
+    await coord._update_disk_temperatures()
+
+    coord._build_disk_name_map.assert_not_called()
+    coord._apply_netdata_temps.assert_not_called()
+    coord._fallback_disk_temperatures.assert_awaited_once()
+    fallback_uids = coord._fallback_disk_temperatures.call_args.args[0]
+    assert set(fallback_uids) == {"d1", "d2"}
+    assert coord._fallback_disk_temperatures.call_args.args[1] is False
 
 
 # ---------------------------
@@ -2241,6 +2467,14 @@ async def test_disk_temps_from_netdata_returns_none_without_graph() -> None:
     assert await coord._disk_temps_from_netdata() is None
 
 
+async def test_disk_temps_from_netdata_returns_none_on_invalid_graph_data() -> None:
+    coord = _bare_coordinator()
+    coord._disk_temp_graph = "disk_temp"
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    assert await coord._disk_temps_from_netdata() is None
+
+
 async def test_disk_temps_from_netdata_collects_temps() -> None:
     coord = _bare_coordinator()
     coord._disk_temp_graph = "disk_temp"
@@ -2266,6 +2500,15 @@ async def test_discover_disk_temp_graph_returns_empty_when_not_found() -> None:
     coord = _bare_coordinator()
     coord.api = MagicMock()
     coord.api.query = AsyncMock(return_value=None)
+    assert await coord._discover_disk_temp_graph() == ""
+
+
+async def test_discover_disk_temp_graph_returns_empty_when_no_match() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"name": "cpu_load", "title": "CPU Load"}]
+    )
     assert await coord._discover_disk_temp_graph() == ""
 
 
@@ -2378,6 +2621,19 @@ async def test_get_container_filters_container_type_and_computes_fields() -> Non
     assert coord.ds["container"]["c1"]["memory"] == 1
     assert coord.ds["container"]["c1"]["running"] is True
     assert coord.ds["container"]["c1"]["ip_address"] == "10.0.0.5"
+
+
+async def test_get_container_normalizes_non_numeric_memory() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"id": "c1", "name": "app1", "type": "CONTAINER", "memory": None}]
+    )
+    await coord.get_container()
+    assert coord.ds["container"]["c1"]["memory"] == 0
 
 
 async def test_get_container_empty_when_not_monitored() -> None:
@@ -2545,6 +2801,24 @@ async def test_get_ups_returns_when_no_graphs_discovered() -> None:
     coord.api.query = AsyncMock()
     await coord.get_ups()
     coord.api.query.assert_not_awaited()
+
+
+async def test_get_ups_assigns_discovered_graphs_when_previously_none() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"ups": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_UPS]}
+    coord._ups_graphs = None
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        side_effect=[
+            [{"name": "upscharge"}],  # discovery call
+            [{"aggregations": {"mean": {"a": 80.0}}}],  # graph data call
+        ]
+    )
+    await coord.get_ups()
+    assert coord._ups_graphs == {"upscharge"}
+    assert coord.ds["ups"]["battery_charge"] == 80.0
 
 
 async def test_get_ups_populates_known_graphs() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,7 +14,7 @@ used for ``TrueNASConfigFlow``.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -23,13 +23,25 @@ from homeassistant.util import slugify
 
 from custom_components.truenas_ce import coordinator as coordinator_module
 from custom_components.truenas_ce.const import (
+    BEHAVIOR_SKIP_DISABLED_CRONJOBS,
+    CONF_BEHAVIORS,
     CONF_MONITORED_GROUPS,
     CONF_POLL_INTERVAL,
+    CONF_STATISTICS_CLEANUP_IGNORED,
     DEFAULT_DEVICE_NAME,
     DEFAULT_POLL_INTERVAL,
     LEGACY_DOMAIN,
     MIGRATION_LEGACY_ENTRY_ID,
+    MIGRATION_RECORDS,
+    MONITOR_GROUP_CLOUDSYNC,
     MONITOR_GROUP_CONTAINERS,
+    MONITOR_GROUP_CRONJOBS,
+    MONITOR_GROUP_DATASETS,
+    MONITOR_GROUP_DIRECTORY_SERVICES,
+    MONITOR_GROUP_REPLICATION,
+    MONITOR_GROUP_RSYNC,
+    MONITOR_GROUP_SNAPSHOTS,
+    MONITOR_GROUP_UPS,
     MONITOR_GROUP_VMS,
 )
 from custom_components.truenas_ce.coordinator import (
@@ -52,6 +64,8 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord = TrueNASCoordinator.__new__(TrueNASCoordinator)
     coord._app_stats_event_name = None
     coord._app_stats_sub_id = None
+    coord.orphaned_statistics = []
+    coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
     return coord
 
 
@@ -1392,3 +1406,1565 @@ async def test_get_updatecheck_no_new_version_resets_status() -> None:
     info = coord.ds["system_info"]
     assert info["update_available"] is False
     assert info["update_version"] == "25.04.1"
+
+
+# ---------------------------
+#   connected
+# ---------------------------
+# Note: TrueNASCoordinator.__init__ itself is not unit-tested here -- HA's
+# DataUpdateCoordinator.__init__ calls frame.report_usage(), which requires
+# hass's frame helper to have been set up by a running Home Assistant core
+# (unavailable via pytest-homeassistant-custom-component on this Windows dev
+# machine). It is exercised by CI's hass-fixture-based integration tests.
+def test_connected_delegates_to_api() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    assert coord.connected() is True
+    coord.api.connected.assert_called_once()
+
+
+# ---------------------------
+#   _async_ensure_connected
+# ---------------------------
+async def test_async_ensure_connected_noop_when_already_connected() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.connect = AsyncMock()
+    await coord._async_ensure_connected()
+    coord.api.connect.assert_not_awaited()
+
+
+async def test_async_ensure_connected_raises_update_failed_on_exception() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.connect = AsyncMock(side_effect=Exception("boom"))
+    with pytest.raises(coordinator_module.UpdateFailed):
+        await coord._async_ensure_connected()
+
+
+async def test_async_ensure_connected_raises_auth_failed_on_invalid_key() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.connect = AsyncMock(return_value=False)
+    coord.api.error = "ERR_INVALID_KEY"
+    coord.host = "truenas.local"
+    with (
+        patch.object(coordinator_module, "ERR_INVALID_KEY", "ERR_INVALID_KEY"),
+        pytest.raises(coordinator_module.ConfigEntryAuthFailed),
+    ):
+        await coord._async_ensure_connected()
+
+
+async def test_async_ensure_connected_raises_update_failed_on_other_error() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.connect = AsyncMock(return_value=False)
+    coord.api.error = "ERR_LOST_QUERY"
+    coord.host = "truenas.local"
+    with pytest.raises(coordinator_module.UpdateFailed):
+        await coord._async_ensure_connected()
+
+
+async def test_async_ensure_connected_succeeds() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.connect = AsyncMock(return_value=True)
+    await coord._async_ensure_connected()  # must not raise
+
+
+# ---------------------------
+#   _async_update_data
+# ---------------------------
+def _stub_all_jobs(coord: TrueNASCoordinator) -> None:
+    """Patch every job invoked by ``_async_update_data`` with a no-op AsyncMock."""
+    for name in (
+        "get_systeminfo",
+        "get_systemstats",
+        "get_service",
+        "get_disk",
+        "get_dataset",
+        "get_vm",
+        "get_container",
+        "get_directoryservices",
+        "get_cloudsync",
+        "get_replication",
+        "get_rsync",
+        "get_snapshottask",
+        "get_scrub",
+        "get_app",
+        "get_app_stats",
+        "get_cronjob",
+        "get_alerts",
+        "get_certificates",
+        "get_arc",
+        "get_smb",
+        "get_ups",
+        "get_pool",
+        "get_updatecheck",
+    ):
+        setattr(coord, name, AsyncMock())
+
+
+async def test_async_update_data_runs_jobs_when_connected() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord._async_ensure_connected = AsyncMock()
+    coord.async_detect_orphaned_statistics = AsyncMock()
+    coord._clear_stale_migration_rollback_issue = MagicMock()
+    coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
+    _stub_all_jobs(coord)
+    coord.ds = {"foo": "bar"}
+
+    result = await coord._async_update_data()
+
+    coord.get_systeminfo.assert_awaited_once()
+    coord.get_pool.assert_awaited_once()
+    coord.get_updatecheck.assert_awaited_once()
+    assert result is coord.ds
+
+
+async def test_async_update_data_skips_jobs_when_disconnected() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord._async_ensure_connected = AsyncMock()
+    coord.async_detect_orphaned_statistics = AsyncMock()
+    coord._clear_stale_migration_rollback_issue = MagicMock()
+    _stub_all_jobs(coord)
+
+    with pytest.raises(coordinator_module.UpdateFailed):
+        await coord._async_update_data()
+
+    coord.get_systeminfo.assert_not_awaited()
+
+
+async def test_async_update_data_swallows_job_exceptions() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord._async_ensure_connected = AsyncMock()
+    coord.async_detect_orphaned_statistics = AsyncMock()
+    coord._clear_stale_migration_rollback_issue = MagicMock()
+    coord.last_updatecheck_update = datetime.now(UTC)
+    _stub_all_jobs(coord)
+    coord.get_service = AsyncMock(side_effect=Exception("boom"))
+    coord.ds = {}
+
+    result = await coord._async_update_data()  # must not raise
+
+    assert result is coord.ds
+
+
+# ---------------------------
+#   Orphaned statistics / migration rollback lifecycle
+# ---------------------------
+async def test_async_detect_orphaned_statistics_skips_without_recorder() -> None:
+    coord = _bare_coordinator()
+    coord.hass = MagicMock()
+    coord.hass.config.components = set()
+    await coord.async_detect_orphaned_statistics()
+    assert coord.orphaned_statistics == []
+
+
+async def test_async_detect_orphaned_statistics_handles_listing_exception() -> None:
+    coord = _bare_coordinator()
+    coord.hass = MagicMock()
+    coord.hass.config.components = {"recorder"}
+    with patch.object(
+        coordinator_module,
+        "get_instance",
+        return_value=MagicMock(
+            async_add_executor_job=AsyncMock(side_effect=Exception("boom"))
+        ),
+    ):
+        await coord.async_detect_orphaned_statistics()
+    assert coord.orphaned_statistics == []
+
+
+async def test_async_detect_orphaned_statistics_filters_matching_ids() -> None:
+    coord = _bare_coordinator()
+    coord.hass = MagicMock()
+    coord.hass.config.components = {"recorder"}
+    coord.config_entry = MagicMock()
+    coord.config_entry.entry_id = "entry1"
+    coord.config_entry.options = {}
+    slug = slugify(DEFAULT_DEVICE_NAME)
+    stat_ids = [
+        {"statistic_id": f"sensor.{slug}_cpu_usage", "source": "recorder"},
+        {"statistic_id": "sensor.unrelated_thing", "source": "recorder"},
+        "not-a-dict",
+    ]
+    ent_reg = MagicMock()
+    ent_reg.async_get.return_value = None
+    with (
+        patch.object(
+            coordinator_module,
+            "get_instance",
+            return_value=MagicMock(
+                async_add_executor_job=AsyncMock(return_value=stat_ids)
+            ),
+        ),
+        patch.object(coordinator_module.er, "async_get", return_value=ent_reg),
+        patch.object(coordinator_module.ir, "async_create_issue") as create_mock,
+    ):
+        await coord.async_detect_orphaned_statistics()
+
+    assert coord.orphaned_statistics == [f"sensor.{slug}_cpu_usage"]
+    create_mock.assert_called_once()
+
+
+def test_update_statistics_issue_deletes_when_no_orphans() -> None:
+    coord = _bare_coordinator()
+    coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
+    coord.config_entry.entry_id = "entry1"
+    coord.config_entry.options = {}
+    coord.orphaned_statistics = []
+    with patch.object(coordinator_module.ir, "async_delete_issue") as delete_mock:
+        coord._update_statistics_issue()
+    delete_mock.assert_called_once()
+
+
+def test_update_statistics_issue_skips_creation_when_ignored() -> None:
+    coord = _bare_coordinator()
+    coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
+    coord.config_entry.entry_id = "entry1"
+    coord.config_entry.options = {CONF_STATISTICS_CLEANUP_IGNORED: True}
+    coord.orphaned_statistics = ["sensor.truenas_x"]
+    with patch.object(coordinator_module.ir, "async_delete_issue") as delete_mock:
+        coord._update_statistics_issue()
+    delete_mock.assert_called_once()
+
+
+def test_raise_migration_rollback_issue_noop_when_not_possible() -> None:
+    coord = _bare_coordinator()
+    coord.config_entry = MagicMock()
+    coord.config_entry.data = {}
+    coord.hass = MagicMock()
+    with patch.object(coordinator_module.ir, "async_create_issue") as create_mock:
+        coord.raise_migration_rollback_issue()
+    create_mock.assert_not_called()
+
+
+def test_raise_migration_rollback_issue_creates_when_possible() -> None:
+    coord = _bare_coordinator()
+    coord.config_entry = MagicMock()
+    coord.config_entry.entry_id = "entry1"
+    coord.config_entry.data = {
+        MIGRATION_LEGACY_ENTRY_ID: "legacy-1",
+        MIGRATION_RECORDS: [1, 2],
+    }
+    coord.hass = MagicMock()
+    coord.hass.config_entries.async_get_entry.return_value = MagicMock()
+    with patch.object(coordinator_module.ir, "async_create_issue") as create_mock:
+        coord.raise_migration_rollback_issue()
+    create_mock.assert_called_once()
+
+
+def test_clear_stale_migration_rollback_issue_inert_for_legacy_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(coordinator_module, "DOMAIN", LEGACY_DOMAIN)
+    coord = _bare_coordinator()
+    with patch.object(coordinator_module.ir, "async_delete_issue") as delete_mock:
+        coord._clear_stale_migration_rollback_issue()
+    delete_mock.assert_not_called()
+
+
+def test_clear_stale_migration_rollback_issue_deletes_when_rollback_impossible() -> (
+    None
+):
+    coord = _bare_coordinator()
+    coord.config_entry = MagicMock()
+    coord.config_entry.entry_id = "entry1"
+    coord.config_entry.data = {}
+    coord.hass = MagicMock()
+    with patch.object(coordinator_module.ir, "async_delete_issue") as delete_mock:
+        coord._clear_stale_migration_rollback_issue()
+    delete_mock.assert_called_once()
+
+
+async def test_async_clear_orphaned_statistics_noop_when_empty() -> None:
+    coord = _bare_coordinator()
+    coord.orphaned_statistics = []
+    coord.hass = MagicMock()
+    await coord.async_clear_orphaned_statistics()
+    coord.hass.assert_not_called() if callable(coord.hass) else None
+
+
+async def test_async_clear_orphaned_statistics_clears_and_refreshes() -> None:
+    coord = _bare_coordinator()
+    coord.orphaned_statistics = ["sensor.truenas_x"]
+    coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
+    coord.config_entry.entry_id = "entry1"
+    coord.ds = {"foo": "bar"}
+    coord.async_set_updated_data = MagicMock()
+    instance_mock = MagicMock()
+    instance_mock.async_clear_statistics = MagicMock()
+    with (
+        patch.object(coordinator_module, "get_instance", return_value=instance_mock),
+        patch.object(coordinator_module.ir, "async_delete_issue") as delete_mock,
+    ):
+        await coord.async_clear_orphaned_statistics()
+
+    instance_mock.async_clear_statistics.assert_called_once_with(["sensor.truenas_x"])
+    assert coord.orphaned_statistics == []
+    delete_mock.assert_called_once()
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+# ---------------------------
+#   get_systeminfo / _handle_update_job / _query_interfaces
+# ---------------------------
+async def test_get_systeminfo_parses_valid_response_and_runs_pipeline() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {}}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(
+        return_value={
+            "version": "TrueNAS-SCALE-25.04.1",
+            "hostname": "nas1",
+            "uptime_seconds": 100,
+            "physmem": 1000,
+        }
+    )
+    coord._handle_update_job = AsyncMock()
+
+    await coord.get_systeminfo()
+
+    assert coord.ds["system_info"]["hostname"] == "nas1"
+    assert coord.ds["system_info"]["update_version"] == "TrueNAS-SCALE-25.04.1"
+    assert coord._version_major == 25
+    coord._handle_update_job.assert_awaited_once()
+
+
+async def test_get_systeminfo_skips_parse_on_invalid_response() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {}}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=None)
+    coord._handle_update_job = AsyncMock()
+
+    await coord.get_systeminfo()
+
+    coord._handle_update_job.assert_awaited_once()
+
+
+async def test_get_systeminfo_returns_early_when_disconnected_after_parse() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {}}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.query = AsyncMock(return_value={"version": "25.04.1"})
+    coord._handle_update_job = AsyncMock()
+
+    await coord.get_systeminfo()
+
+    coord._handle_update_job.assert_not_awaited()
+
+
+async def test_handle_update_job_noop_without_jobid() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {"update_jobid": 0}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord._handle_update_job()
+    coord.api.query.assert_not_awaited()
+
+
+async def test_handle_update_job_keeps_progress_while_running() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {"update_jobid": 5, "update_available": True}}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(
+        return_value={"progress": {"percent": 42}, "state": "RUNNING"}
+    )
+    await coord._handle_update_job()
+    assert coord.ds["system_info"]["update_progress"] == 42
+    assert coord.ds["system_info"]["update_state"] == "RUNNING"
+
+
+async def test_handle_update_job_resets_when_finished() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "system_info": {
+            "update_jobid": 5,
+            "update_available": False,
+            "version": "25.04.1",
+        }
+    }
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(
+        return_value={"progress": {"percent": 100}, "state": "SUCCESS"}
+    )
+    await coord._handle_update_job()
+    assert coord.ds["system_info"]["update_progress"] == 0
+    assert coord.ds["system_info"]["update_jobid"] == 0
+    assert coord.ds["system_info"]["update_state"] == "unknown"
+
+
+async def test_handle_update_job_returns_early_when_disconnected() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {"update_jobid": 5}}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.query = AsyncMock(return_value=None)
+    await coord._handle_update_job()
+    assert coord.ds["system_info"]["update_jobid"] == 5
+
+
+async def test_query_interfaces_derives_link_up() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"id": "eth0", "name": "eth0", "state": {"link_state": "LINK_STATE_UP"}},
+            {"id": "eth1", "name": "eth1", "state": {"link_state": "LINK_STATE_DOWN"}},
+        ]
+    )
+    await coord._query_interfaces()
+    assert coord.ds["interface"]["eth0"]["link_up"] is True
+    assert coord.ds["interface"]["eth1"]["link_up"] is False
+
+
+# ---------------------------
+#   get_systemstats family
+# ---------------------------
+def test_select_stat_graph_names_includes_interface_when_present() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {"eth0": {}}}
+    coord._is_virtual = False
+    coord._systemstats_errored = {}
+    names = coord._select_stat_graph_names()
+    assert "interface" in names
+    assert "cputemp" in names
+
+
+def test_select_stat_graph_names_removes_cputemp_for_virtual() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {}}
+    coord._is_virtual = True
+    coord._systemstats_errored = {}
+    names = coord._select_stat_graph_names()
+    assert "cputemp" not in names
+    assert "interface" not in names
+
+
+def test_select_stat_graph_names_filters_cooldown_graphs() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {}}
+    coord._is_virtual = False
+    coord._systemstats_errored = {"cpu": datetime.now(UTC)}
+    coord._systemstats_error_cooldown = timedelta(minutes=10)
+    names = coord._select_stat_graph_names()
+    assert "cpu" not in names
+
+
+async def test_fetch_stat_graphs_collects_and_records_failures() -> None:
+    coord = _bare_coordinator()
+    coord.host = "truenas.local"
+    coord._systemstats_errored = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(side_effect=[[{"name": "load"}], None])
+    result = await coord._fetch_stat_graphs(["load", "cpu"], {"start": 0, "end": 1})
+    assert result == [{"name": "load"}]
+    assert "cpu" in coord._systemstats_errored
+
+
+def test_record_failed_graphs_logs_only_new_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coord = _bare_coordinator()
+    coord.host = "truenas.local"
+    coord._systemstats_errored = {"cpu": datetime.now(UTC)}
+    with caplog.at_level("WARNING"):
+        coord._record_failed_graphs(["cpu", "memory"])
+    assert "memory" in caplog.text
+    assert coord._systemstats_errored.keys() == {"cpu", "memory"}
+
+
+def test_record_failed_graphs_noop_for_empty_list() -> None:
+    coord = _bare_coordinator()
+    coord._systemstats_errored = {}
+    coord._record_failed_graphs([])
+    assert coord._systemstats_errored == {}
+
+
+def test_process_system_stat_dispatches_by_name() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {}}
+    # Missing "aggregations"/"legend" fails the isinstance guard in
+    # _systemstats_process, so it falls back to _store_stat_defaults, which
+    # (for t != "cpu") stores the bare arr name, not a "load_"-prefixed one.
+    coord._process_system_stat({"name": "load"})
+    assert coord.ds["system_info"]["shortterm"] == 0.0
+
+
+def test_process_system_stat_ignores_missing_name() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._process_system_stat({})  # must not raise
+
+
+def test_process_cputemp_stores_max_mean() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._process_cputemp({"aggregations": {"mean": {"core0": 40.0, "core1": 45.0}}})
+    assert coord.ds["system_info"]["cpu_temperature"] == 45.0
+
+
+def test_process_cputemp_none_when_no_valid_means() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._process_cputemp({"aggregations": {"mean": {}}})
+    assert coord.ds["system_info"]["cpu_temperature"] is None
+
+
+def test_process_memory_stat_computes_usage_percent() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {"physmem": 1000}}
+    coord._process_memory_stat(
+        {"legend": ["available"], "aggregations": {"mean": {"available": 250.0}}}
+    )
+    assert coord.ds["system_info"]["memory-total_value"] == 1000
+    assert coord.ds["system_info"]["memory-free_value"] == 250
+    assert coord.ds["system_info"]["memory-usage_percent"] == 75
+
+
+def test_handle_unknown_stat_logs_once_and_detects_near_miss(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coord = _bare_coordinator()
+    coord.host = "truenas.local"
+    coord._unknown_system_stat_names = set()
+    with caplog.at_level("DEBUG"):
+        coord._handle_unknown_stat("cpu_usage")
+        coord._handle_unknown_stat("cpu_usage")
+    assert caplog.text.count("unknown system stat graph name") == 1
+
+
+def test_process_system_stat_interface_updates_rx_tx() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {"eth0": {}}}
+    item = {
+        "legend": ["received", "sent"],
+        "aggregations": {"mean": {"received": 100.0, "sent": 50.0}},
+    }
+    coord._process_system_stat_interface(item, "eth0")
+    assert coord.ds["interface"]["eth0"]["rx"] > 0
+    assert coord.ds["interface"]["eth0"]["tx"] > 0
+
+
+def test_process_system_stat_interface_zeroes_on_invalid_legend() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {"eth0": {}}}
+    coord._process_system_stat_interface({"legend": "not-a-list"}, "eth0")
+    assert coord.ds["interface"]["eth0"]["rx"] == 0.0
+    assert coord.ds["interface"]["eth0"]["tx"] == 0.0
+
+
+async def test_get_systemstats_returns_early_without_graph_names() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {}}
+    coord._is_virtual = True
+    coord._systemstats_errored = {
+        name: datetime.now(UTC) for name in ("load", "cpu", "arcsize", "memory")
+    }
+    coord._systemstats_error_cooldown = timedelta(minutes=10)
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_systemstats()
+    coord.api.query.assert_not_awaited()
+
+
+async def test_get_systemstats_processes_returned_graphs() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"interface": {}, "system_info": {}}
+    coord._is_virtual = True
+    coord._systemstats_errored = {}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"name": "load"}])
+    await coord.get_systemstats()
+    assert coord.ds["system_info"]["shortterm"] == 0.0
+
+
+# ---------------------------
+#   get_service
+# ---------------------------
+async def test_get_service_derives_running_and_display_name() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"service": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "service": "cifs",
+                "name": "",
+                "enable": True,
+                "state": "RUNNING",
+            },
+            {
+                "id": 2,
+                "service": "ssh",
+                "name": "Custom SSH",
+                "enable": False,
+                "state": "STOPPED",
+            },
+        ]
+    )
+    await coord.get_service()
+    assert coord.ds["service"][1]["running"] is True
+    assert coord.ds["service"][1]["display_name"] == "SMB"
+    assert coord.ds["service"][2]["display_name"] == "Custom SSH"
+
+
+# ---------------------------
+#   get_pool / _add_boot_pool
+# ---------------------------
+async def test_get_pool_uses_dataset_mountpoint_match() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "pool": {},
+        "dataset": {"tank": {"mountpoint": "/mnt/tank", "available": 40, "used": 60}},
+    }
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "guid": "g1",
+                    "name": "tank",
+                    "path": "/mnt/tank",
+                    "fragmentation": "12",
+                    "topology": {},
+                }
+            ],
+            None,  # boot.get_state
+        ]
+    )
+    await coord.get_pool()
+    assert coord.ds["pool"]["g1"]["available"] == 40
+    assert coord.ds["pool"]["g1"]["total"] == 100
+    assert coord.ds["pool"]["g1"]["fragmentation"] == 12
+
+
+async def test_get_pool_returns_early_when_disconnected() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"pool": {}, "dataset": {}}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.query = AsyncMock(return_value=[])
+    await coord.get_pool()
+    assert coord.ds["pool"] == {}
+
+
+async def test_add_boot_pool_adds_when_present() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"pool": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value={"name": "boot-pool", "topology": {}, "fragmentation": "0"}
+    )
+    await coord._add_boot_pool()
+    assert "boot-pool" in coord.ds["pool"]
+
+
+async def test_add_boot_pool_noop_when_absent() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"pool": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    await coord._add_boot_pool()
+    assert coord.ds["pool"] == {}
+
+
+# ---------------------------
+#   get_dataset
+# ---------------------------
+async def test_get_dataset_empty_when_group_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"dataset": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_dataset()
+    assert coord.ds["dataset"] == {}
+    coord.api.query.assert_not_awaited()
+
+
+async def test_get_dataset_parses_when_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"dataset": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_DATASETS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"id": "tank", "type": "FILESYSTEM", "name": "tank"}]
+    )
+    await coord.get_dataset()
+    assert "tank" in coord.ds["dataset"]
+
+
+# ---------------------------
+#   get_disk and disk-temperature helpers
+# ---------------------------
+async def test_get_disk_populates_and_updates_temperatures() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"disk": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"identifier": "disk1", "devname": "sda", "name": "sda", "type": "HDD"}
+        ]
+    )
+    coord._update_disk_temperatures = AsyncMock()
+    await coord.get_disk()
+    assert "disk1" in coord.ds["disk"]
+    coord._update_disk_temperatures.assert_awaited_once()
+
+
+def test_build_disk_name_map_collects_all_keys() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "disk": {"d1": {"identifier": "disk1", "devname": "sda", "name": "sda"}}
+    }
+    disk_map = coord._build_disk_name_map()
+    assert disk_map == {"disk1": "d1", "sda": "d1"}
+
+
+def test_build_disk_name_map_logs_collision(caplog: pytest.LogCaptureFixture) -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "disk": {
+            "d1": {"identifier": "shared", "devname": "sda", "name": "sda"},
+            "d2": {"identifier": "shared", "devname": "sdb", "name": "sdb"},
+        }
+    }
+    with caplog.at_level("DEBUG"):
+        coord._build_disk_name_map()
+    assert "collision" in caplog.text
+
+
+def test_apply_netdata_temps_matches_by_disk_map() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"disk": {"d1": {"temperature": None}}}
+    coord._apply_netdata_temps({"sda": 42.345}, {"sda": "d1"})
+    # 42.345 isn't exactly representable as a float, so round() gives 42.34.
+    assert coord.ds["disk"]["d1"]["temperature"] == round(42.345, 2)
+
+
+async def test_fallback_disk_temperatures_maps_matched_disk() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "disk": {"d1": {"name": "sda", "devname": "sda", "identifier": "disk1"}}
+    }
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value={"sda": 39.0})
+    await coord._fallback_disk_temperatures(["d1"], has_netdata=False)
+    assert coord.ds["disk"]["d1"]["temperature"] == 39.0
+
+
+async def test_fallback_disk_temperatures_warns_on_invalid_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "disk": {"d1": {"name": "sda", "devname": "sda", "identifier": "disk1"}}
+    }
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    with caplog.at_level("WARNING"):
+        await coord._fallback_disk_temperatures(["d1"], has_netdata=False)
+    assert "Failed to update disk temperatures" in caplog.text
+
+
+def test_map_single_disk_api_temp_sets_matched_value() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "disk": {"d1": {"name": "sda", "devname": "sda", "identifier": "disk1"}}
+    }
+    coord._map_single_disk_api_temp("d1", {"sda": 41.5})
+    assert coord.ds["disk"]["d1"]["temperature"] == 41.5
+
+
+def test_map_single_disk_api_temp_logs_when_no_match(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "disk": {"d1": {"name": "sda", "devname": "sda", "identifier": "disk1"}}
+    }
+    with caplog.at_level("DEBUG"):
+        coord._map_single_disk_api_temp("d1", {"other": 41.5})
+    assert "No matching temperature entry" in caplog.text
+
+
+def test_map_single_disk_api_temp_logs_invalid_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "disk": {"d1": {"name": "sda", "devname": "sda", "identifier": "disk1"}}
+    }
+    with caplog.at_level("DEBUG"):
+        coord._map_single_disk_api_temp("d1", {"sda": "not-a-number"})
+    assert "Invalid temperature value" in caplog.text
+
+
+async def test_disk_temps_from_netdata_returns_none_without_graph() -> None:
+    coord = _bare_coordinator()
+    coord._disk_temp_graph = None
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    coord._discover_disk_temp_graph = AsyncMock(return_value="")
+    assert await coord._disk_temps_from_netdata() is None
+
+
+async def test_disk_temps_from_netdata_collects_temps() -> None:
+    coord = _bare_coordinator()
+    coord._disk_temp_graph = "disk_temp"
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"identifier": "disk1", "aggregations": {"mean": {"a": 35.0}}}]
+    )
+    result = await coord._disk_temps_from_netdata()
+    assert result == {"disk1": 35.0}
+
+
+async def test_discover_disk_temp_graph_finds_matching_name() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"name": "disk_temp_sda", "title": "Disk Temperature"}]
+    )
+    result = await coord._discover_disk_temp_graph()
+    assert result == "disk_temp_sda"
+
+
+async def test_discover_disk_temp_graph_returns_empty_when_not_found() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    assert await coord._discover_disk_temp_graph() == ""
+
+
+def test_collect_disk_temp_uses_median_of_valid_means() -> None:
+    coord = _bare_coordinator()
+    temps: dict[str, float] = {}
+    # 200.0 is outside the 0-100 sane bound and is discarded, leaving [30.0, 32.0]
+    # whose median (even count) is their average, 31.0.
+    coord._collect_disk_temp(
+        {
+            "identifier": "disk1",
+            "aggregations": {"mean": {"a": 30.0, "b": 200.0, "c": 32.0}},
+        },
+        temps,
+    )
+    assert temps == {"disk1": 31.0}
+
+
+def test_collect_disk_temp_ignores_entry_without_identifier() -> None:
+    coord = _bare_coordinator()
+    temps: dict[str, float] = {}
+    coord._collect_disk_temp({"aggregations": {"mean": {"a": 30.0}}}, temps)
+    assert temps == {}
+
+
+# ---------------------------
+#   get_vm
+# ---------------------------
+async def test_get_vm_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"vm": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_vm()
+    assert coord.ds["vm"] == {}
+
+
+async def test_get_vm_computes_memory_and_running() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"vm": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_VMS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "vm1",
+                "vcpus": 2,
+                "memory": 2048,
+                "status": {"state": "RUNNING"},
+            }
+        ]
+    )
+    await coord.get_vm()
+    assert coord.ds["vm"][1]["memory"] == 2
+    assert coord.ds["vm"][1]["running"] is True
+
+
+async def test_get_vm_handles_null_memory() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"vm": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_VMS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "vm1",
+                "vcpus": 2,
+                "memory": None,
+                "status": {"state": "STOPPED"},
+            }
+        ]
+    )
+    await coord.get_vm()
+    assert coord.ds["vm"][1]["memory"] == 0
+
+
+# ---------------------------
+#   get_container
+# ---------------------------
+async def test_get_container_filters_container_type_and_computes_fields() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": "c1",
+                "name": "app1",
+                "type": "CONTAINER",
+                "cpu": "1",
+                "memory": 1048576,
+                "status": "RUNNING",
+                "aliases": [{"type": "INET", "address": "10.0.0.5"}],
+            },
+            {"id": "v1", "name": "legacyvm", "type": "VM"},
+        ]
+    )
+    await coord.get_container()
+    assert "c1" in coord.ds["container"]
+    assert "v1" not in coord.ds["container"]
+    assert coord.ds["container"]["c1"]["cpu"] == 1
+    assert coord.ds["container"]["c1"]["memory"] == 1
+    assert coord.ds["container"]["c1"]["running"] is True
+    assert coord.ds["container"]["c1"]["ip_address"] == "10.0.0.5"
+
+
+async def test_get_container_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_container()
+    assert coord.ds["container"] == {}
+
+
+async def test_get_container_logs_when_query_returns_non_list(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    with caplog.at_level("DEBUG"):
+        await coord.get_container()
+    assert coord.ds["container"] == {}
+
+
+# ---------------------------
+#   get_directoryservices
+# ---------------------------
+async def test_get_directoryservices_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"directoryservices": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_directoryservices()
+    assert coord.ds["directoryservices"] == {}
+
+
+async def test_get_directoryservices_empty_when_not_configured() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"directoryservices": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {
+        CONF_MONITORED_GROUPS: [MONITOR_GROUP_DIRECTORY_SERVICES]
+    }
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value={"service_type": None})
+    await coord.get_directoryservices()
+    assert coord.ds["directoryservices"] == {}
+
+
+async def test_get_directoryservices_populates_when_enabled() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"directoryservices": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {
+        CONF_MONITORED_GROUPS: [MONITOR_GROUP_DIRECTORY_SERVICES]
+    }
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        side_effect=[
+            {
+                "id": 1,
+                "service_type": "ACTIVEDIRECTORY",
+                "enable": True,
+                "enable_account_cache": True,
+                "enable_dns_updates": True,
+                "kerberos_realm": "REALM",
+                "configuration": {"domain": "example.com", "site": "default"},
+            },
+            {"status": "HEALTHY", "status_msg": None},
+        ]
+    )
+    await coord.get_directoryservices()
+    assert coord.ds["directoryservices"][1]["healthy"] is True
+
+
+# ---------------------------
+#   get_certificates
+# ---------------------------
+async def test_get_certificates_computes_days_until_expiry() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    future = datetime.now(UTC) + timedelta(days=10)
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "cert1",
+                "cert_type": "CERTIFICATE",
+                "until": future.strftime("%c"),
+            }
+        ]
+    )
+    await coord.get_certificates()
+    assert coord.ds["certificate"][1]["days_until_expiry"] in (9, 10)
+
+
+async def test_get_certificates_none_expiry_when_until_missing() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": 1, "name": "cert1"}])
+    await coord.get_certificates()
+    assert coord.ds["certificate"][1]["days_until_expiry"] is None
+
+
+# ---------------------------
+#   get_arc
+# ---------------------------
+async def test_get_arc_stores_none_for_missing_graph() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    await coord.get_arc()
+    assert coord.ds["arc"]["data_hit_percent"] is None
+
+
+async def test_get_arc_computes_value_for_present_graph() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"aggregations": {"mean": {"a": 90.0}}}])
+    await coord.get_arc()
+    assert coord.ds["arc"]["data_hit_percent"] == 90.0
+
+
+# ---------------------------
+#   get_ups / _discover_ups_graphs
+# ---------------------------
+async def test_get_ups_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"ups": {"stale": 1}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord._ups_graphs = None
+    await coord.get_ups()
+    assert coord.ds["ups"] == {}
+
+
+async def test_get_ups_returns_when_discovery_fails() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"ups": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_UPS]}
+    coord._ups_graphs = None
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    await coord.get_ups()
+    assert coord._ups_graphs is None
+
+
+async def test_get_ups_returns_when_no_graphs_discovered() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"ups": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_UPS]}
+    coord._ups_graphs = set()
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_ups()
+    coord.api.query.assert_not_awaited()
+
+
+async def test_get_ups_populates_known_graphs() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"ups": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_UPS]}
+    coord._ups_graphs = {"upscharge"}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"aggregations": {"mean": {"a": 80.0}}}])
+    await coord.get_ups()
+    assert coord.ds["ups"]["battery_charge"] == 80.0
+
+
+async def test_discover_ups_graphs_returns_none_for_invalid_response() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=None)
+    assert await coord._discover_ups_graphs() is None
+
+
+async def test_discover_ups_graphs_filters_known_names() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"name": "upscharge"}, {"name": "unrelated_graph"}]
+    )
+    result = await coord._discover_ups_graphs()
+    assert result == {"upscharge"}
+
+
+# ---------------------------
+#   get_cloudsync / get_replication / get_rsync / get_snapshottask / get_scrub
+# ---------------------------
+async def test_get_cloudsync_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cloudsync": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_cloudsync()
+    assert coord.ds["cloudsync"] == {}
+
+
+async def test_get_cloudsync_parses_when_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cloudsync": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CLOUDSYNC]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": "cs1", "description": "backup"}])
+    await coord.get_cloudsync()
+    assert "cs1" in coord.ds["cloudsync"]
+
+
+async def test_get_replication_falls_back_to_job_state() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"replication": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_REPLICATION]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"id": 1, "name": "repl1", "job": {"state": "RUNNING"}}]
+    )
+    await coord.get_replication()
+    assert coord.ds["replication"][1]["state"] == "RUNNING"
+    assert "job_state" not in coord.ds["replication"][1]
+
+
+async def test_get_replication_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"replication": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_replication()
+    assert coord.ds["replication"] == {}
+
+
+async def test_get_rsync_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"rsynctask": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_rsync()
+    assert coord.ds["rsynctask"] == {}
+
+
+async def test_get_rsync_parses_when_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"rsynctask": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_RSYNC]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": 1, "path": "/mnt/tank"}])
+    await coord.get_rsync()
+    assert 1 in coord.ds["rsynctask"]
+
+
+async def test_get_snapshottask_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"snapshottask": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_snapshottask()
+    assert coord.ds["snapshottask"] == {}
+
+
+async def test_get_snapshottask_parses_when_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"snapshottask": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_SNAPSHOTS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": 1, "dataset": "tank/data"}])
+    await coord.get_snapshottask()
+    assert 1 in coord.ds["snapshottask"]
+
+
+async def test_get_scrub_parses_response() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"scrub": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": 1, "pool_name": "tank"}])
+    await coord.get_scrub()
+    assert 1 in coord.ds["scrub"]
+
+
+# ---------------------------
+#   get_app / _clear_finished_app_updates
+# ---------------------------
+async def test_get_app_catalog_update_available() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": "app1",
+                "name": "app1",
+                "state": "RUNNING",
+                "upgrade_available": True,
+                "custom_app": False,
+                "image_updates_available": False,
+            }
+        ]
+    )
+    coord._clear_finished_app_updates = AsyncMock()
+    await coord.get_app()
+    assert coord.ds["app"]["app1"]["running"] is True
+    assert coord.ds["app"]["app1"]["update_available"] is True
+
+
+async def test_get_app_custom_app_falls_back_to_image_updates() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": "app1",
+                "name": "app1",
+                "state": "STOPPED",
+                "upgrade_available": False,
+                "custom_app": True,
+                "image_updates_available": True,
+            }
+        ]
+    )
+    coord._clear_finished_app_updates = AsyncMock()
+    await coord.get_app()
+    assert coord.ds["app"]["app1"]["update_available"] is True
+
+
+async def test_get_app_no_update_for_noncustom_without_upgrade() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": "app1",
+                "name": "app1",
+                "state": "STOPPED",
+                "upgrade_available": False,
+                "custom_app": False,
+                "image_updates_available": True,
+            }
+        ]
+    )
+    coord._clear_finished_app_updates = AsyncMock()
+    await coord.get_app()
+    assert coord.ds["app"]["app1"]["update_available"] is False
+
+
+async def test_clear_finished_app_updates_resets_when_not_running() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"app1": {"update_jobid": 5}}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"state": "SUCCESS"}])
+    await coord._clear_finished_app_updates()
+    assert coord.ds["app"]["app1"]["update_jobid"] == 0
+
+
+async def test_clear_finished_app_updates_keeps_running_job() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"app1": {"update_jobid": 5}}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"state": "RUNNING"}])
+    await coord._clear_finished_app_updates()
+    assert coord.ds["app"]["app1"]["update_jobid"] == 5
+
+
+async def test_clear_finished_app_updates_skips_without_jobid() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"app1": {"update_jobid": 0}}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord._clear_finished_app_updates()
+    coord.api.query.assert_not_awaited()
+
+
+# ---------------------------
+#   app.stats subscription helpers
+# ---------------------------
+def test_get_app_identifier_prefers_name() -> None:
+    coord = _bare_coordinator()
+    assert coord._get_app_identifier({"name": "app1", "app_name": "legacy"}) == "app1"
+
+
+def test_get_app_identifier_falls_back_to_app_name() -> None:
+    coord = _bare_coordinator()
+    assert coord._get_app_identifier({"app_name": "legacy"}) == "legacy"
+
+
+def test_get_app_identifier_returns_none_when_missing() -> None:
+    coord = _bare_coordinator()
+    assert coord._get_app_identifier({}) is None
+
+
+def test_resolve_app_stats_event_name_uses_poll_interval() -> None:
+    coord = _bare_coordinator()
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_POLL_INTERVAL: 30}
+    assert coord._resolve_app_stats_event_name() == 'app.stats:{"interval": 30}'
+
+
+def test_resolve_app_stats_event_name_falls_back_on_invalid_value() -> None:
+    coord = _bare_coordinator()
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_POLL_INTERVAL: "bad"}
+    assert (
+        coord._resolve_app_stats_event_name()
+        == f'app.stats:{{"interval": {DEFAULT_POLL_INTERVAL}}}'
+    )
+
+
+async def test_stop_app_stats_if_active_stops_when_subscribed() -> None:
+    coord = _bare_coordinator()
+    coord._app_stats_sub_id = "sub-1"
+    coord.stop_app_stats = AsyncMock()
+    await coord._stop_app_stats_if_active()
+    coord.stop_app_stats.assert_awaited_once_with(force=True)
+
+
+async def test_stop_app_stats_if_active_noop_when_not_subscribed() -> None:
+    coord = _bare_coordinator()
+    coord._app_stats_sub_id = None
+    coord.stop_app_stats = AsyncMock()
+    await coord._stop_app_stats_if_active()
+    coord.stop_app_stats.assert_not_awaited()
+
+
+async def test_maybe_teardown_changed_app_stats_subscription_stops_on_change() -> None:
+    coord = _bare_coordinator()
+    coord._app_stats_event_name = "old"
+    coord.stop_app_stats = AsyncMock()
+    await coord._maybe_teardown_changed_app_stats_subscription("new")
+    coord.stop_app_stats.assert_awaited_once_with(force=True)
+
+
+async def test_maybe_clear_inactive_app_stats_subscription_clears_when_inactive() -> (
+    None
+):
+    coord = _bare_coordinator()
+    coord._app_stats_sub_id = "sub-1"
+    coord.api = MagicMock()
+    coord.api.is_subscribed = AsyncMock(return_value=False)
+    await coord._maybe_clear_inactive_app_stats_subscription()
+    assert coord._app_stats_sub_id is None
+
+
+async def test_subscribe_to_app_stats_handles_missing_sub_id() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.subscribe_events = AsyncMock(return_value=(None, None))
+    await coord._subscribe_to_app_stats("event")
+    assert coord._app_stats_sub_id is None
+
+
+async def test_subscribe_to_app_stats_handles_exception() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.subscribe_events = AsyncMock(side_effect=Exception("boom"))
+    await coord._subscribe_to_app_stats("event")  # must not raise
+    assert coord._app_stats_sub_id is None
+
+
+async def test_stop_app_stats_unsubscribe_exception_still_clears_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock(side_effect=Exception("boom"))
+    coord._app_stats_sub_id = "sub-1"
+    with caplog.at_level("DEBUG"):
+        await coord.stop_app_stats()
+    assert coord._app_stats_sub_id is None
+
+
+async def test_stop_app_stats_not_connected_no_force_is_noop() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord._app_stats_sub_id = "sub-1"
+    coord._app_stats_event_name = "event"
+    await coord.stop_app_stats(force=False)
+    assert coord._app_stats_sub_id == "sub-1"
+
+
+def test_coerce_float_handles_invalid_values() -> None:
+    coord = _bare_coordinator()
+    assert coord._coerce_float(None) is None
+    assert coord._coerce_float("bad") is None
+    assert coord._coerce_float("3.5") == pytest.approx(3.5)
+
+
+def test_collect_current_app_names_uses_identifier() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"a": {"name": "app1"}, "b": "not-a-dict"}}
+    assert coord._collect_current_app_names() == {"app1"}
+
+
+def test_prune_stale_app_stats_removes_missing_entries() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app_stats": {"app1": {}, "stale": {}}}
+    coord._prune_stale_app_stats({"app1"})
+    assert coord.ds["app_stats"] == {"app1": {}}
+
+
+# ---------------------------
+#   get_cronjob
+# ---------------------------
+async def test_get_cronjob_empty_when_not_monitored() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cronjob": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock()
+    await coord.get_cronjob()
+    assert coord.ds["cronjob"] == {}
+
+
+async def test_get_cronjob_skips_disabled_by_default_behavior() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cronjob": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {
+        CONF_MONITORED_GROUPS: [MONITOR_GROUP_CRONJOBS],
+        CONF_BEHAVIORS: [BEHAVIOR_SKIP_DISABLED_CRONJOBS],
+    }
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"id": 1, "enabled": True, "description": "Job A"},
+            {"id": 2, "enabled": False, "description": "Job B"},
+        ]
+    )
+    await coord.get_cronjob()
+    assert 1 in coord.ds["cronjob"]
+    assert 2 not in coord.ds["cronjob"]
+    assert coord.ds["cronjob"][1]["display_name"] == "Job A"
+
+
+async def test_get_cronjob_keeps_disabled_when_behavior_off() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cronjob": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {
+        CONF_MONITORED_GROUPS: [MONITOR_GROUP_CRONJOBS],
+        CONF_BEHAVIORS: [],
+    }
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"id": 2, "enabled": False, "description": "", "command": "ls"}]
+    )
+    await coord.get_cronjob()
+    assert coord.ds["cronjob"][2]["display_name"] == "ls"
+
+
+async def test_get_cronjob_falls_back_to_legacy_option_when_behaviors_absent() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cronjob": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {
+        CONF_MONITORED_GROUPS: [MONITOR_GROUP_CRONJOBS],
+        "cronjob_skip_disabled": False,
+    }
+    coord.config_entry.data = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"id": 3, "enabled": False, "description": "", "command": ""}]
+    )
+    await coord.get_cronjob()
+    assert coord.ds["cronjob"][3]["display_name"] == "Cronjob 3"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,34 @@
+"""Unit tests for diagnostics.py."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from _fakes import make_coordinator
+
+from custom_components.truenas_ce.diagnostics import async_get_config_entry_diagnostics
+
+
+async def test_diagnostics_redacts_sensitive_fields_and_includes_data() -> None:
+    coordinator = make_coordinator(data={"system_info": {"version": "25.10.4"}})
+    coordinator.config_entry.data["password"] = "s3cr3t"
+    coordinator.config_entry.options = {"host": "truenas.local"}
+    entry = SimpleNamespace(
+        data=coordinator.config_entry.data,
+        options=coordinator.config_entry.options,
+        runtime_data=coordinator,
+    )
+
+    result = await async_get_config_entry_diagnostics(SimpleNamespace(), entry)
+
+    assert result["entry"]["data"]["password"] == "**REDACTED**"
+    assert result["entry"]["options"]["host"] == "**REDACTED**"
+    assert result["data"]["system_info"]["version"] == "25.10.4"
+
+
+async def test_diagnostics_no_coordinator_returns_empty_data() -> None:
+    entry = SimpleNamespace(data={}, options={}, runtime_data=None)
+
+    result = await async_get_config_entry_diagnostics(SimpleNamespace(), entry)
+
+    assert not result["data"]

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,478 @@
+"""Unit tests for entity.py: module helpers and TrueNASEntity base behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from _fakes import make_coordinator
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.truenas_ce.entity import (
+    TrueNASEntity,
+    TrueNASEntityDescription,
+    _append_if_new,
+    _collect_new_entities,
+    _extract_composite_ref,
+    _get_composite_container,
+    _is_uid_excluded,
+    _new_referenced_entities,
+    _skip_keyless_description,
+    format_device_identifier,
+    format_unique_id,
+)
+from custom_components.truenas_ce.sensor_types import TrueNASSensorEntityDescription
+
+_STATIC_DESC = TrueNASEntityDescription(
+    key="uptime", name="Uptime", data_path="system_info"
+)
+_REF_DESC = TrueNASSensorEntityDescription(
+    key="disk_temp",
+    name="Temperature",
+    data_path="disk",
+    data_reference="guid",
+    func="TrueNASEntity",
+)
+
+
+# ---------------------------
+#   format_unique_id / format_device_identifier
+# ---------------------------
+def test_format_unique_id_without_reference() -> None:
+    assert format_unique_id("TrueNAS", "system_uptime") == "truenas-system_uptime"
+
+
+def test_format_unique_id_with_reference_slugifies() -> None:
+    result = format_unique_id("TrueNAS", "disk_temp", "Disk One!")
+    assert result == "truenas-disk_temp-disk_one"
+
+
+def test_format_device_identifier() -> None:
+    assert format_device_identifier("TrueNAS", "nas.local") == "TrueNAS_nas.local"
+
+
+# ---------------------------
+#   _get_composite_container / _extract_composite_ref
+# ---------------------------
+def test_get_composite_container_non_dict_vals_returns_none() -> None:
+    assert _get_composite_container("not-a-dict", "networks") is None
+
+
+def test_extract_composite_ref_non_dict_item_returns_none() -> None:
+    assert (
+        _extract_composite_ref(
+            "not-a-dict", _REF_DESC, honor_exclude=True, leaf_key="x"
+        )
+        is None
+    )
+
+
+def test_extract_composite_ref_excluded_item_returns_none() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="net_rx",
+        name="RX",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_composite_references=("networks", "interface_name"),
+        data_exclude=("link_state", "DOWN"),
+    )
+    item = {"interface_name": "eth0", "link_state": "DOWN"}
+    ref = _extract_composite_ref(
+        item, desc, honor_exclude=True, leaf_key="interface_name"
+    )
+    assert ref is None
+
+
+def test_extract_composite_ref_honor_exclude_false_ignores_exclude() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="net_rx",
+        name="RX",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_composite_references=("networks", "interface_name"),
+        data_exclude=("link_state", "DOWN"),
+    )
+    item = {"interface_name": "eth0", "link_state": "DOWN"}
+    ref = _extract_composite_ref(
+        item, desc, honor_exclude=False, leaf_key="interface_name"
+    )
+    assert ref == "eth0"
+
+
+# ---------------------------
+#   _skip_keyless_description
+# ---------------------------
+def test_skip_keyless_description_true_when_attribute_missing() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k", name="N", data_path="p", data_attribute="value"
+    )
+    assert _skip_keyless_description(desc, {}) is True
+
+
+def test_skip_keyless_description_false_when_attribute_present() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k", name="N", data_path="p", data_attribute="value"
+    )
+    assert _skip_keyless_description(desc, {"value": 42}) is False
+
+
+def test_skip_keyless_description_no_attribute_at_all() -> None:
+    assert _skip_keyless_description(_STATIC_DESC, {}) is False
+
+
+# ---------------------------
+#   _is_uid_excluded
+# ---------------------------
+def test_is_uid_excluded_no_data_exclude_configured() -> None:
+    assert _is_uid_excluded(_REF_DESC, {"link_state": "DOWN"}) is False
+
+
+def test_is_uid_excluded_matches() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k", name="N", data_path="p", data_exclude=("link_state", "DOWN")
+    )
+    assert _is_uid_excluded(desc, {"link_state": "DOWN"}) is True
+
+
+def test_is_uid_excluded_non_dict_vals() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k", name="N", data_path="p", data_exclude=("link_state", "DOWN")
+    )
+    assert _is_uid_excluded(desc, "not-a-dict") is False
+
+
+# ---------------------------
+#   _new_referenced_entities / _collect_new_entities / _append_if_new
+# ---------------------------
+def _dispatcher() -> dict[str, type[TrueNASEntity]]:
+    return {"TrueNASEntity": TrueNASEntity}
+
+
+def test_new_referenced_entities_creates_one_per_uid() -> None:
+    coordinator = make_coordinator(
+        data={"disk": {"d1": {"guid": "g1"}, "d2": {"guid": "g2"}}}
+    )
+    entities = _new_referenced_entities(
+        coordinator, _REF_DESC, coordinator.data["disk"], _dispatcher(), set()
+    )
+    assert {e._uid for e in entities} == {"d1", "d2"}
+
+
+def test_new_referenced_entities_honors_exclude_behavior() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        data_exclude=("down", True),
+        func="TrueNASEntity",
+    )
+    coordinator = make_coordinator(
+        data={
+            "disk": {
+                "d1": {"guid": "g1", "down": True},
+                "d2": {"guid": "g2", "down": False},
+            }
+        }
+    )
+    coordinator.config_entry.options = {"behaviors": ["remove_inactive_nic"]}
+    entities = _new_referenced_entities(
+        coordinator, desc, coordinator.data["disk"], _dispatcher(), set()
+    )
+    assert {e._uid for e in entities} == {"d2"}
+
+
+def test_collect_new_entities_skips_missing_data_path() -> None:
+    desc = TrueNASSensorEntityDescription(key="k", name="N", data_path="nonexistent")
+    coordinator = make_coordinator(data={})
+    result = _collect_new_entities(coordinator, [desc], _dispatcher(), set())
+    assert not result
+
+
+def test_collect_new_entities_skips_app_stats_sensor_descriptions() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k", name="N", data_path="disk", func="TrueNASAppStatsSensor"
+    )
+    coordinator = make_coordinator(data={"disk": {"d1": {}}})
+    result = _collect_new_entities(coordinator, [desc], _dispatcher(), set())
+    assert not result
+
+
+def test_collect_new_entities_keyless_description() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="uptime",
+        name="Uptime",
+        data_path="system_info",
+        data_attribute="hostname",
+        func="TrueNASEntity",
+    )
+    coordinator = make_coordinator()
+    result = _collect_new_entities(coordinator, [desc], _dispatcher(), set())
+    assert len(result) == 1
+    assert result[0]._uid is None
+
+
+def test_collect_new_entities_referenced_description() -> None:
+    coordinator = make_coordinator(data={"disk": {"d1": {"guid": "g1"}}})
+    result = _collect_new_entities(coordinator, [_REF_DESC], _dispatcher(), set())
+    assert len(result) == 1
+    assert result[0]._uid == "d1"
+
+
+def test_append_if_new_skips_already_seen() -> None:
+    coordinator = make_coordinator(data={"disk": {"d1": {"guid": "g1"}}})
+    entity = _new_referenced_entities(
+        coordinator, _REF_DESC, coordinator.data["disk"], _dispatcher(), set()
+    )[0]
+
+    new_entities: list[TrueNASEntity] = []
+    seen = {entity.unique_id}
+    _append_if_new(entity, seen, new_entities)
+    assert not new_entities
+
+
+def test_append_if_new_adds_unseen() -> None:
+    coordinator = make_coordinator(data={"disk": {"d1": {"guid": "g1"}}})
+    entity = _new_referenced_entities(
+        coordinator, _REF_DESC, coordinator.data["disk"], _dispatcher(), set()
+    )[0]
+
+    new_entities: list[TrueNASEntity] = []
+    seen: set[str] = set()
+    _append_if_new(entity, seen, new_entities)
+    assert new_entities == [entity]
+    assert entity.unique_id in seen
+
+
+# ---------------------------
+#   TrueNASEntity
+# ---------------------------
+def _make_entity(
+    *,
+    uid: str | None = None,
+    data: dict | None = None,
+    description: TrueNASEntityDescription | None = None,
+    coordinator=None,
+) -> TrueNASEntity:
+    desc = description or _STATIC_DESC
+    coord = coordinator or make_coordinator(
+        data={"disk": {uid: (data or {})}} if uid else (data or {})
+    )
+    return TrueNASEntity(coord, desc, uid)
+
+
+def test_name_static_description_no_uid() -> None:
+    entity = _make_entity()
+    assert entity.name == "Uptime"
+
+
+def test_name_static_description_no_name() -> None:
+    desc = TrueNASEntityDescription(key="uptime", name=None, data_path="system_info")
+    entity = _make_entity(description=desc)
+    assert entity.name is None
+
+
+def test_name_referenced_entity_uses_data_name() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        data_name="devname",
+    )
+    entity = _make_entity(
+        uid="d1", data={"devname": "sda", "guid": "g1"}, description=desc
+    )
+    assert entity.name == "sda Temperature"
+
+
+def test_name_referenced_entity_falls_back_to_uid() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        data_name="devname",
+    )
+    entity = _make_entity(uid="d1", data={"guid": "g1"}, description=desc)
+    assert entity.name == "d1 Temperature"
+
+
+def test_name_referenced_entity_no_desc_name() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name=None,
+        data_path="disk",
+        data_reference="guid",
+        data_name="devname",
+    )
+    entity = _make_entity(
+        uid="d1", data={"devname": "sda", "guid": "g1"}, description=desc
+    )
+    assert entity.name == "sda"
+
+
+def test_unique_id_static_description() -> None:
+    entity = _make_entity()
+    assert entity.unique_id == "truenas-uptime"
+
+
+def test_unique_id_referenced_uses_data_reference_value() -> None:
+    entity = _make_entity(uid="d1", data={"guid": "g1"}, description=_REF_DESC)
+    assert entity.unique_id == "truenas-disk_temp-g1"
+
+
+def test_unique_id_referenced_falls_back_to_uid_when_reference_missing() -> None:
+    entity = _make_entity(uid="d1", data={}, description=_REF_DESC)
+    assert entity.unique_id == "truenas-disk_temp-d1"
+
+
+def test_device_info_system_group() -> None:
+    desc = TrueNASEntityDescription(
+        key="uptime", name="Uptime", data_path="system_info", ha_group="System"
+    )
+    entity = _make_entity(description=desc)
+    info = entity.device_info
+    assert info["name"] == "TrueNAS"
+    assert info["model"] == "TrueNAS Mini"
+    assert info["configuration_url"] == "http://truenas.local"
+
+
+def test_device_info_system_group_https_when_wss() -> None:
+    desc = TrueNASEntityDescription(
+        key="uptime", name="Uptime", data_path="system_info", ha_group="System"
+    )
+    coordinator = make_coordinator(api_scheme="wss")
+    entity = TrueNASEntity(coordinator, desc)
+    assert entity.device_info["configuration_url"] == "https://truenas.local"
+
+
+def test_device_info_non_system_group() -> None:
+    desc = TrueNASEntityDescription(
+        key="disk_temp", name="Temperature", data_path="disk", ha_group="Disks"
+    )
+    entity = _make_entity(description=desc)
+    info = entity.device_info
+    assert info["default_name"] == "TrueNAS Disks"
+    assert info["via_device"] == ("truenas_ce", "TrueNAS_truenas.local")
+
+
+def test_device_info_data_group_resolves_group_from_data() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        ha_group="data__pool",
+    )
+    entity = _make_entity(
+        uid="d1", data={"guid": "g1", "pool": "tank"}, description=desc
+    )
+    info = entity.device_info
+    assert info["default_name"] == "TrueNAS tank"
+
+
+def test_device_info_explicit_connection_and_value() -> None:
+    desc = TrueNASEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        ha_group="Disks",
+        ha_connection="custom_domain",
+        ha_connection_value="fixed-value",
+    )
+    entity = _make_entity(description=desc)
+    info = entity.device_info
+    assert info["connections"] == {("custom_domain", "fixed-value")}
+
+
+def test_device_info_connection_value_from_data() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        ha_group="Disks",
+        ha_connection_value="data__pool",
+    )
+    entity = _make_entity(
+        uid="d1", data={"guid": "g1", "pool": "tank"}, description=desc
+    )
+    info = entity.device_info
+    assert info["connections"] == {("truenas_ce", "TrueNAS_tank")}
+
+
+def test_extra_state_attributes_includes_attribution_and_listed_fields() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        data_attributes_list=("model",),
+    )
+    entity = _make_entity(
+        uid="d1", data={"guid": "g1", "model": "WD Red"}, description=desc
+    )
+    attrs = entity.extra_state_attributes
+    assert attrs["Model"] == "WD Red"
+    assert "attribution" in attrs
+
+
+def test_raise_unsupported_raises_service_validation_error() -> None:
+    entity = _make_entity()
+    with pytest.raises(ServiceValidationError, match="not supported"):
+        entity._raise_unsupported("start")
+
+
+def test_raise_if_api_error_no_error_is_noop() -> None:
+    entity = _make_entity()
+    entity._raise_if_api_error("start")
+
+
+def test_raise_if_api_error_raises_when_error_set() -> None:
+    coordinator = make_coordinator(api_error="boom")
+    entity = _make_entity(coordinator=coordinator)
+    with pytest.raises(HomeAssistantError, match="boom"):
+        entity._raise_if_api_error("start")
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["start", "stop", "restart", "reload", "snapshot", "refresh"],
+)
+async def test_default_action_stubs_raise_unsupported(method_name: str) -> None:
+    entity = _make_entity()
+    method = getattr(entity, method_name)
+    with pytest.raises(ServiceValidationError):
+        await method()
+
+
+async def test_default_unlock_stub_raises_unsupported() -> None:
+    entity = _make_entity()
+    with pytest.raises(ServiceValidationError):
+        await entity.unlock()
+
+
+async def test_default_lock_stub_raises_unsupported() -> None:
+    entity = _make_entity()
+    with pytest.raises(ServiceValidationError):
+        await entity.lock()
+
+
+async def test_default_passphrase_set_stub_raises_unsupported() -> None:
+    entity = _make_entity()
+    with pytest.raises(ServiceValidationError):
+        await entity.passphrase_set("secret")
+
+
+def test_handle_coordinator_update_refreshes_data_and_calls_super() -> None:
+    coordinator = make_coordinator(data={"disk": {"d1": {"guid": "g1"}}})
+    entity = TrueNASEntity(coordinator, _REF_DESC, "d1")
+    coordinator.data["disk"]["d1"]["guid"] = "g2"
+
+    with patch.object(CoordinatorEntity, "_handle_coordinator_update") as super_update:
+        entity._handle_coordinator_update()
+
+    assert entity._data == {"guid": "g2"}
+    super_update.assert_called_once()

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -116,6 +116,7 @@ def _fake_api() -> SimpleNamespace:
     return SimpleNamespace(
         connected=MagicMock(return_value=True),
         connect=AsyncMock(return_value=True),
+        close=AsyncMock(),
         query=AsyncMock(side_effect=_query),
         error="",
         scheme="ws",

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -1,0 +1,153 @@
+"""Real-``hass`` coverage for entity.py's platform-setup wiring.
+
+``_cleanup_orphaned_entities`` and ``async_add_entities`` both need a real
+entity/device registry (``er.async_get``/``dr.async_get``) and, for
+``async_add_entities``, the ``entity_platform`` context var that only exists
+while a platform's own ``async_setup_entry`` is actually running -- none of
+this can be faked with a bare-instance/``SimpleNamespace`` coordinator, unlike
+most of this test suite. Like ``test_config_flow_flows.py``/``test_services.py``,
+this therefore needs ``pytest-homeassistant-custom-component`` and only runs in
+CI (see ``conftest.py``'s ``collect_ignore_glob`` for why it can't run on this
+repo's Windows dev machine).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_NAME, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+import custom_components.truenas_ce as init_module
+from custom_components.truenas_ce.const import CONF_MONITORED_GROUPS, DOMAIN
+from custom_components.truenas_ce.entity import _cleanup_orphaned_entities
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+# ---------------------------
+#   _cleanup_orphaned_entities
+# ---------------------------
+async def test_cleanup_orphaned_entities_removes_stale_entity_and_empty_device(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_NAME: "TrueNAS"})
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(last_update_success=True)
+
+    dev_reg = dr.async_get(hass)
+    live_device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "live-device")}
+    )
+    empty_device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "empty-device")}
+    )
+
+    ent_reg = er.async_get(hass)
+    active_entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "truenas-active-id",
+        config_entry=entry,
+        device_id=live_device.id,
+    )
+    orphan_entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "truenas-live-base-orphan",
+        config_entry=entry,
+        device_id=empty_device.id,
+    )
+    unrelated_entity = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, "truenas-unrelated-id", config_entry=entry
+    )
+
+    with patch.object(
+        init_module,
+        "_collect_active_unique_ids",
+        return_value=({"truenas-active-id"}, {"truenas-live-base"}),
+    ):
+        _cleanup_orphaned_entities(hass, entry, coordinator)
+
+    assert ent_reg.async_get(active_entity.entity_id) is not None
+    assert ent_reg.async_get(orphan_entity.entity_id) is None
+    assert ent_reg.async_get(unrelated_entity.entity_id) is not None
+    assert dev_reg.async_get(live_device.id) is not None
+    assert dev_reg.async_get(empty_device.id) is None
+
+
+async def test_cleanup_orphaned_entities_noop_after_failed_refresh(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_NAME: "TrueNAS"})
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(last_update_success=False)
+
+    ent_reg = er.async_get(hass)
+    stale_entity = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, "truenas-live-base-orphan", config_entry=entry
+    )
+
+    with patch.object(init_module, "_collect_active_unique_ids") as collect_mock:
+        _cleanup_orphaned_entities(hass, entry, coordinator)
+    collect_mock.assert_not_called()
+    assert ent_reg.async_get(stale_entity.entity_id) is not None
+
+
+# ---------------------------
+#   async_add_entities (via a real platform-setup pass)
+# ---------------------------
+def _fake_api() -> SimpleNamespace:
+    """A fake TrueNASAPI returning an empty (but present) system.info payload.
+
+    Every other query returns None, matching the coordinator's normal handling
+    of a not-yet-responding TrueNAS -- this keeps the platform-forward pass
+    real while avoiding any actual network I/O.
+    """
+
+    async def _query(method: str, *args: object, **kwargs: object) -> dict | None:
+        return {} if method == "system.info" else None
+
+    return SimpleNamespace(
+        connected=MagicMock(return_value=True),
+        connect=AsyncMock(return_value=True),
+        query=AsyncMock(side_effect=_query),
+        error="",
+        scheme="ws",
+    )
+
+
+async def test_async_setup_entry_creates_entities_via_real_platform_setup(
+    hass: HomeAssistant,
+) -> None:
+    """A real ``async_setup_entry`` run forwards to every platform, so this
+    exercises ``entity.async_add_entities``'s live wiring (service
+    registration, dispatcher-connect, coordinator-identity check, entity
+    creation) exactly as production does -- not reachable via a bare-instance
+    coordinator since it needs the real ``entity_platform`` context var.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "TrueNAS",
+            CONF_HOST: "truenas.local",
+            CONF_API_KEY: "test-key",
+            CONF_VERIFY_SSL: False,
+        },
+        options={CONF_MONITORED_GROUPS: []},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.truenas_ce.coordinator.TrueNASAPI",
+        return_value=_fake_api(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.async_entity_ids("sensor")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,6 +28,7 @@ from custom_components.truenas_ce import (
     _handle_passphrase_list,
     _handle_passphrase_remove,
     _migrate_data_size_units,
+    _migrate_description,
     _process_dynamic_description,
     _process_static_description,
     _referenced_unique_ids,
@@ -126,6 +127,58 @@ def test_migrate_data_size_units_processes_data_size_descriptions() -> None:
 
     # Called at least once for a DATA_SIZE sensor description (pool available/usage).
     assert migrate_mock.called
+
+
+def test_migrate_description_noop_when_data_not_dict() -> None:
+    coordinator = MagicMock()
+    coordinator.ds = {}
+    description = _desc(key="pool_size", data_path="pool", data_attribute="size")
+
+    with patch.object(init_module, "_force_entity_unit") as force_mock:
+        _migrate_description(MagicMock(), coordinator, "TrueNAS", description, False)
+
+    force_mock.assert_not_called()
+
+
+def test_migrate_description_without_reference_calls_once() -> None:
+    coordinator = MagicMock()
+    coordinator.ds = {"system_info": {"uptime_seconds": 12345}}
+    description = _desc(
+        key="uptime", data_path="system_info", data_attribute="uptime_seconds"
+    )
+    ent_reg = MagicMock()
+
+    with patch.object(init_module, "_force_entity_unit") as force_mock:
+        _migrate_description(ent_reg, coordinator, "TrueNAS", description, False)
+
+    force_mock.assert_called_once_with(
+        ent_reg, "TrueNAS", description, None, 12345, False
+    )
+
+
+def test_migrate_description_with_reference_skips_non_dict_vals() -> None:
+    coordinator = MagicMock()
+    coordinator.ds = {
+        "pool": {
+            "pool1": {"name": "tank", "size": 100},
+            "pool2": "not-a-dict",
+            "pool3": {"size": 200},
+        }
+    }
+    description = _desc(
+        key="pool_size",
+        data_path="pool",
+        data_reference="name",
+        data_attribute="size",
+    )
+    ent_reg = MagicMock()
+
+    with patch.object(init_module, "_force_entity_unit") as force_mock:
+        _migrate_description(ent_reg, coordinator, "TrueNAS", description, True)
+
+    assert force_mock.call_count == 2
+    force_mock.assert_any_call(ent_reg, "TrueNAS", description, "tank", 100, True)
+    force_mock.assert_any_call(ent_reg, "TrueNAS", description, "pool3", 200, True)
 
 
 # ---------------------------
@@ -342,6 +395,20 @@ def test_process_dynamic_description_with_composite_references() -> None:
     assert active == {init_module.format_unique_id("TrueNAS", "app_net", "a::eth0")}
 
 
+def test_process_dynamic_description_empty_sub_data_returns_live_base_only() -> None:
+    description = _desc(
+        key="app_stats",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_reference="app_name",
+    )
+    active, live_bases = _process_dynamic_description(
+        "TrueNAS", description, {"app_stats": {}}, False, set()
+    )
+    assert active == set()
+    assert live_bases == {init_module.format_unique_id("TrueNAS", "app_stats")}
+
+
 # ---------------------------
 #   _collect_active_unique_ids (integration of the helpers above)
 # ---------------------------
@@ -407,6 +474,17 @@ def test_resolve_config_entry_by_explicit_id() -> None:
 
     resolved, error = _resolve_config_entry(hass, "entry1")
     assert resolved is entry
+    assert error == {}
+
+
+def test_resolve_config_entry_by_explicit_id_skips_non_matching_entries() -> None:
+    hass = MagicMock()
+    entry1 = _config_entry(entry_id="e1")
+    entry2 = _config_entry(entry_id="e2")
+    hass.config_entries.async_entries.return_value = [entry1, entry2]
+
+    resolved, error = _resolve_config_entry(hass, "e2")
+    assert resolved is entry2
     assert error == {}
 
 
@@ -680,6 +758,36 @@ async def test_async_setup_entry_wires_coordinator_and_platforms() -> None:
     cleanup_mock.assert_called_once()
     finalize_mock.assert_called_once()
     notify_mock.assert_called_once()
+
+
+async def test_async_setup_entry_refresh_listener_dispatches_update_signal() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    entry = _config_entry(entry_id="e1")
+    entry.async_on_unload = MagicMock()
+
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock()
+    coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+    with (
+        patch.object(init_module, "TrueNASCoordinator", return_value=coordinator),
+        patch.object(
+            init_module, "async_adopt_legacy_entities", new=AsyncMock(return_value=[])
+        ),
+        patch.object(init_module, "_migrate_data_size_units"),
+        patch.object(init_module, "_cleanup_orphaned_entities"),
+        patch.object(init_module, "finalize_legacy_adoption"),
+        patch.object(init_module, "async_notify_migration_result"),
+        patch.object(init_module, "async_dispatcher_send") as dispatch_mock,
+    ):
+        await async_setup_entry(hass, entry)
+        refresh_callback = coordinator.async_add_listener.call_args.args[0]
+        refresh_callback()
+
+    dispatch_mock.assert_called_once_with(
+        hass, init_module.SIGNAL_UPDATE_SENSORS, coordinator
+    )
 
 
 async def test_async_unload_entry_stops_coordinator_on_success() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,725 @@
+"""Unit tests for __init__.py (setup/unload, entity cleanup, service handlers).
+
+Follows the same bare-instance / heavy-mock style as test_coordinator.py and
+test_migration.py: real ``homeassistant`` core types are importable without
+``pytest-homeassistant-custom-component``, so hass/entity registries/config
+entries are stood in with ``MagicMock``/``SimpleNamespace``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_NAME
+from homeassistant.exceptions import ServiceValidationError
+
+import custom_components.truenas_ce as init_module
+from custom_components.truenas_ce import (
+    _build_disabled_data_paths,
+    _collect_active_unique_ids,
+    _force_entity_unit,
+    _handle_alert_dismiss,
+    _handle_alert_list,
+    _handle_alert_restore,
+    _handle_keyless,
+    _handle_passphrase_list,
+    _handle_passphrase_remove,
+    _migrate_data_size_units,
+    _process_dynamic_description,
+    _process_static_description,
+    _referenced_unique_ids,
+    _require_config_entry,
+    _resolve_config_entry,
+    async_setup,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.truenas_ce.const import (
+    CONF_DATASET_PASSPHRASES,
+    MONITOR_GROUP_VMS,
+    SERVICE_ALERT_PROPERTIES,
+    SERVICE_ALERT_UUID,
+    SERVICE_PASSPHRASE_DATASET_PATH,
+)
+from custom_components.truenas_ce.sensor_types import TrueNASSensorEntityDescription
+
+
+def _desc(**kwargs: Any) -> TrueNASSensorEntityDescription:
+    kwargs.setdefault("name", None)
+    return TrueNASSensorEntityDescription(**kwargs)
+
+
+def _config_entry(
+    *,
+    entry_id: str = "entry1",
+    data: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        entry_id=entry_id,
+        data={CONF_NAME: "TrueNAS", **(data or {})},
+        options=options or {},
+        state=init_module.ConfigEntryState.LOADED,
+    )
+
+
+# ---------------------------
+#   _migrate_data_size_units / _force_entity_unit
+# ---------------------------
+def test_force_entity_unit_writes_new_unit_option() -> None:
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = "sensor.truenas_pool_usage"
+    # Existing option ("MB") must differ from the newly-computed unit ("GB" for
+    # 5e9 bytes decimal) so the update branch actually fires.
+    existing_entry = SimpleNamespace(options={"sensor": {"unit_of_measurement": "MB"}})
+    ent_reg.async_get.return_value = existing_entry
+    description = _desc(key="pool_size", data_attribute="size")
+
+    _force_entity_unit(ent_reg, "TrueNAS", description, "pool1", 5_000_000_000, False)
+
+    ent_reg.async_update_entity_options.assert_called_once()
+    entity_id, domain, options = ent_reg.async_update_entity_options.call_args.args
+    assert entity_id == "sensor.truenas_pool_usage"
+    assert domain == "sensor"
+    assert options["unit_of_measurement"] == "GB"
+
+
+def test_force_entity_unit_noop_when_entity_missing() -> None:
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = None
+    description = _desc(key="pool_size", data_attribute="size")
+
+    _force_entity_unit(ent_reg, "TrueNAS", description, "pool1", 100, False)
+
+    ent_reg.async_update_entity_options.assert_not_called()
+
+
+def test_force_entity_unit_noop_when_unit_unchanged() -> None:
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = "sensor.truenas_pool_usage"
+    # Pre-set the option to whatever scaled_data_unit will compute for value=0.
+    from custom_components.truenas_ce.helper import scaled_data_unit
+
+    unit, _ = scaled_data_unit(0, False)
+    existing_entry = SimpleNamespace(options={"sensor": {"unit_of_measurement": unit}})
+    ent_reg.async_get.return_value = existing_entry
+    description = _desc(key="pool_size", data_attribute="size")
+
+    _force_entity_unit(ent_reg, "TrueNAS", description, "pool1", 0, False)
+
+    ent_reg.async_update_entity_options.assert_not_called()
+
+
+def test_migrate_data_size_units_processes_data_size_descriptions() -> None:
+    coordinator = MagicMock()
+    coordinator.ds = {"pool": {"pool1": {"size": 5_000_000_000}}}
+    entry = _config_entry(options={"data_unit": "GiB"})
+
+    with (
+        patch.object(init_module.er, "async_get", return_value=MagicMock()),
+        patch.object(init_module, "_migrate_description") as migrate_mock,
+    ):
+        _migrate_data_size_units(MagicMock(), entry, coordinator)
+
+    # Called at least once for a DATA_SIZE sensor description (pool available/usage).
+    assert migrate_mock.called
+
+
+# ---------------------------
+#   _handle_keyless / _referenced_unique_ids
+# ---------------------------
+def test_handle_keyless_routes_to_live_bases_when_disabled() -> None:
+    active: set[str] = set()
+    live_bases: set[str] = set()
+    _handle_keyless("truenas-uptime", True, active, live_bases)
+    assert live_bases == {"truenas-uptime"}
+    assert active == set()
+
+
+def test_handle_keyless_routes_to_active_when_enabled() -> None:
+    active: set[str] = set()
+    live_bases: set[str] = set()
+    _handle_keyless("truenas-uptime", False, active, live_bases)
+    assert active == {"truenas-uptime"}
+    assert live_bases == set()
+
+
+def test_referenced_unique_ids_builds_ids_for_each_object() -> None:
+    description = _desc(key="vm_status", data_reference="name", data_attribute="status")
+    data = {
+        "1": {"name": "vm1", "status": "RUNNING"},
+        "2": {"name": "vm2", "status": "STOPPED"},
+    }
+    ids = _referenced_unique_ids("TrueNAS", description, data)
+    assert ids == {
+        init_module.format_unique_id("TrueNAS", "vm_status", "vm1"),
+        init_module.format_unique_id("TrueNAS", "vm_status", "vm2"),
+    }
+
+
+def test_referenced_unique_ids_honors_exclude_when_requested() -> None:
+    description = _desc(
+        key="if_rx",
+        data_reference="name",
+        data_attribute="rx",
+        data_exclude=("link_up", False),
+    )
+    data = {
+        "eth0": {"name": "eth0", "rx": 1, "link_up": True},
+        "eth1": {"name": "eth1", "rx": 2, "link_up": False},
+    }
+    ids = _referenced_unique_ids("TrueNAS", description, data, honor_exclude=True)
+    assert ids == {init_module.format_unique_id("TrueNAS", "if_rx", "eth0")}
+
+
+def test_referenced_unique_ids_ignores_exclude_when_not_honored() -> None:
+    description = _desc(
+        key="if_rx",
+        data_reference="name",
+        data_attribute="rx",
+        data_exclude=("link_up", False),
+    )
+    data = {"eth1": {"name": "eth1", "rx": 2, "link_up": False}}
+    ids = _referenced_unique_ids("TrueNAS", description, data, honor_exclude=False)
+    assert ids == {init_module.format_unique_id("TrueNAS", "if_rx", "eth1")}
+
+
+def test_referenced_unique_ids_falls_back_to_uid_when_reference_missing() -> None:
+    description = _desc(key="vm_status", data_reference="name", data_attribute="status")
+    data = {"1": {"status": "RUNNING"}}
+    ids = _referenced_unique_ids("TrueNAS", description, data)
+    assert ids == {init_module.format_unique_id("TrueNAS", "vm_status", "1")}
+
+
+# ---------------------------
+#   _build_disabled_data_paths
+# ---------------------------
+def test_build_disabled_data_paths_returns_paths_of_unmonitored_groups() -> None:
+    monitored = [
+        g for g in init_module.DEFAULT_MONITORED_GROUPS if g != MONITOR_GROUP_VMS
+    ]
+    disabled = _build_disabled_data_paths(monitored)
+    assert "vm" in disabled
+    assert "container" not in disabled
+
+
+def test_build_disabled_data_paths_empty_when_all_monitored() -> None:
+    disabled = _build_disabled_data_paths(init_module.DEFAULT_MONITORED_GROUPS)
+    assert disabled == set()
+
+
+# ---------------------------
+#   _process_static_description
+# ---------------------------
+def test_process_static_description_keyless_enabled() -> None:
+    description = _desc(
+        key="uptime", data_path="system_info", data_attribute="uptime_seconds"
+    )
+    active: set[str] = set()
+    live_bases: set[str] = set()
+    _process_static_description(
+        "TrueNAS", description, set(), False, active, live_bases, {"system_info": {}}
+    )
+    assert active == {init_module.format_unique_id("TrueNAS", "uptime")}
+
+
+def test_process_static_description_keyless_disabled_group() -> None:
+    description = _desc(key="vm_count", data_path="vm", data_attribute="count")
+    active: set[str] = set()
+    live_bases: set[str] = set()
+    _process_static_description(
+        "TrueNAS", description, {"vm"}, False, active, live_bases, {}
+    )
+    assert live_bases == {init_module.format_unique_id("TrueNAS", "vm_count")}
+    assert active == set()
+
+
+def test_process_static_description_referenced_no_data_and_enabled_returns_early() -> (
+    None
+):
+    description = _desc(key="vm_status", data_path="vm", data_reference="name")
+    active: set[str] = set()
+    live_bases: set[str] = set()
+    _process_static_description(
+        "TrueNAS", description, set(), False, active, live_bases, {"vm": {}}
+    )
+    assert active == set()
+    assert live_bases == set()
+
+
+def test_process_static_description_referenced_with_data() -> None:
+    description = _desc(key="vm_status", data_path="vm", data_reference="name")
+    active: set[str] = set()
+    live_bases: set[str] = set()
+    data = {"vm": {"1": {"name": "vm1"}}}
+    _process_static_description(
+        "TrueNAS", description, set(), False, active, live_bases, data
+    )
+    assert active == {init_module.format_unique_id("TrueNAS", "vm_status", "vm1")}
+    assert live_bases == {init_module.format_unique_id("TrueNAS", "vm_status")}
+
+
+def test_process_static_description_referenced_disabled_group_keeps_live_base() -> None:
+    description = _desc(key="vm_status", data_path="vm", data_reference="name")
+    active: set[str] = set()
+    live_bases: set[str] = set()
+    data = {"vm": {"1": {"name": "vm1"}}}
+    _process_static_description(
+        "TrueNAS", description, {"vm"}, False, active, live_bases, data
+    )
+    assert active == set()
+    assert live_bases == {init_module.format_unique_id("TrueNAS", "vm_status")}
+
+
+# ---------------------------
+#   _process_dynamic_description
+# ---------------------------
+def test_process_dynamic_description_ignores_static_description() -> None:
+    description = _desc(key="uptime", data_path="system_info")
+    active, live_bases = _process_dynamic_description(
+        "TrueNAS", description, {}, False, set()
+    )
+    assert active == set()
+    assert live_bases == set()
+
+
+def test_process_dynamic_description_disabled_group_returns_live_base_only() -> None:
+    description = _desc(
+        key="app_stats",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_reference="app_name",
+    )
+    active, live_bases = _process_dynamic_description(
+        "TrueNAS",
+        description,
+        {"app_stats": {"a": {"app_name": "a"}}},
+        False,
+        {"app_stats"},
+    )
+    assert active == set()
+    assert live_bases == {init_module.format_unique_id("TrueNAS", "app_stats")}
+
+
+def test_process_dynamic_description_no_reference_or_composite() -> None:
+    description = _desc(key="app_stats", data_path="app_stats", data_dynamic_keys=True)
+    active, live_bases = _process_dynamic_description(
+        "TrueNAS", description, {"app_stats": {"a": {}}}, False, set()
+    )
+    assert active == set()
+    assert live_bases == {init_module.format_unique_id("TrueNAS", "app_stats")}
+
+
+def test_process_dynamic_description_with_reference() -> None:
+    description = _desc(
+        key="app_stats",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_reference="app_name",
+    )
+    data = {"app_stats": {"a": {"app_name": "myapp"}}}
+    active, live_bases = _process_dynamic_description(
+        "TrueNAS", description, data, False, set()
+    )
+    assert active == {init_module.format_unique_id("TrueNAS", "app_stats", "myapp")}
+
+
+def test_process_dynamic_description_with_composite_references() -> None:
+    description = _desc(
+        key="app_net",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_reference="interface_name",
+        data_composite_references=("networks", "interface_name"),
+    )
+    data = {"app_stats": {"a": {"networks": [{"interface_name": "eth0"}]}}}
+    active, live_bases = _process_dynamic_description(
+        "TrueNAS", description, data, False, set()
+    )
+    assert active == {init_module.format_unique_id("TrueNAS", "app_net", "a::eth0")}
+
+
+# ---------------------------
+#   _collect_active_unique_ids (integration of the helpers above)
+# ---------------------------
+def test_collect_active_unique_ids_combines_static_and_dynamic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    static_desc = _desc(
+        key="uptime", data_path="system_info", data_attribute="uptime_seconds"
+    )
+    dynamic_desc = _desc(
+        key="app_stats",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_reference="app_name",
+    )
+    monkeypatch.setattr(init_module, "_ALL_DESCRIPTIONS", (static_desc, dynamic_desc))
+
+    coordinator = MagicMock()
+    coordinator.config_entry.options = {}
+    coordinator.data = {
+        "system_info": {},
+        "app_stats": {"a": {"app_name": "myapp"}},
+    }
+
+    active, live_bases = _collect_active_unique_ids("TrueNAS", coordinator)
+
+    assert init_module.format_unique_id("TrueNAS", "uptime") in active
+    assert init_module.format_unique_id("TrueNAS", "app_stats", "myapp") in active
+    assert init_module.format_unique_id("TrueNAS", "app_stats") in live_bases
+
+
+def test_collect_active_unique_ids_honors_behavior_toggle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    description = _desc(
+        key="if_rx",
+        data_path="interface",
+        data_reference="name",
+        data_attribute="rx",
+        data_exclude=("link_up", False),
+    )
+    monkeypatch.setattr(init_module, "_ALL_DESCRIPTIONS", (description,))
+
+    coordinator = MagicMock()
+    coordinator.config_entry.options = {
+        init_module.CONF_BEHAVIORS: [init_module.BEHAVIOR_REMOVE_INACTIVE_NIC]
+    }
+    coordinator.data = {
+        "interface": {"eth1": {"name": "eth1", "rx": 1, "link_up": False}}
+    }
+
+    active, _ = _collect_active_unique_ids("TrueNAS", coordinator)
+    assert active == set()
+
+
+# ---------------------------
+#   _resolve_config_entry / _require_config_entry
+# ---------------------------
+def test_resolve_config_entry_by_explicit_id() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="entry1")
+    hass.config_entries.async_entries.return_value = [entry]
+
+    resolved, error = _resolve_config_entry(hass, "entry1")
+    assert resolved is entry
+    assert error == {}
+
+
+def test_resolve_config_entry_explicit_id_not_loaded() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="entry1")
+    entry.state = init_module.ConfigEntryState.NOT_LOADED
+    hass.config_entries.async_entries.return_value = [entry]
+
+    resolved, error = _resolve_config_entry(hass, "entry1")
+    assert resolved is None
+    assert "not loaded" in error["error"]
+
+
+def test_resolve_config_entry_explicit_id_not_found() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    resolved, error = _resolve_config_entry(hass, "missing")
+    assert resolved is None
+    assert "not found" in error["error"]
+
+
+def test_resolve_config_entry_no_entries_loaded() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    resolved, error = _resolve_config_entry(hass, None)
+    assert resolved is None
+    assert "No TrueNAS instances" in error["error"]
+
+
+def test_resolve_config_entry_multiple_loaded_without_id() -> None:
+    hass = MagicMock()
+    entry1 = _config_entry(entry_id="e1")
+    entry2 = _config_entry(entry_id="e2")
+    hass.config_entries.async_entries.return_value = [entry1, entry2]
+    resolved, error = _resolve_config_entry(hass, None)
+    assert resolved is None
+    assert "Multiple TrueNAS instances" in error["error"]
+
+
+def test_resolve_config_entry_single_loaded_without_id() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    hass.config_entries.async_entries.return_value = [entry]
+    resolved, error = _resolve_config_entry(hass, None)
+    assert resolved is entry
+    assert error == {}
+
+
+def test_require_config_entry_raises_on_error() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    with pytest.raises(ServiceValidationError):
+        _require_config_entry(hass, None)
+
+
+def test_require_config_entry_returns_entry_on_success() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    hass.config_entries.async_entries.return_value = [entry]
+    assert _require_config_entry(hass, "e1") is entry
+
+
+# ---------------------------
+#   Alert / passphrase service handlers
+# ---------------------------
+async def test_handle_alert_list_returns_all_when_error() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    call = SimpleNamespace(data={})
+    result = await _handle_alert_list(hass, call)
+    assert result["alerts"] == []
+    assert "error" in result
+
+
+async def test_handle_alert_list_filters_default_properties() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    entry.runtime_data = SimpleNamespace(
+        api=SimpleNamespace(
+            query=AsyncMock(
+                return_value=[
+                    {"uuid": "u1", "level": "WARNING", "formatted": "msg", "extra": "x"}
+                ]
+            )
+        )
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={})
+
+    result = await _handle_alert_list(hass, call)
+
+    # DEFAULT_ALERT_PROPERTIES is "uuid,formatted" -- level/extra are dropped.
+    assert result["alerts"] == [{"uuid": "u1", "formatted": "msg"}]
+
+
+async def test_handle_alert_list_returns_raw_with_wildcard() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    raw_alerts = [{"uuid": "u1", "level": "WARNING"}]
+    entry.runtime_data = SimpleNamespace(
+        api=SimpleNamespace(query=AsyncMock(return_value=raw_alerts))
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={SERVICE_ALERT_PROPERTIES: "*"})
+
+    result = await _handle_alert_list(hass, call)
+    assert result == {"alerts": raw_alerts}
+
+
+async def test_handle_alert_list_malformed_response() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    entry.runtime_data = SimpleNamespace(
+        api=SimpleNamespace(query=AsyncMock(return_value=None))
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={})
+
+    result = await _handle_alert_list(hass, call)
+    assert result["alerts"] == []
+    assert "error" in result
+
+
+async def test_handle_alert_dismiss_requires_uuid() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    entry.runtime_data = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={})
+
+    with pytest.raises(ServiceValidationError, match="UUID is required"):
+        await _handle_alert_dismiss(hass, call)
+
+
+async def test_handle_alert_dismiss_calls_alert_action() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    entry.runtime_data = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={SERVICE_ALERT_UUID: "u1"})
+
+    with patch.object(init_module, "alert_action", new=AsyncMock()) as action_mock:
+        await _handle_alert_dismiss(hass, call)
+
+    action_mock.assert_awaited_once_with(entry.runtime_data, "u1", "dismiss")
+
+
+async def test_handle_alert_restore_calls_alert_action() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    entry.runtime_data = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={SERVICE_ALERT_UUID: "u1"})
+
+    with patch.object(init_module, "alert_action", new=AsyncMock()) as action_mock:
+        await _handle_alert_restore(hass, call)
+
+    action_mock.assert_awaited_once_with(entry.runtime_data, "u1", "restore")
+
+
+async def test_handle_alert_restore_requires_uuid() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    entry.runtime_data = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={})
+
+    with pytest.raises(ServiceValidationError, match="UUID is required"):
+        await _handle_alert_restore(hass, call)
+
+
+async def test_handle_passphrase_remove_requires_path() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={SERVICE_PASSPHRASE_DATASET_PATH: "  "})
+
+    with pytest.raises(ServiceValidationError, match="dataset_path is required"):
+        await _handle_passphrase_remove(hass, call)
+
+
+async def test_handle_passphrase_remove_requires_existing_entry() -> None:
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1", data={CONF_DATASET_PASSPHRASES: {}})
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={SERVICE_PASSPHRASE_DATASET_PATH: "tank/data"})
+
+    with pytest.raises(ServiceValidationError, match="No stored passphrase"):
+        await _handle_passphrase_remove(hass, call)
+
+
+async def test_handle_passphrase_remove_deletes_entry() -> None:
+    hass = MagicMock()
+    entry = _config_entry(
+        entry_id="e1",
+        data={CONF_DATASET_PASSPHRASES: {"tank/data": "secret", "tank/other": "x"}},
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={SERVICE_PASSPHRASE_DATASET_PATH: "tank/data"})
+
+    await _handle_passphrase_remove(hass, call)
+
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    assert "tank/data" not in kwargs["data"][CONF_DATASET_PASSPHRASES]
+    assert "tank/other" in kwargs["data"][CONF_DATASET_PASSPHRASES]
+
+
+async def test_handle_passphrase_list_returns_sorted_dataset_names() -> None:
+    hass = MagicMock()
+    entry = _config_entry(
+        entry_id="e1", data={CONF_DATASET_PASSPHRASES: {"tank/b": "x", "tank/a": "y"}}
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+    call = SimpleNamespace(data={})
+
+    result = await _handle_passphrase_list(hass, call)
+    assert result == {"datasets": ["tank/a", "tank/b"]}
+
+
+async def test_handle_passphrase_list_error_when_no_entry() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    call = SimpleNamespace(data={})
+
+    result = await _handle_passphrase_list(hass, call)
+    assert result["datasets"] == []
+    assert "error" in result
+
+
+# ---------------------------
+#   async_setup
+# ---------------------------
+async def test_async_setup_registers_all_services() -> None:
+    hass = MagicMock()
+    result = await async_setup(hass, {})
+    assert result is True
+    assert hass.services.async_register.call_count == 5
+
+
+# ---------------------------
+#   async_setup_entry / async_unload_entry
+# ---------------------------
+async def test_async_setup_entry_wires_coordinator_and_platforms() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    entry = _config_entry(entry_id="e1")
+    entry.async_on_unload = MagicMock()
+
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock()
+    coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+    with (
+        patch.object(init_module, "TrueNASCoordinator", return_value=coordinator),
+        patch.object(
+            init_module, "async_adopt_legacy_entities", new=AsyncMock(return_value=[])
+        ),
+        patch.object(init_module, "_migrate_data_size_units") as migrate_mock,
+        patch.object(init_module, "_cleanup_orphaned_entities") as cleanup_mock,
+        patch.object(init_module, "finalize_legacy_adoption") as finalize_mock,
+        patch.object(init_module, "async_notify_migration_result") as notify_mock,
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    assert entry.runtime_data is coordinator
+    coordinator.async_config_entry_first_refresh.assert_awaited_once()
+    hass.config_entries.async_forward_entry_setups.assert_awaited_once()
+    migrate_mock.assert_called_once()
+    cleanup_mock.assert_called_once()
+    finalize_mock.assert_called_once()
+    notify_mock.assert_called_once()
+
+
+async def test_async_unload_entry_stops_coordinator_on_success() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    entry = _config_entry(entry_id="e1")
+
+    coordinator = SimpleNamespace(
+        stop_app_stats=AsyncMock(),
+        api=SimpleNamespace(close=AsyncMock()),
+    )
+    entry.runtime_data = coordinator
+
+    with patch.object(init_module, "get_truenas_coordinator", return_value=coordinator):
+        result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    coordinator.stop_app_stats.assert_awaited_once()
+    coordinator.api.close.assert_awaited_once()
+    assert not hasattr(entry, "runtime_data")
+
+
+async def test_async_unload_entry_noop_when_platform_unload_fails() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+    entry = _config_entry(entry_id="e1")
+    entry.runtime_data = MagicMock()
+
+    result = await async_unload_entry(hass, entry)
+
+    assert result is False
+    assert hasattr(entry, "runtime_data")
+
+
+async def test_async_unload_entry_handles_missing_coordinator() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    entry = _config_entry(entry_id="e1")
+
+    with patch.object(init_module, "get_truenas_coordinator", return_value=None):
+        result = await async_unload_entry(hass, entry)
+
+    assert result is True

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,742 @@
+"""Unit tests for migration.py (Community-Edition legacy-entity adoption).
+
+Mirrors the coordinator.py test style: real ``homeassistant`` core types are
+importable without ``pytest-homeassistant-custom-component``, so hass/entity
+registry/config entries are stood in with ``MagicMock``/``SimpleNamespace``
+instead of a running HomeAssistant instance.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryDisabler
+
+from custom_components.truenas_ce import migration as migration_module
+from custom_components.truenas_ce.const import (
+    MIGRATION_BACKUP_KEY,
+    MIGRATION_DONE,
+    MIGRATION_LEGACY_CONFIG,
+    MIGRATION_LEGACY_ENTRY_ID,
+    MIGRATION_RECORDS,
+)
+from custom_components.truenas_ce.migration import (
+    _build_migration_message,
+    _classify_reconnection,
+    _collect_legacy_records,
+    _find_legacy_entry,
+    _log_reconnection,
+    _persist_migration_state,
+    _remap_and_restore,
+    _remove_legacy_entities,
+    _restore_overrides,
+    _temp_entity_id,
+    async_adopt_legacy_entities,
+    async_notify_migration_result,
+    async_rollback_to_legacy,
+    finalize_legacy_adoption,
+)
+
+
+def _record(
+    *,
+    unique_id: str = "uid1",
+    entity_domain: str = "sensor",
+    entity_id: str = "sensor.truenas_cpu",
+    name: str | None = None,
+    icon: str | None = None,
+    area_id: str | None = None,
+    disabled_user: bool = False,
+) -> dict[str, Any]:
+    return {
+        "unique_id": unique_id,
+        "entity_domain": entity_domain,
+        "entity_id": entity_id,
+        "name": name,
+        "icon": icon,
+        "area_id": area_id,
+        "disabled_user": disabled_user,
+    }
+
+
+def _config_entry(
+    *, entry_id: str = "ce-entry", data: dict[str, Any] | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(entry_id=entry_id, data=data or {}, options={})
+
+
+# ---------------------------
+#   _find_legacy_entry
+# ---------------------------
+def test_find_legacy_entry_matches_by_host() -> None:
+    hass = MagicMock()
+    legacy_a = SimpleNamespace(entry_id="a", data={"host": "other.local"})
+    legacy_b = SimpleNamespace(entry_id="b", data={"host": "truenas.local"})
+    hass.config_entries.async_entries.return_value = [legacy_a, legacy_b]
+
+    entry = _config_entry(data={"host": "truenas.local"})
+    assert _find_legacy_entry(hass, entry) is legacy_b
+
+
+def test_find_legacy_entry_falls_back_to_single_candidate() -> None:
+    hass = MagicMock()
+    legacy = SimpleNamespace(entry_id="a", data={"host": "renamed.local"})
+    hass.config_entries.async_entries.return_value = [legacy]
+
+    entry = _config_entry(data={"host": "truenas.local"})
+    assert _find_legacy_entry(hass, entry) is legacy
+
+
+def test_find_legacy_entry_returns_none_for_multiple_non_matching() -> None:
+    hass = MagicMock()
+    legacy_a = SimpleNamespace(entry_id="a", data={"host": "one.local"})
+    legacy_b = SimpleNamespace(entry_id="b", data={"host": "two.local"})
+    hass.config_entries.async_entries.return_value = [legacy_a, legacy_b]
+
+    entry = _config_entry(data={"host": "truenas.local"})
+    assert _find_legacy_entry(hass, entry) is None
+
+
+def test_find_legacy_entry_returns_none_when_no_candidates() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    entry = _config_entry(data={"host": "truenas.local"})
+    assert _find_legacy_entry(hass, entry) is None
+
+
+# ---------------------------
+#   _collect_legacy_records / _remove_legacy_entities
+# ---------------------------
+def test_collect_legacy_records_snapshots_registry_entries() -> None:
+    ent_reg = MagicMock()
+    entry1 = SimpleNamespace(
+        unique_id="uid1",
+        domain="sensor",
+        entity_id="sensor.truenas_cpu",
+        name="CPU",
+        icon="mdi:chip",
+        area_id="office",
+        disabled_by=None,
+    )
+    with patch.object(
+        migration_module.er,
+        "async_entries_for_config_entry",
+        return_value=[entry1],
+    ):
+        records = _collect_legacy_records(ent_reg, SimpleNamespace(entry_id="legacy"))
+
+    assert records == [_record(name="CPU", icon="mdi:chip", area_id="office")]
+
+
+def test_collect_legacy_records_marks_user_disabled() -> None:
+    ent_reg = MagicMock()
+    entry1 = SimpleNamespace(
+        unique_id="uid1",
+        domain="sensor",
+        entity_id="sensor.truenas_cpu",
+        name=None,
+        icon=None,
+        area_id=None,
+        disabled_by=migration_module.er.RegistryEntryDisabler.USER,
+    )
+    with patch.object(
+        migration_module.er,
+        "async_entries_for_config_entry",
+        return_value=[entry1],
+    ):
+        records = _collect_legacy_records(ent_reg, SimpleNamespace(entry_id="legacy"))
+
+    assert records[0]["disabled_user"] is True
+
+
+def test_remove_legacy_entities_removes_each_record() -> None:
+    ent_reg = MagicMock()
+    records = [_record(entity_id="sensor.a"), _record(entity_id="sensor.b")]
+    _remove_legacy_entities(ent_reg, records)
+    assert ent_reg.async_remove.call_count == 2
+    ent_reg.async_remove.assert_any_call("sensor.a")
+    ent_reg.async_remove.assert_any_call("sensor.b")
+
+
+# ---------------------------
+#   _persist_migration_state
+# ---------------------------
+def test_persist_migration_state_with_legacy_entry_and_backup() -> None:
+    hass = MagicMock()
+    entry = _config_entry(data={"existing": "value"})
+    legacy_entry = SimpleNamespace(
+        entry_id="legacy-1", data={"host": "x"}, options={"opt": 1}
+    )
+    records = [_record()]
+
+    _persist_migration_state(hass, entry, legacy_entry, records, "backup-key-1")
+
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    new_data = kwargs["data"]
+    assert new_data["existing"] == "value"
+    assert new_data[MIGRATION_DONE] is True
+    assert new_data[MIGRATION_RECORDS] == records
+    assert new_data[MIGRATION_LEGACY_ENTRY_ID] == "legacy-1"
+    assert new_data[MIGRATION_LEGACY_CONFIG] == {
+        "data": {"host": "x"},
+        "options": {"opt": 1},
+    }
+    assert new_data[MIGRATION_BACKUP_KEY] == "backup-key-1"
+
+
+def test_persist_migration_state_without_legacy_entry() -> None:
+    hass = MagicMock()
+    entry = _config_entry()
+
+    _persist_migration_state(hass, entry, None, [], None)
+
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    new_data = kwargs["data"]
+    assert new_data[MIGRATION_DONE] is True
+    assert MIGRATION_LEGACY_ENTRY_ID not in new_data
+    assert MIGRATION_BACKUP_KEY not in new_data
+
+
+# ---------------------------
+#   _temp_entity_id
+# ---------------------------
+def test_temp_entity_id_returns_first_free_candidate() -> None:
+    ent_reg = MagicMock()
+    ent_reg.async_get.return_value = None
+    temp_id, counter = _temp_entity_id(ent_reg, "sensor.truenas_cpu", 0)
+    assert temp_id == "sensor.truenas_ce_mig_0"
+    assert counter == 1
+
+
+def test_temp_entity_id_skips_occupied_candidates() -> None:
+    ent_reg = MagicMock()
+    ent_reg.async_get.side_effect = [object(), object(), None]
+    temp_id, counter = _temp_entity_id(ent_reg, "sensor.truenas_cpu", 0)
+    assert temp_id == "sensor.truenas_ce_mig_2"
+    assert counter == 3
+
+
+# ---------------------------
+#   _restore_overrides
+# ---------------------------
+def test_restore_overrides_applies_all_present_fields() -> None:
+    ent_reg = MagicMock()
+    record = _record(name="CPU", icon="mdi:chip", area_id="office", disabled_user=True)
+    _restore_overrides(ent_reg, "sensor.truenas_cpu", record)
+    ent_reg.async_update_entity.assert_called_once_with(
+        "sensor.truenas_cpu",
+        name="CPU",
+        icon="mdi:chip",
+        area_id="office",
+        disabled_by=migration_module.er.RegistryEntryDisabler.USER,
+    )
+
+
+def test_restore_overrides_noop_when_no_fields_set() -> None:
+    ent_reg = MagicMock()
+    record = _record()
+    _restore_overrides(ent_reg, "sensor.truenas_cpu", record)
+    ent_reg.async_update_entity.assert_not_called()
+
+
+# ---------------------------
+#   _remap_and_restore
+# ---------------------------
+def test_remap_and_restore_simple_rename() -> None:
+    """Rename is a two-pass park-then-restore even for a single, non-cyclic pair."""
+    ent_reg = MagicMock()
+    ent_reg.async_get.return_value = None
+    record = _record(name="CPU")
+    pairs = [("sensor.truenas_ce_cpu", "sensor.truenas_cpu", record)]
+
+    _remap_and_restore(ent_reg, pairs)
+
+    ent_reg.async_update_entity.assert_any_call(
+        "sensor.truenas_ce_cpu", new_entity_id="sensor.truenas_ce_mig_0"
+    )
+    ent_reg.async_update_entity.assert_any_call(
+        "sensor.truenas_ce_mig_0", new_entity_id="sensor.truenas_cpu"
+    )
+
+
+def test_remap_and_restore_already_on_target_skips_rename() -> None:
+    ent_reg = MagicMock()
+    record = _record(name="CPU")
+    pairs = [("sensor.truenas_cpu", "sensor.truenas_cpu", record)]
+
+    _remap_and_restore(ent_reg, pairs)
+
+    # No rename call should reference this id since current == target.
+    for call in ent_reg.async_update_entity.call_args_list:
+        assert (
+            call.kwargs.get("new_entity_id") != "sensor.truenas_cpu"
+            or call.args[0] != "sensor.truenas_cpu"
+        )
+
+
+def test_remap_and_restore_permutation_cycle() -> None:
+    """sda -> sdb and sdb -> sda must both succeed (two-pass park-then-restore)."""
+    ent_reg = MagicMock()
+    # After parking, target ids are free; simulate that via async_get returning
+    # None once entities have been parked (start occupied, then free).
+    occupied = {"sensor.truenas_sda", "sensor.truenas_sdb"}
+
+    def fake_get(entity_id: str) -> Any:
+        return object() if entity_id in occupied else None
+
+    ent_reg.async_get.side_effect = fake_get
+
+    def fake_update(
+        entity_id: str, *, new_entity_id: str | None = None, **_: Any
+    ) -> None:
+        if new_entity_id:
+            occupied.discard(entity_id)
+            occupied.add(new_entity_id)
+
+    ent_reg.async_update_entity.side_effect = fake_update
+
+    pairs = [
+        ("sensor.truenas_sda", "sensor.truenas_sdb", _record()),
+        ("sensor.truenas_sdb", "sensor.truenas_sda", _record()),
+    ]
+    _remap_and_restore(ent_reg, pairs)
+
+    final_ids = {
+        call.args[0]
+        if not call.kwargs.get("new_entity_id")
+        else call.kwargs["new_entity_id"]
+        for call in ent_reg.async_update_entity.call_args_list
+    }
+    assert "sensor.truenas_sda" in final_ids
+    assert "sensor.truenas_sdb" in final_ids
+
+
+def test_remap_and_restore_target_still_occupied_leaves_entity_in_place(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ent_reg = MagicMock()
+    # Only the target id is occupied; temp ids must stay free or _temp_entity_id
+    # would loop forever looking for one.
+    ent_reg.async_get.side_effect = lambda entity_id: (
+        object() if entity_id == "sensor.truenas_cpu" else None
+    )
+    record = _record(name="CPU")
+    pairs = [("sensor.truenas_ce_mig_0", "sensor.truenas_cpu", record)]
+
+    with caplog.at_level("WARNING"):
+        _remap_and_restore(ent_reg, pairs)
+
+    assert "could not restore id" in caplog.text
+
+
+# ---------------------------
+#   _classify_reconnection / _log_reconnection
+# ---------------------------
+def test_classify_reconnection_splits_records() -> None:
+    ent_reg = MagicMock()
+
+    def fake_get_entity_id(
+        domain: str, _domain_const: str, unique_id: str
+    ) -> str | None:
+        return {
+            "uid-reconnected": "sensor.truenas_cpu",
+            "uid-mismatched": "sensor.truenas_ce_mig_0",
+        }.get(unique_id)
+
+    ent_reg.async_get_entity_id.side_effect = fake_get_entity_id
+    records = [
+        _record(unique_id="uid-reconnected", entity_id="sensor.truenas_cpu"),
+        _record(unique_id="uid-pending", entity_id="sensor.truenas_pending"),
+        _record(unique_id="uid-mismatched", entity_id="sensor.truenas_original"),
+    ]
+
+    reconnected, pending, mismatched = _classify_reconnection(ent_reg, records)
+
+    assert reconnected == 1
+    assert pending == ["sensor.truenas_pending"]
+    assert mismatched == ["sensor.truenas_original -> sensor.truenas_ce_mig_0"]
+
+
+def test_log_reconnection_handles_empty_lists() -> None:
+    _log_reconnection([], [])  # must not raise
+
+
+def test_log_reconnection_logs_pending_and_mismatched(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("INFO"):
+        _log_reconnection(["sensor.a"], ["sensor.b -> sensor.c"])
+    assert "not yet recreated" in caplog.text
+    assert "could not reclaim" in caplog.text
+
+
+# ---------------------------
+#   _build_migration_message
+# ---------------------------
+def test_build_migration_message_singular_noun() -> None:
+    checks = {"entities": (True, "Entities adopted: 1")}
+    message = _build_migration_message(1, checks)
+    assert "1 entity adopted" in message
+    assert "Entities adopted: 1" in message
+
+
+def test_build_migration_message_plural_noun_and_marks() -> None:
+    checks = {
+        "entities": (True, "Entities adopted: 2"),
+        "history": (False, "History reconnected: 0/2"),
+    }
+    message = _build_migration_message(2, checks)
+    assert "2 entities adopted" in message
+    assert "✅ Entities adopted: 2" in message
+    assert "⚠️ History reconnected: 0/2" in message
+
+
+# ---------------------------
+#   async_adopt_legacy_entities
+# ---------------------------
+async def test_async_adopt_legacy_entities_inert_when_domain_is_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(migration_module, "DOMAIN", migration_module.LEGACY_DOMAIN)
+    hass = MagicMock()
+    entry = _config_entry()
+    assert await async_adopt_legacy_entities(hass, entry) == []
+
+
+async def test_async_adopt_legacy_entities_noop_when_already_done() -> None:
+    hass = MagicMock()
+    entry = _config_entry(data={MIGRATION_DONE: True})
+    assert await async_adopt_legacy_entities(hass, entry) == []
+
+
+async def test_async_adopt_legacy_entities_no_legacy_entry_found() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    entry = _config_entry(data={"host": "truenas.local"})
+
+    records = await async_adopt_legacy_entities(hass, entry)
+
+    assert records == []
+    hass.config_entries.async_update_entry.assert_called_once()
+
+
+async def test_async_adopt_legacy_entities_full_happy_path() -> None:
+    hass = MagicMock()
+    legacy_entry = SimpleNamespace(
+        entry_id="legacy-1",
+        data={"host": "truenas.local"},
+        options={},
+        disabled_by=None,
+    )
+    hass.config_entries.async_entries.return_value = [legacy_entry]
+    hass.config_entries.async_set_disabled_by = AsyncMock()
+    entry = _config_entry(data={"host": "truenas.local"})
+
+    ent_reg = MagicMock()
+    reg_entry = SimpleNamespace(
+        unique_id="uid1",
+        domain="sensor",
+        entity_id="sensor.truenas_cpu",
+        name=None,
+        icon=None,
+        area_id=None,
+        disabled_by=None,
+    )
+    with (
+        patch.object(migration_module.er, "async_get", return_value=ent_reg),
+        patch.object(
+            migration_module.er,
+            "async_entries_for_config_entry",
+            return_value=[reg_entry],
+        ),
+        patch.object(
+            migration_module,
+            "_write_migration_backup",
+            new=AsyncMock(return_value="backup-key"),
+        ),
+    ):
+        records = await async_adopt_legacy_entities(hass, entry)
+
+    assert len(records) == 1
+    hass.config_entries.async_set_disabled_by.assert_awaited_once_with(
+        "legacy-1", ConfigEntryDisabler.USER
+    )
+    ent_reg.async_remove.assert_called_once_with("sensor.truenas_cpu")
+
+
+async def test_async_adopt_legacy_entities_skips_disable_when_already_disabled() -> (
+    None
+):
+    hass = MagicMock()
+    legacy_entry = SimpleNamespace(
+        entry_id="legacy-1",
+        data={"host": "truenas.local"},
+        options={},
+        disabled_by=ConfigEntryDisabler.USER,
+    )
+    hass.config_entries.async_entries.return_value = [legacy_entry]
+    hass.config_entries.async_set_disabled_by = AsyncMock()
+    entry = _config_entry(data={"host": "truenas.local"})
+
+    with (
+        patch.object(migration_module.er, "async_get", return_value=MagicMock()),
+        patch.object(
+            migration_module.er, "async_entries_for_config_entry", return_value=[]
+        ),
+        patch.object(
+            migration_module,
+            "_write_migration_backup",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await async_adopt_legacy_entities(hass, entry)
+
+    hass.config_entries.async_set_disabled_by.assert_not_awaited()
+
+
+# ---------------------------
+#   finalize_legacy_adoption
+# ---------------------------
+def test_finalize_legacy_adoption_inert_when_domain_is_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(migration_module, "DOMAIN", migration_module.LEGACY_DOMAIN)
+    hass = MagicMock()
+    finalize_legacy_adoption(
+        hass, [_record()]
+    )  # must not raise / not call er.async_get
+    hass.assert_not_called() if callable(hass) else None
+
+
+def test_finalize_legacy_adoption_noop_for_empty_records() -> None:
+    hass = MagicMock()
+    finalize_legacy_adoption(hass, [])
+
+
+def test_finalize_legacy_adoption_remaps_matched_entities() -> None:
+    hass = MagicMock()
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = "sensor.truenas_ce_cpu"
+    ent_reg.async_get.return_value = None
+    record = _record()
+
+    with patch.object(migration_module.er, "async_get", return_value=ent_reg):
+        finalize_legacy_adoption(hass, [record])
+
+    ent_reg.async_update_entity.assert_any_call(
+        "sensor.truenas_ce_cpu", new_entity_id="sensor.truenas_ce_mig_0"
+    )
+    ent_reg.async_update_entity.assert_any_call(
+        "sensor.truenas_ce_mig_0", new_entity_id="sensor.truenas_cpu"
+    )
+
+
+def test_finalize_legacy_adoption_skips_unmatched_records() -> None:
+    hass = MagicMock()
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = None
+    record = _record()
+
+    with patch.object(migration_module.er, "async_get", return_value=ent_reg):
+        finalize_legacy_adoption(hass, [record])
+
+    ent_reg.async_update_entity.assert_not_called()
+
+
+# ---------------------------
+#   _write_migration_backup / _remove_backups
+# ---------------------------
+async def test_write_migration_backup_success() -> None:
+    hass = MagicMock()
+    entry = _config_entry()
+    legacy_entry = SimpleNamespace(entry_id="legacy-1", data={}, options={})
+
+    store_instance = MagicMock()
+    store_instance.async_save = AsyncMock()
+    store_instance.key = "truenas_ce_migration_backup_20260101_000000"
+
+    with (
+        patch.object(migration_module, "Store", return_value=store_instance),
+        patch.object(
+            migration_module, "_remove_backups", new=AsyncMock()
+        ) as remove_mock,
+    ):
+        key = await migration_module._write_migration_backup(
+            hass, entry, legacy_entry, []
+        )
+
+    assert key == store_instance.key
+    store_instance.async_save.assert_awaited_once()
+    remove_mock.assert_awaited_once_with(hass, store_instance.key)
+
+
+async def test_write_migration_backup_failure_returns_none() -> None:
+    hass = MagicMock()
+    entry = _config_entry()
+    legacy_entry = SimpleNamespace(entry_id="legacy-1", data={}, options={})
+
+    store_instance = MagicMock()
+    store_instance.async_save = AsyncMock(side_effect=OSError("disk full"))
+
+    with patch.object(migration_module, "Store", return_value=store_instance):
+        key = await migration_module._write_migration_backup(
+            hass, entry, legacy_entry, []
+        )
+
+    assert key is None
+
+
+async def test_remove_backups_removes_all_except_keep_key() -> None:
+    hass = MagicMock()
+    hass.config.path.return_value = "/config/.storage"
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda func: func())
+
+    store_instance = MagicMock()
+    store_instance.async_remove = AsyncMock()
+
+    with (
+        patch(
+            "os.listdir",
+            return_value=[
+                "truenas_ce_migration_backup_1",
+                "truenas_ce_migration_backup_2",
+                "unrelated_file",
+            ],
+        ),
+        patch.object(migration_module, "Store", return_value=store_instance),
+    ):
+        await migration_module._remove_backups(hass, "truenas_ce_migration_backup_1")
+
+    store_instance.async_remove.assert_awaited_once()
+
+
+async def test_remove_backups_handles_listdir_error() -> None:
+    hass = MagicMock()
+    hass.config.path.return_value = "/config/.storage"
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda func: func())
+
+    with patch("os.listdir", side_effect=OSError("no such dir")):
+        await migration_module._remove_backups(hass, None)  # must not raise
+
+
+async def test_remove_backups_logs_on_remove_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    hass = MagicMock()
+    hass.config.path.return_value = "/config/.storage"
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda func: func())
+
+    store_instance = MagicMock()
+    store_instance.async_remove = AsyncMock(side_effect=OSError("locked"))
+
+    with (
+        patch("os.listdir", return_value=["truenas_ce_migration_backup_1"]),
+        patch.object(migration_module, "Store", return_value=store_instance),
+        caplog.at_level("WARNING"),
+    ):
+        await migration_module._remove_backups(hass, None)
+
+    assert "Could not remove CE migration backup" in caplog.text
+
+
+# ---------------------------
+#   async_notify_migration_result
+# ---------------------------
+def test_async_notify_migration_result_inert_when_domain_is_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(migration_module, "DOMAIN", migration_module.LEGACY_DOMAIN)
+    hass = MagicMock()
+    async_notify_migration_result(hass, _config_entry(), [_record()])
+
+
+def test_async_notify_migration_result_noop_for_empty_records() -> None:
+    hass = MagicMock()
+    async_notify_migration_result(hass, _config_entry(), [])
+
+
+def test_async_notify_migration_result_creates_notification() -> None:
+    hass = MagicMock()
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = "sensor.truenas_cpu"
+    entry = _config_entry(
+        data={
+            MIGRATION_LEGACY_ENTRY_ID: "legacy-1",
+            MIGRATION_RECORDS: [_record()],
+            MIGRATION_BACKUP_KEY: "key1",
+        }
+    )
+    legacy_entry = SimpleNamespace(disabled_by=ConfigEntryDisabler.USER)
+    hass.config_entries.async_get_entry.return_value = legacy_entry
+    notify_mock = MagicMock()
+
+    with (
+        patch.object(migration_module.er, "async_get", return_value=ent_reg),
+        patch.object(
+            migration_module.persistent_notification, "async_create", notify_mock
+        ),
+    ):
+        async_notify_migration_result(
+            hass, entry, [_record(entity_id="sensor.truenas_cpu")]
+        )
+
+    notify_mock.assert_called_once()
+    _, kwargs = notify_mock.call_args
+    assert kwargs["notification_id"] == f"truenas_ce_migration_{entry.entry_id}"
+
+
+# ---------------------------
+#   async_rollback_to_legacy
+# ---------------------------
+async def test_async_rollback_to_legacy_inert_when_domain_is_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(migration_module, "DOMAIN", migration_module.LEGACY_DOMAIN)
+    hass = MagicMock()
+    assert await async_rollback_to_legacy(hass, _config_entry()) is False
+
+
+async def test_async_rollback_to_legacy_false_when_no_legacy_id() -> None:
+    hass = MagicMock()
+    entry = _config_entry(data={})
+    assert await async_rollback_to_legacy(hass, entry) is False
+
+
+async def test_async_rollback_to_legacy_false_when_legacy_entry_gone() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_get_entry.return_value = None
+    entry = _config_entry(data={MIGRATION_LEGACY_ENTRY_ID: "legacy-1"})
+    assert await async_rollback_to_legacy(hass, entry) is False
+
+
+async def test_async_rollback_to_legacy_full_flow() -> None:
+    hass = MagicMock()
+    hass.config_entries.async_get_entry.return_value = SimpleNamespace(
+        entry_id="legacy-1"
+    )
+    hass.config_entries.async_remove = AsyncMock()
+    hass.config_entries.async_set_disabled_by = AsyncMock()
+    entry = _config_entry(
+        data={
+            MIGRATION_LEGACY_ENTRY_ID: "legacy-1",
+            MIGRATION_RECORDS: [_record()],
+        }
+    )
+
+    ent_reg = MagicMock()
+    ent_reg.async_get_entity_id.return_value = "sensor.truenas_original"
+    ent_reg.async_get.return_value = None
+
+    with (
+        patch.object(migration_module.er, "async_get", return_value=ent_reg),
+        patch.object(migration_module, "_remove_backups", new=AsyncMock()) as rm_mock,
+    ):
+        result = await async_rollback_to_legacy(hass, entry)
+
+    assert result is True
+    hass.config_entries.async_remove.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_set_disabled_by.assert_awaited_once_with("legacy-1", None)
+    rm_mock.assert_awaited_once_with(hass, keep_key=None)

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,184 @@
+"""Unit tests for repairs.py."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from _fakes import make_coordinator
+
+from custom_components.truenas_ce.const import (
+    CONF_STATISTICS_CLEANUP_IGNORED,
+    MIGRATION_RECORDS,
+)
+from custom_components.truenas_ce.repairs import (
+    MigrationRollbackRepairFlow,
+    StatisticsCleanupRepairFlow,
+    async_create_fix_flow,
+)
+
+
+def _close_coroutine(coro: object) -> None:
+    """Close an unused coroutine so pytest doesn't warn about it never being awaited."""
+    if hasattr(coro, "close"):
+        coro.close()
+
+
+def _make_hass(entry: SimpleNamespace | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=MagicMock(return_value=entry),
+            async_update_entry=MagicMock(),
+        ),
+        async_create_task=MagicMock(side_effect=_close_coroutine),
+    )
+
+
+async def test_create_fix_flow_routes_statistics_issue() -> None:
+    flow = await async_create_fix_flow(
+        SimpleNamespace(), "statistics_orphaned_entry1", None
+    )
+    assert isinstance(flow, StatisticsCleanupRepairFlow)
+    assert flow._entry_id == "entry1"
+
+
+async def test_create_fix_flow_routes_migration_rollback_issue() -> None:
+    flow = await async_create_fix_flow(
+        SimpleNamespace(), "migration_rollback_available_entry2", None
+    )
+    assert isinstance(flow, MigrationRollbackRepairFlow)
+    assert flow._entry_id == "entry2"
+
+
+async def test_statistics_cleanup_init_shows_menu_with_count() -> None:
+    coordinator = make_coordinator()
+    coordinator.orphaned_statistics = ["sensor.a", "sensor.b"]
+    entry = SimpleNamespace(runtime_data=coordinator)
+    flow = StatisticsCleanupRepairFlow("entry1")
+    flow.hass = _make_hass(entry)
+
+    result = await flow.async_step_init()
+    assert result["description_placeholders"] == {"count": "2"}
+
+
+async def test_statistics_cleanup_init_no_coordinator_zero_count() -> None:
+    entry = SimpleNamespace(runtime_data=None)
+    flow = StatisticsCleanupRepairFlow("entry1")
+    flow.hass = _make_hass(entry)
+
+    result = await flow.async_step_init()
+    assert result["description_placeholders"] == {"count": "0"}
+
+
+async def test_statistics_cleanup_fix_clears_statistics() -> None:
+    coordinator = make_coordinator()
+    entry = SimpleNamespace(runtime_data=coordinator)
+    flow = StatisticsCleanupRepairFlow("entry1")
+    flow.hass = _make_hass(entry)
+
+    result = await flow.async_step_fix()
+    coordinator.async_clear_orphaned_statistics.assert_awaited_once()
+    assert result["type"] == "create_entry"
+
+
+async def test_statistics_cleanup_fix_no_coordinator_is_noop() -> None:
+    entry = SimpleNamespace(runtime_data=None)
+    flow = StatisticsCleanupRepairFlow("entry1")
+    flow.hass = _make_hass(entry)
+
+    result = await flow.async_step_fix()
+    assert result["type"] == "create_entry"
+
+
+async def test_statistics_cleanup_ignore_sets_option_and_deletes_issue() -> None:
+    entry = SimpleNamespace(options={}, runtime_data=None)
+    flow = StatisticsCleanupRepairFlow("entry1")
+    flow.hass = _make_hass(entry)
+
+    with patch(
+        "custom_components.truenas_ce.repairs.ir.async_delete_issue"
+    ) as delete_issue:
+        result = await flow.async_step_ignore()
+
+    flow.hass.config_entries.async_update_entry.assert_called_once_with(
+        entry, options={CONF_STATISTICS_CLEANUP_IGNORED: True}
+    )
+    delete_issue.assert_called_once()
+    assert result["type"] == "create_entry"
+
+
+async def test_statistics_cleanup_ignore_no_entry_still_deletes_issue() -> None:
+    flow = StatisticsCleanupRepairFlow("entry1")
+    flow.hass = _make_hass(None)
+
+    with patch(
+        "custom_components.truenas_ce.repairs.ir.async_delete_issue"
+    ) as delete_issue:
+        await flow.async_step_ignore()
+
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+    delete_issue.assert_called_once()
+
+
+async def test_migration_rollback_init_counts_adopted_entities() -> None:
+    entry = SimpleNamespace(data={MIGRATION_RECORDS: ["a", "b", "c"]})
+    flow = MigrationRollbackRepairFlow("entry2")
+    flow.hass = _make_hass(entry)
+
+    result = await flow.async_step_init()
+    assert result["description_placeholders"] == {"count": "3"}
+
+
+async def test_migration_rollback_init_no_entry_zero_count() -> None:
+    flow = MigrationRollbackRepairFlow("entry2")
+    flow.hass = _make_hass(None)
+
+    result = await flow.async_step_init()
+    assert result["description_placeholders"] == {"count": "0"}
+
+
+async def test_migration_rollback_step_schedules_rollback_task() -> None:
+    entry = SimpleNamespace(data={})
+    flow = MigrationRollbackRepairFlow("entry2")
+    flow.hass = _make_hass(entry)
+
+    with (
+        patch(
+            "custom_components.truenas_ce.repairs.ir.async_delete_issue"
+        ) as delete_issue,
+        patch(
+            "custom_components.truenas_ce.repairs.async_rollback_to_legacy",
+            new=AsyncMock(),
+        ),
+    ):
+        result = await flow.async_step_rollback()
+
+    flow.hass.async_create_task.assert_called_once()
+    delete_issue.assert_called_once()
+    assert result["type"] == "create_entry"
+
+
+async def test_migration_rollback_step_no_entry_skips_task() -> None:
+    flow = MigrationRollbackRepairFlow("entry2")
+    flow.hass = _make_hass(None)
+
+    with patch(
+        "custom_components.truenas_ce.repairs.ir.async_delete_issue"
+    ) as delete_issue:
+        await flow.async_step_rollback()
+
+    flow.hass.async_create_task.assert_not_called()
+    delete_issue.assert_called_once()
+
+
+async def test_migration_rollback_ignore_deletes_issue() -> None:
+    flow = MigrationRollbackRepairFlow("entry2")
+    flow.hass = _make_hass(None)
+
+    with patch(
+        "custom_components.truenas_ce.repairs.ir.async_delete_issue"
+    ) as delete_issue:
+        result = await flow.async_step_ignore()
+
+    delete_issue.assert_called_once()
+    assert result["type"] == "create_entry"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,785 @@
+"""Unit tests for sensor.py."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from _fakes import make_config_entry, make_coordinator
+from homeassistant.const import UnitOfInformation
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from custom_components.truenas_ce import sensor as sensor_mod
+from custom_components.truenas_ce.const import CONF_DATA_UNIT
+from custom_components.truenas_ce.sensor import (
+    TrueNASAlertSensor,
+    TrueNASAppStatsSensor,
+    TrueNASCertExpirySensor,
+    TrueNASCloudsyncSensor,
+    TrueNASDatasetSensor,
+    TrueNASDiskSensor,
+    TrueNASReplicationSensor,
+    TrueNASRsyncSensor,
+    TrueNASSensor,
+    TrueNASSnapshotTaskSensor,
+    TrueNASUptimeSensor,
+    _compose_app_network_uid,
+    _discover_app_stats,
+    _discover_network_sensors,
+    _discover_standard_sensor,
+    _maybe_discover_app_stats_sensor,
+    _parse_app_network_uid,
+    _resolve_app_network_data,
+)
+from custom_components.truenas_ce.sensor_types import TrueNASSensorEntityDescription
+
+_PLAIN_DESC = TrueNASSensorEntityDescription(
+    key="k", name="N", data_path="disk", data_attribute="value"
+)
+
+
+def _make_sensor(
+    cls,
+    data: dict,
+    path: str = "disk",
+    desc: TrueNASSensorEntityDescription | None = None,
+):
+    description = desc or TrueNASSensorEntityDescription(
+        key="k", name="N", data_path=path, data_attribute="value"
+    )
+    coordinator = make_coordinator(data={path: {"o1": data}})
+    return cls(coordinator, description, "o1")
+
+
+# ---------------------------
+#   _parse_app_network_uid / _compose_app_network_uid / _resolve_app_network_data
+# ---------------------------
+def test_compose_and_parse_roundtrip() -> None:
+    uid = _compose_app_network_uid("plex", "eth0")
+    assert uid == "plex::eth0"
+    assert _parse_app_network_uid(uid) == ("plex", "eth0")
+
+
+@pytest.mark.parametrize("uid", ["no-separator", "::eth0", "plex::", "::"])
+def test_parse_app_network_uid_malformed_returns_none_none(uid: str) -> None:
+    assert _parse_app_network_uid(uid) == (None, None)
+
+
+def test_resolve_app_network_data_malformed_uid_returns_none() -> None:
+    assert _resolve_app_network_data("bad-uid", {}) is None
+
+
+def test_resolve_app_network_data_unknown_base_returns_none() -> None:
+    assert _resolve_app_network_data("plex::eth0", {}) is None
+
+
+def test_resolve_app_network_data_networks_not_list_returns_none() -> None:
+    app_stats = {"plex": {"networks": "not-a-list"}}
+    assert _resolve_app_network_data("plex::eth0", app_stats) is None
+
+
+def test_resolve_app_network_data_no_matching_interface_returns_none() -> None:
+    app_stats = {"plex": {"networks": [{"interface_name": "eth1"}]}}
+    assert _resolve_app_network_data("plex::eth0", app_stats) is None
+
+
+def test_resolve_app_network_data_returns_merged_payload() -> None:
+    app_stats = {
+        "plex": {"app_name": "plex", "networks": [{"interface_name": "eth0", "rx": 5}]}
+    }
+    result = _resolve_app_network_data("plex::eth0", app_stats)
+    assert result == {
+        "app_name": "plex",
+        "networks": app_stats["plex"]["networks"],
+        "interface_name": "eth0",
+        "rx": 5,
+    }
+
+
+# ---------------------------
+#   _discover_network_sensors / _discover_standard_sensor /
+#   _maybe_discover_app_stats_sensor
+# ---------------------------
+def _net_desc(key: str = "app_stats_network_rx") -> TrueNASSensorEntityDescription:
+    return TrueNASSensorEntityDescription(key=key, name="RX", data_path="app_stats")
+
+
+def test_discover_network_sensors_ignores_non_list_networks() -> None:
+    entities: list = []
+    _discover_network_sensors(
+        _net_desc(), "plex", {"networks": "bad"}, "inst", set(), entities, MagicMock()
+    )
+    assert not entities
+
+
+def test_discover_network_sensors_ignores_non_dict_and_missing_name() -> None:
+    entities: list = []
+    app_data = {"networks": ["not-a-dict", {}, {"interface_name": ""}]}
+    _discover_network_sensors(
+        _net_desc(), "plex", app_data, "inst", set(), entities, MagicMock()
+    )
+    assert not entities
+
+
+def test_discover_network_sensors_creates_entity_and_skips_loaded() -> None:
+    entities: list = []
+    app_data = {"networks": [{"interface_name": "eth0"}]}
+    coord = make_coordinator()
+    loaded: set[str] = set()
+    _discover_network_sensors(
+        _net_desc(), "plex", app_data, "TrueNAS", loaded, entities, coord
+    )
+    assert len(entities) == 1
+
+    entities2: list = []
+    _discover_network_sensors(
+        _net_desc(), "plex", app_data, "TrueNAS", loaded, entities2, coord
+    )
+    assert not entities2
+
+
+def test_discover_standard_sensor_creates_and_skips_loaded() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_cpu", name="CPU", data_path="app_stats"
+    )
+    entities: list = []
+    coord = make_coordinator()
+    loaded: set[str] = set()
+    _discover_standard_sensor(desc, "plex", "TrueNAS", loaded, entities, coord)
+    assert len(entities) == 1
+
+    entities2: list = []
+    _discover_standard_sensor(desc, "plex", "TrueNAS", loaded, entities2, coord)
+    assert not entities2
+
+
+def test_maybe_discover_app_stats_sensor_skips_empty_app_data() -> None:
+    entities: list = []
+    _maybe_discover_app_stats_sensor(
+        _net_desc(), "plex", {}, "inst", set(), entities, MagicMock()
+    )
+    assert not entities
+
+
+def test_maybe_discover_app_stats_sensor_routes_network_key() -> None:
+    entities: list = []
+    coord = make_coordinator()
+    app_data = {"networks": [{"interface_name": "eth0"}]}
+    _maybe_discover_app_stats_sensor(
+        _net_desc(), "plex", app_data, "inst", set(), entities, coord
+    )
+    assert len(entities) == 1
+    assert entities[0]._uid == "plex::eth0"
+
+
+def test_maybe_discover_app_stats_sensor_routes_standard_key() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_cpu", name="CPU", data_path="app_stats"
+    )
+    entities: list = []
+    coord = make_coordinator()
+    _maybe_discover_app_stats_sensor(
+        desc, "plex", {"cpu": 1}, "inst", set(), entities, coord
+    )
+    assert len(entities) == 1
+    assert entities[0]._uid == "plex"
+
+
+def test_discover_app_stats_adds_new_entities_via_callback() -> None:
+    coord = make_coordinator(data={"app_stats": {"plex": {"cpu": 1}}})
+    platform = SimpleNamespace(entities={})
+    add_entities = MagicMock()
+    with patch.object(
+        sensor_mod,
+        "_app_stats_descriptions",
+        return_value=[
+            TrueNASSensorEntityDescription(
+                key="app_stats_cpu", name="CPU", data_path="app_stats"
+            )
+        ],
+    ):
+        _discover_app_stats(platform, coord, add_entities)
+    add_entities.assert_called_once()
+    assert len(add_entities.call_args.args[0]) == 1
+
+
+def test_discover_app_stats_no_entities_skips_callback() -> None:
+    coord = make_coordinator(data={"app_stats": {}})
+    platform = SimpleNamespace(entities={})
+    add_entities = MagicMock()
+    _discover_app_stats(platform, coord, add_entities)
+    add_entities.assert_not_called()
+
+
+# ---------------------------
+#   TrueNASSensor
+# ---------------------------
+def test_native_value_returns_data_attribute() -> None:
+    sensor = _make_sensor(TrueNASSensor, {"value": 42})
+    assert sensor.native_value == 42
+
+
+def test_native_unit_of_measurement_plain() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k",
+        name="N",
+        data_path="disk",
+        data_attribute="value",
+        native_unit_of_measurement="MB",
+    )
+    sensor = _make_sensor(TrueNASSensor, {"value": 1}, desc=desc)
+    assert sensor.native_unit_of_measurement == "MB"
+
+
+def test_native_unit_of_measurement_none_when_not_configured() -> None:
+    sensor = _make_sensor(TrueNASSensor, {"value": 1})
+    assert sensor.native_unit_of_measurement is None
+
+
+def test_native_unit_of_measurement_data_prefixed_present() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k",
+        name="N",
+        data_path="disk",
+        data_attribute="value",
+        native_unit_of_measurement="data__uom",
+    )
+    sensor = _make_sensor(TrueNASSensor, {"value": 1, "uom": "GB"}, desc=desc)
+    assert sensor.native_unit_of_measurement == "GB"
+
+
+def test_native_unit_of_measurement_data_prefixed_missing_falls_back() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k",
+        name="N",
+        data_path="disk",
+        data_attribute="value",
+        native_unit_of_measurement="data__uom",
+    )
+    sensor = _make_sensor(TrueNASSensor, {"value": 1}, desc=desc)
+    assert sensor.native_unit_of_measurement == "data__uom"
+
+
+def test_init_scales_gib_suggested_unit_from_options() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k",
+        name="N",
+        data_path="disk",
+        data_attribute="value",
+        suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
+    )
+    entry = make_config_entry(options={CONF_DATA_UNIT: "GiB"})
+    coordinator = make_coordinator(
+        data={"disk": {"o1": {"value": 5 * 1024**3}}}, config_entry=entry
+    )
+    sensor = TrueNASSensor(coordinator, desc, "o1")
+    assert sensor._attr_suggested_unit_of_measurement == UnitOfInformation.GIBIBYTES
+
+
+def test_init_scales_gb_suggested_unit_from_entry_data_fallback() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k",
+        name="N",
+        data_path="disk",
+        data_attribute="value",
+        suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
+    )
+    entry = make_config_entry(data={CONF_DATA_UNIT: "GB"})
+    coordinator = make_coordinator(
+        data={"disk": {"o1": {"value": 5 * 1000**3}}}, config_entry=entry
+    )
+    sensor = TrueNASSensor(coordinator, desc, "o1")
+    assert sensor._attr_suggested_unit_of_measurement == UnitOfInformation.GIGABYTES
+
+
+def test_init_does_not_scale_non_gb_suggested_unit() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="k",
+        name="N",
+        data_path="disk",
+        data_attribute="value",
+        suggested_unit_of_measurement="MB/s",
+    )
+    sensor = _make_sensor(TrueNASSensor, {"value": 1}, desc=desc)
+    assert sensor._attr_suggested_unit_of_measurement == "MB/s"
+
+
+# ---------------------------
+#   TrueNASCertExpirySensor
+# ---------------------------
+def test_cert_expiry_none_when_missing() -> None:
+    sensor = _make_sensor(TrueNASCertExpirySensor, {})
+    assert sensor.native_value is None
+
+
+def test_cert_expiry_days_when_under_a_year() -> None:
+    sensor = _make_sensor(TrueNASCertExpirySensor, {"value": 100})
+    assert sensor.native_value == 100
+    assert sensor.native_unit_of_measurement.value == "d"
+
+
+def test_cert_expiry_years_when_over_a_year() -> None:
+    sensor = _make_sensor(TrueNASCertExpirySensor, {"value": 730})
+    assert sensor.native_value == 2.0
+    assert sensor.native_unit_of_measurement.value == "y"
+
+
+# ---------------------------
+#   TrueNASDiskSensor
+# ---------------------------
+@pytest.mark.parametrize(
+    ("devname", "disk_type", "expected"),
+    [
+        ("nvme0n1", "SSD", "mdi:expansion-card-variant"),
+        ("sda", "HDD", "mdi:harddisk"),
+        ("sda", "SSD", "mdi:chip"),
+        ("sda", "SED", "mdi:chip"),
+        ("sda", "WEIRD", "mdi:harddisk"),
+    ],
+)
+def test_disk_sensor_icon(devname: str, disk_type: str, expected: str) -> None:
+    sensor = _make_sensor(TrueNASDiskSensor, {"devname": devname, "type": disk_type})
+    assert sensor.icon == expected
+
+
+# ---------------------------
+#   TrueNASUptimeSensor
+# ---------------------------
+def test_uptime_native_value_positive() -> None:
+    sensor = _make_sensor(TrueNASUptimeSensor, {"value": 1735689600})
+    assert isinstance(sensor.native_value, datetime)
+
+
+def test_uptime_native_value_zero_is_none() -> None:
+    sensor = _make_sensor(TrueNASUptimeSensor, {"value": 0})
+    assert sensor.native_value is None
+
+
+async def test_uptime_restart_calls_reboot() -> None:
+    sensor = _make_sensor(TrueNASUptimeSensor, {})
+    await sensor.restart()
+    sensor.coordinator.api.query.assert_awaited_once_with(
+        "system.reboot", ["Home Assistant Integration"]
+    )
+
+
+async def test_uptime_stop_calls_shutdown() -> None:
+    sensor = _make_sensor(TrueNASUptimeSensor, {})
+    await sensor.stop()
+    sensor.coordinator.api.query.assert_awaited_once_with(
+        "system.shutdown", ["Home Assistant Integration"]
+    )
+
+
+async def test_uptime_refresh_calls_coordinator_refresh() -> None:
+    sensor = _make_sensor(TrueNASUptimeSensor, {})
+    await sensor.refresh()
+    sensor.coordinator.async_refresh.assert_awaited_once()
+
+
+# ---------------------------
+#   TrueNASAlertSensor
+# ---------------------------
+async def test_alert_dismiss_without_uuid_raises() -> None:
+    sensor = _make_sensor(TrueNASAlertSensor, {})
+    with pytest.raises(ServiceValidationError, match="uuid"):
+        await sensor.dismiss()
+
+
+async def test_alert_dismiss_with_uuid_calls_query_and_refreshes() -> None:
+    sensor = _make_sensor(TrueNASAlertSensor, {})
+    await sensor.dismiss(uuid="u1")
+    sensor.coordinator.api.query.assert_awaited_once_with("alert.dismiss", ["u1"])
+    sensor.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_alert_restore_without_uuid_raises() -> None:
+    sensor = _make_sensor(TrueNASAlertSensor, {})
+    with pytest.raises(ServiceValidationError, match="uuid"):
+        await sensor.restore()
+
+
+async def test_alert_restore_with_uuid_calls_query_and_refreshes() -> None:
+    sensor = _make_sensor(TrueNASAlertSensor, {})
+    await sensor.restore(uuid="u2")
+    sensor.coordinator.api.query.assert_awaited_once_with("alert.restore", ["u2"])
+    sensor.coordinator.async_refresh.assert_awaited_once()
+
+
+# ---------------------------
+#   TrueNASRsyncSensor / TrueNASReplicationSensor / TrueNASSnapshotTaskSensor
+# ---------------------------
+async def test_rsync_start_skips_when_running() -> None:
+    sensor = _make_sensor(TrueNASRsyncSensor, {"state": "RUNNING", "id": 1})
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_not_awaited()
+
+
+async def test_rsync_start_runs_task() -> None:
+    sensor = _make_sensor(TrueNASRsyncSensor, {"state": "FINISHED", "id": 1})
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_awaited_once_with(
+        "rsynctask.run", 1, "rsynctask"
+    )
+
+
+async def test_replication_start_skips_when_waiting() -> None:
+    sensor = _make_sensor(TrueNASReplicationSensor, {"state": "WAITING", "id": 2})
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_not_awaited()
+
+
+async def test_replication_start_runs_task() -> None:
+    sensor = _make_sensor(TrueNASReplicationSensor, {"state": "FINISHED", "id": 2})
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_awaited_once_with(
+        "replication.run", 2, "replication"
+    )
+
+
+async def test_snapshottask_start_skips_when_running() -> None:
+    sensor = _make_sensor(TrueNASSnapshotTaskSensor, {"state": "RUNNING", "id": 3})
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_not_awaited()
+
+
+async def test_snapshottask_start_runs_task() -> None:
+    sensor = _make_sensor(TrueNASSnapshotTaskSensor, {"state": "FINISHED", "id": 3})
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_awaited_once_with(
+        "pool.snapshottask.run", 3, "snapshottask"
+    )
+
+
+# ---------------------------
+#   TrueNASCloudsyncSensor
+# ---------------------------
+def _make_cloudsync(data: dict | None = None) -> TrueNASCloudsyncSensor:
+    return _make_sensor(
+        TrueNASCloudsyncSensor,
+        {"id": 9, "description": "backup", **(data or {})},
+        path="cloudsync",
+    )
+
+
+async def test_cloudsync_start_invalid_job_logs_and_returns() -> None:
+    sensor = _make_cloudsync()
+    sensor.coordinator.api.query.return_value = []
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_not_awaited()
+
+
+async def test_cloudsync_start_already_running_skips() -> None:
+    sensor = _make_cloudsync()
+    sensor.coordinator.api.query.return_value = [{"job": {"state": "RUNNING"}}]
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_not_awaited()
+
+
+async def test_cloudsync_start_success() -> None:
+    sensor = _make_cloudsync()
+    sensor.coordinator.api.query.return_value = [{"job": {"state": "FINISHED"}}]
+    await sensor.start()
+    sensor.coordinator.async_run_task.assert_awaited_once_with(
+        "cloudsync.sync", 9, "cloudsync"
+    )
+
+
+async def test_cloudsync_stop_invalid_job_returns() -> None:
+    sensor = _make_cloudsync()
+    sensor.coordinator.api.query.return_value = []
+    await sensor.stop()
+    sensor.coordinator.api.query.assert_awaited_once()
+
+
+async def test_cloudsync_stop_not_running_returns() -> None:
+    sensor = _make_cloudsync()
+    sensor.coordinator.api.query.return_value = [{"job": {"state": "FINISHED"}}]
+    await sensor.stop()
+    sensor.coordinator.api.query.assert_awaited_once()
+
+
+async def test_cloudsync_stop_success() -> None:
+    sensor = _make_cloudsync()
+    sensor.coordinator.api.query.side_effect = [[{"job": {"state": "RUNNING"}}], None]
+    await sensor.stop()
+    sensor.coordinator.api.query.assert_awaited_with("cloudsync.abort", [9])
+
+
+# ---------------------------
+#   TrueNASDatasetSensor
+# ---------------------------
+def _make_dataset(data: dict | None = None) -> TrueNASDatasetSensor:
+    return _make_sensor(
+        TrueNASDatasetSensor,
+        {"id": "tank/data", "name": "tank/data", **(data or {})},
+        path="dataset",
+    )
+
+
+async def test_dataset_snapshot_success_uses_pool_snapshot() -> None:
+    sensor = _make_dataset()
+    sensor.coordinator.api.query.return_value = {"id": 1}
+    await sensor.snapshot()
+    sensor.coordinator.api.query.assert_awaited_once()
+    assert sensor.coordinator.api.query.call_args.args[0] == "pool.snapshot.create"
+
+
+async def test_dataset_snapshot_falls_back_to_zfs_snapshot() -> None:
+    sensor = _make_dataset()
+    sensor.coordinator.api.query.side_effect = [None, {"id": 1}]
+    await sensor.snapshot()
+    assert sensor.coordinator.api.query.await_count == 2
+    assert sensor.coordinator.api.query.call_args.args[0] == "zfs.snapshot.create"
+
+
+async def test_dataset_snapshot_both_fail_raises() -> None:
+    sensor = _make_dataset()
+    sensor.coordinator.api.query.side_effect = [None, None]
+    sensor.coordinator.api.error = "no permission"
+    with pytest.raises(HomeAssistantError, match="no permission"):
+        await sensor.snapshot()
+
+
+async def test_dataset_lock_rejects_unencrypted() -> None:
+    sensor = _make_dataset({"encrypted": False})
+    with pytest.raises(ServiceValidationError, match="not encrypted"):
+        await sensor.lock()
+
+
+async def test_dataset_lock_already_locked_returns_early() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": True})
+    await sensor.lock()
+    sensor.coordinator.async_refresh.assert_awaited_once()
+    sensor.coordinator.api.query.assert_not_awaited()
+
+
+async def test_dataset_lock_runs_job_to_success() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": False})
+    sensor.coordinator.api.query.side_effect = [
+        42,
+        {"state": "SUCCESS", "result": None},
+    ]
+    await sensor.lock(force_umount=True)
+    assert sensor.coordinator.async_refresh.await_count == 2
+
+
+async def test_dataset_unlock_rejects_unencrypted() -> None:
+    sensor = _make_dataset({"encrypted": False})
+    with pytest.raises(ServiceValidationError, match="not encrypted"):
+        await sensor.unlock(passphrase="secret")
+
+
+async def test_dataset_unlock_no_passphrase_raises() -> None:
+    sensor = _make_dataset({"encrypted": True})
+    sensor.coordinator.config_entry.data.pop("dataset_passphrases", None)
+    with pytest.raises(ServiceValidationError, match="No passphrase"):
+        await sensor.unlock()
+
+
+async def test_dataset_unlock_already_unlocked_returns_early() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": False})
+    await sensor.unlock(passphrase="secret")
+    sensor.coordinator.async_refresh.assert_awaited_once()
+    sensor.coordinator.api.query.assert_not_awaited()
+
+
+async def test_dataset_unlock_uses_stored_passphrase() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": True})
+    sensor.coordinator.config_entry.data["dataset_passphrases"] = {
+        "tank/data": "stored-secret"
+    }
+    sensor.coordinator.api.query.side_effect = [42, {"state": "SUCCESS", "result": {}}]
+    await sensor.unlock()
+    job_call = sensor.coordinator.api.query.call_args_list[0]
+    assert job_call.args[1][1]["datasets"][0]["passphrase"] == "stored-secret"
+
+
+async def test_dataset_unlock_job_success_with_failed_entries_raises() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": True})
+    sensor.coordinator.api.query.side_effect = [
+        42,
+        {
+            "state": "SUCCESS",
+            "result": {"failed": {"tank/data": {"error": "bad passphrase"}}},
+        },
+    ]
+    with pytest.raises(HomeAssistantError, match="bad passphrase"):
+        await sensor.unlock(passphrase="wrong")
+
+
+async def test_dataset_unlock_job_failed_state_raises() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": True})
+    sensor.coordinator.api.query.side_effect = [
+        42,
+        {"state": "FAILED", "error": "disk error"},
+    ]
+    with pytest.raises(HomeAssistantError, match="disk error"):
+        await sensor.unlock(passphrase="secret")
+
+
+async def test_dataset_run_job_invalid_job_id_raises() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": True})
+    sensor.coordinator.api.query.return_value = None
+    with pytest.raises(HomeAssistantError, match="invalid job id"):
+        await sensor.unlock(passphrase="secret")
+
+
+async def test_dataset_wait_for_job_missing_job_exhausts_retries() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": True})
+    sensor.coordinator.api.query.side_effect = [42, None, None, None, None, None]
+    with (
+        patch("custom_components.truenas_ce.sensor.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(HomeAssistantError, match="not found"),
+    ):
+        await sensor.unlock(passphrase="secret")
+
+
+async def test_dataset_passphrase_set_stores_in_config_entry() -> None:
+    sensor = _make_dataset()
+    sensor.hass = sensor.coordinator.hass
+    await sensor.passphrase_set("new-secret")
+    sensor.coordinator.hass.config_entries.async_update_entry.assert_called_once()
+
+
+async def test_dataset_passphrase_set_no_name_raises() -> None:
+    sensor = _make_dataset({"name": None})
+    sensor._data["name"] = None
+    with pytest.raises(ServiceValidationError, match="unknown"):
+        await sensor.passphrase_set("secret")
+
+
+# ---------------------------
+#   TrueNASAppStatsSensor
+# ---------------------------
+def _app_stats_desc(key: str = "app_stats_cpu") -> TrueNASSensorEntityDescription:
+    return TrueNASSensorEntityDescription(
+        key=key, name="CPU", data_path="app_stats", data_attribute="cpu"
+    )
+
+
+def test_app_stats_standard_native_value_and_name() -> None:
+    coordinator = make_coordinator(
+        data={"app_stats": {"plex": {"app_name": "Plex", "cpu": 12.5}}}
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, _app_stats_desc(), "plex")
+    assert sensor.native_value == 12.5
+    assert sensor.name == "Plex CPU"
+    assert sensor.unique_id == "truenas-app_stats_cpu-plex"
+    assert sensor.available is True
+
+
+def test_app_stats_native_value_none_when_no_data() -> None:
+    coordinator = make_coordinator(data={"app_stats": {}})
+    sensor = TrueNASAppStatsSensor(coordinator, _app_stats_desc(), "plex")
+    assert sensor.native_value is None
+
+
+def test_app_stats_native_value_none_when_no_data_attribute() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_cpu", name="CPU", data_path="app_stats"
+    )
+    coordinator = make_coordinator(data={"app_stats": {"plex": {"app_name": "Plex"}}})
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex")
+    assert sensor.native_value is None
+
+
+def test_app_stats_network_native_value_converts_bytes_to_kib() -> None:
+    coordinator = make_coordinator(
+        data={
+            "app_stats": {
+                "plex": {
+                    "app_name": "Plex",
+                    "networks": [{"interface_name": "eth0", "rx": 2048}],
+                }
+            }
+        }
+    )
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx",
+        name="RX",
+        data_path="app_stats",
+        data_attribute="rx",
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex::eth0")
+    assert sensor.native_value == 2.0
+
+
+def test_app_stats_network_native_value_invalid_conversion_returns_none() -> None:
+    coordinator = make_coordinator(
+        data={
+            "app_stats": {
+                "plex": {
+                    "app_name": "Plex",
+                    "networks": [{"interface_name": "eth0", "rx": "bad"}],
+                }
+            }
+        }
+    )
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx",
+        name="RX",
+        data_path="app_stats",
+        data_attribute="rx",
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex::eth0")
+    assert sensor.native_value is None
+
+
+def test_app_stats_network_name_resolved() -> None:
+    coordinator = make_coordinator(
+        data={
+            "app_stats": {
+                "plex": {"app_name": "Plex", "networks": [{"interface_name": "eth0"}]}
+            }
+        }
+    )
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx", name="RX", data_path="app_stats"
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex::eth0")
+    assert sensor.name == "Plex eth0 RX"
+
+
+def test_app_stats_network_name_unresolved_uses_base_uid() -> None:
+    coordinator = make_coordinator(data={"app_stats": {}})
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx", name="RX", data_path="app_stats"
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex::eth0")
+    assert sensor.name == "plex RX"
+
+
+def test_app_stats_network_name_malformed_uid_returns_none() -> None:
+    coordinator = make_coordinator(data={"app_stats": {}})
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx", name="RX", data_path="app_stats"
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "malformed")
+    assert sensor.name is None
+
+
+def test_app_stats_extra_state_attributes_network() -> None:
+    coordinator = make_coordinator(
+        data={
+            "app_stats": {
+                "plex": {"app_name": "Plex", "networks": [{"interface_name": "eth0"}]}
+            }
+        }
+    )
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx", name="RX", data_path="app_stats"
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex::eth0")
+    attrs = sensor.extra_state_attributes
+    assert attrs["app_name"] == "Plex"
+    assert attrs["interface_name"] == "eth0"
+
+
+def test_app_stats_extra_state_attributes_no_data_returns_attribution_only() -> None:
+    coordinator = make_coordinator(data={"app_stats": {}})
+    sensor = TrueNASAppStatsSensor(coordinator, _app_stats_desc(), "plex")
+    attrs = sensor.extra_state_attributes
+    assert "app_name" not in attrs

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,92 @@
+"""Unit tests for switch.py."""
+
+from __future__ import annotations
+
+from _fakes import make_coordinator
+
+from custom_components.truenas_ce.switch import (
+    TrueNASCloudsyncSwitch,
+    TrueNASCronjobSwitch,
+    TrueNASServiceSwitch,
+)
+from custom_components.truenas_ce.switch_types import TrueNASSwitchEntityDescription
+
+_SERVICE_DESC = TrueNASSwitchEntityDescription(
+    key="service_switch", name=None, data_path="service", data_is_on="running"
+)
+_CLOUDSYNC_DESC = TrueNASSwitchEntityDescription(
+    key="cloudsync_switch", name=None, data_path="cloudsync", data_is_on="enabled"
+)
+_CRONJOB_DESC = TrueNASSwitchEntityDescription(
+    key="cronjob_switch", name=None, data_path="cronjob", data_is_on="enabled"
+)
+
+
+def test_service_switch_is_on_true() -> None:
+    coordinator = make_coordinator(
+        data={"service": {"s1": {"running": True, "service": "ssh"}}}
+    )
+    switch = TrueNASServiceSwitch(coordinator, _SERVICE_DESC, "s1")
+    assert switch.is_on is True
+
+
+def test_service_switch_is_on_false_when_missing() -> None:
+    coordinator = make_coordinator(data={"service": {"s1": {"service": "ssh"}}})
+    switch = TrueNASServiceSwitch(coordinator, _SERVICE_DESC, "s1")
+    assert switch.is_on is False
+
+
+async def test_service_switch_turn_on_calls_service_start_and_refreshes() -> None:
+    coordinator = make_coordinator(data={"service": {"s1": {"service": "ssh"}}})
+    switch = TrueNASServiceSwitch(coordinator, _SERVICE_DESC, "s1")
+    await switch.async_turn_on()
+    coordinator.api.query.assert_awaited_once_with("service.start", ["ssh"])
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_service_switch_turn_off_calls_service_stop_and_refreshes() -> None:
+    coordinator = make_coordinator(data={"service": {"s1": {"service": "ssh"}}})
+    switch = TrueNASServiceSwitch(coordinator, _SERVICE_DESC, "s1")
+    await switch.async_turn_off()
+    coordinator.api.query.assert_awaited_once_with("service.stop", ["ssh"])
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_cloudsync_switch_turn_on_calls_update_method() -> None:
+    coordinator = make_coordinator(data={"cloudsync": {"c1": {"id": 3}}})
+    switch = TrueNASCloudsyncSwitch(coordinator, _CLOUDSYNC_DESC, "c1")
+    await switch.async_turn_on()
+    coordinator.api.query.assert_awaited_once_with(
+        "cloudsync.update", [3, {"enabled": True}]
+    )
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_cloudsync_switch_turn_off_calls_update_method() -> None:
+    coordinator = make_coordinator(data={"cloudsync": {"c1": {"id": 3}}})
+    switch = TrueNASCloudsyncSwitch(coordinator, _CLOUDSYNC_DESC, "c1")
+    await switch.async_turn_off()
+    coordinator.api.query.assert_awaited_once_with(
+        "cloudsync.update", [3, {"enabled": False}]
+    )
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_cronjob_switch_turn_on_calls_update_method() -> None:
+    coordinator = make_coordinator(data={"cronjob": {"j1": {"id": 9}}})
+    switch = TrueNASCronjobSwitch(coordinator, _CRONJOB_DESC, "j1")
+    await switch.async_turn_on()
+    coordinator.api.query.assert_awaited_once_with(
+        "cronjob.update", [9, {"enabled": True}]
+    )
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_cronjob_switch_turn_off_calls_update_method() -> None:
+    coordinator = make_coordinator(data={"cronjob": {"j1": {"id": 9}}})
+    switch = TrueNASCronjobSwitch(coordinator, _CRONJOB_DESC, "j1")
+    await switch.async_turn_off()
+    coordinator.api.query.assert_awaited_once_with(
+        "cronjob.update", [9, {"enabled": False}]
+    )
+    coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,135 @@
+"""Unit tests for update.py."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import make_coordinator
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.truenas_ce.update import TrueNASAppUpdate, TrueNASUpdate
+from custom_components.truenas_ce.update_types import TrueNASUpdateEntityDescription
+
+_SYSTEM_DESC = TrueNASUpdateEntityDescription(
+    key="system_update", name=None, data_path="system_info", title="TrueNAS"
+)
+_APP_DESC = TrueNASUpdateEntityDescription(key="app_update", name=None, data_path="app")
+
+
+def _make_system_update(data: dict | None = None) -> TrueNASUpdate:
+    coordinator = make_coordinator(data={"system_info": {**data} if data else {}})
+    return TrueNASUpdate(coordinator, _SYSTEM_DESC)
+
+
+def _make_app_update(data: dict | None = None) -> TrueNASAppUpdate:
+    coordinator = make_coordinator(data={"app": {"a1": (data or {})}})
+    return TrueNASAppUpdate(coordinator, _APP_DESC, "a1")
+
+
+def test_system_update_installed_and_latest_version() -> None:
+    update = _make_system_update({"version": "25.10.4", "update_version": "25.10.5"})
+    assert update.installed_version == "25.10.4"
+    assert update.latest_version == "25.10.5"
+
+
+def test_system_update_in_progress_and_percentage() -> None:
+    update = _make_system_update({"update_state": "RUNNING", "update_progress": 42})
+    assert update.in_progress is True
+    assert update.update_percentage == 42
+
+
+def test_system_update_not_running_has_no_percentage() -> None:
+    update = _make_system_update({"update_state": "IDLE"})
+    assert update.in_progress is False
+    assert update.update_percentage is None
+
+
+async def test_system_update_async_install_success() -> None:
+    update = _make_system_update({})
+    update.coordinator.api.query.return_value = 555
+    await update.async_install(version=None, backup=False)
+    update.coordinator.api.query.assert_awaited_once_with(
+        "update.update", {"reboot": True}
+    )
+    assert update._data["update_jobid"] == 555
+    update.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_system_update_async_install_failure_raises() -> None:
+    update = _make_system_update({})
+    update.coordinator.api.query.return_value = None
+    update.coordinator.api.error = "job rejected"
+    with pytest.raises(HomeAssistantError, match="job rejected"):
+        await update.async_install(version=None, backup=False)
+
+
+async def test_system_update_options_updated_is_noop() -> None:
+    update = _make_system_update({})
+    await update.options_updated()
+
+
+def test_app_update_installed_version() -> None:
+    update = _make_app_update({"version": "1.2.3"})
+    assert update.installed_version == "1.2.3"
+
+
+def test_app_update_latest_version_no_update_available() -> None:
+    update = _make_app_update({"version": "1.2.3", "update_available": False})
+    assert update.latest_version == "1.2.3"
+
+
+def test_app_update_latest_version_unknown_catalog_shows_image_update() -> None:
+    update = _make_app_update(
+        {"version": "1.2.3", "update_available": True, "latest_version": "unknown"}
+    )
+    assert update.latest_version == "1.2.3 (image update)"
+
+
+def test_app_update_latest_version_unknown_no_installed_shows_image_update() -> None:
+    update = _make_app_update({"update_available": True, "latest_version": "unknown"})
+    assert update.latest_version == "image update"
+
+
+def test_app_update_latest_version_same_as_installed_shows_image_update() -> None:
+    update = _make_app_update(
+        {"version": "1.2.3", "update_available": True, "latest_version": "1.2.3"}
+    )
+    assert update.latest_version == "1.2.3 (image update)"
+
+
+def test_app_update_latest_version_real_catalog_version() -> None:
+    update = _make_app_update(
+        {"version": "1.2.3", "update_available": True, "latest_version": "1.3.0"}
+    )
+    assert update.latest_version == "1.3.0"
+
+
+def test_app_update_title_and_in_progress() -> None:
+    update = _make_app_update({"name": "Plex", "update_jobid": 42})
+    assert update.title == "Plex"
+    assert update.in_progress is True
+
+
+async def test_app_update_async_install_not_running_logs_and_skips() -> None:
+    update = _make_app_update({"id": "a1"})
+    update.coordinator.data["app"] = {"a1": {"state": "STOPPED"}}
+    await update.async_install(version=None, backup=False)
+    update.coordinator.api.query.assert_not_awaited()
+
+
+async def test_app_update_async_install_success() -> None:
+    update = _make_app_update({"id": "a1"})
+    update.coordinator.data["app"] = {"a1": {"state": "RUNNING"}}
+    update.coordinator.api.query.return_value = 99
+    await update.async_install(version=None, backup=False)
+    update.coordinator.api.query.assert_awaited_once_with("app.upgrade", ["a1"])
+    assert update._data["update_jobid"] == 99
+    update.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_app_update_async_install_failure_raises() -> None:
+    update = _make_app_update({"id": "a1"})
+    update.coordinator.data["app"] = {"a1": {"state": "RUNNING"}}
+    update.coordinator.api.query.return_value = None
+    update.coordinator.api.error = "upgrade failed"
+    with pytest.raises(HomeAssistantError, match="upgrade failed"):
+        await update.async_install(version=None, backup=False)


### PR DESCRIPTION
## Proposed change

Adds unit test coverage for the platform modules named in the Silver `test-coverage` quality-scale todo: `entity.py`, `button.py`, `switch.py`, `update.py`, `binary_sensor.py`, `sensor.py`. Each rises from 0-43% to 84-98% local coverage. As a bonus, `diagnostics.py` and `repairs.py` (previously untested) reach 100%.

Tests use a lightweight fake-coordinator (`tests/_fakes.py`, `SimpleNamespace`-based) instead of `pytest-homeassistant-custom-component`, which is incompatible on Windows dev machines (its pytest plugin imports `fcntl`). This mirrors the existing local/CI split already used by `test_config_flow_flows.py`/`test_services.py`.

CI's `pytest` invocation is updated to actually report coverage (`--cov`/`--cov-report=term-missing`), since it previously ran plain `pytest` with no coverage measurement at all despite `pytest-cov` being an installed dev dependency.

A second batch of tests then covers the three lowest-covered modules that remained after the platform-module pass -- `migration.py` (22% -> 99%), `__init__.py` (51% -> 93%) and `coordinator.py` (49% -> 93%) -- using the same `MagicMock`/`SimpleNamespace` approach.

**CI now reports 95% overall coverage** (up from a never-measured baseline), meeting the Silver `test-coverage` requirement. `quality_scale.yaml`'s `test-coverage` entry is updated to `done`, and since all ten Silver rules are now satisfied, `manifest.json`'s `quality_scale` moves from `bronze` to `silver`.

Remaining uncovered lines are `TrueNASCoordinator.__init__` (needs HA's frame helper, only reachable via a running Home Assistant core) and a couple of `entity.py` entity-discovery edge branches -- both exercised by CI's hass-fixture-based test files already, just not fully.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

`quality_scale.yaml`'s `test-coverage` entry is now `done` and `manifest.json`'s `quality_scale` is `silver`, confirmed by the CI-reported 95% total coverage on this PR.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add extensive unit test coverage for the TrueNAS integration, enable coverage reporting in CI, and mark the integration as Silver-quality in Home Assistant metadata.

Enhancements:
- Raise the integration quality_scale from bronze to silver in manifest.json to reflect completed Silver requirements.

Build:
- Update CI pytest invocation to collect coverage for the TrueNAS integration and report missing lines.

CI:
- Adjust test collection skips for hass-based tests when pytest-homeassistant-custom-component is unavailable.

Documentation:
- Update quality_scale.yaml to mark test-coverage as done and explain the remaining untestable edges.

Tests:
- Add unit tests for coordinator lifecycle, statistics/migration handling, and app stats subscription logic.
- Add unit tests for core integration setup/unload, entity base behavior, platform entities (sensors, binary sensors, switches, buttons, updates), diagnostics, and repairs flows.
- Introduce shared SimpleNamespace-based coordinator/config-entry fakes for platform tests and adjust existing config-flow tests for additional cases.
- Add a hass-backed entity-setup test that runs only when pytest-homeassistant-custom-component is available.