### PR TITLE
fix: restore missing TrueNASSnapshotTaskSensor dispatcher entry (v2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,51 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.5.1] — Sensor platform hotfix
+
+### Fixed
+- **Sensor platform failed to load entirely (regression from 2.5.0):** the `snapshottask`
+  sensor description referenced `TrueNASSnapshotTaskSensor`, but the class was missing from
+  `sensor.py`'s dispatcher map. Any config entry monitoring the Snapshots group hit a
+  `KeyError` during platform setup, aborting entity creation for **all** sensors (not just
+  snapshot tasks) and leaving them "Unavailable". Restored the missing dispatcher entry and
+  added a real-`hass` regression test that exercises the dispatcher end to end.
+
+## [2.5.0] — App Monitoring & Automatic Reauthentication
+
+### Added
+- **App resource monitoring (#38):** each running TrueNAS app now exposes live CPU, memory,
+  network RX/TX and block I/O sensors, updated event-driven via TrueNAS's `app.stats`
+  subscription. Toggle the group under *Settings → TrueNAS → Configure → Monitored groups →
+  Apps*.
+- **Automatic reauthentication (#28):** if the stored TrueNAS API key becomes invalid or is
+  revoked, the integration now raises a guided Repair flow to enter a new key — no more silent
+  "unavailable" state and no need to remove/re-add the integration.
+
 ### Changed
-- **Async API client — now powered by `aiotruenas`:** the integration's TrueNAS API layer was
-  rewritten from a synchronous, thread-based WebSocket client to a native `asyncio` client built
-  on the new [`aiotruenas`](https://github.com/kayl-codes/aiotruenas) library (a standalone,
+- **Async API client — now powered by `aiotruenas` (#27):** the integration's TrueNAS API layer
+  was rewritten from a synchronous, thread-based WebSocket client to a native `asyncio` client
+  built on the new [`aiotruenas`](https://github.com/kayl-codes/aiotruenas) library (a standalone,
   independently maintained TrueNAS client). This also moves the integration onto TrueNAS's modern
   JSON-RPC 2.0 **`/api/current`** endpoint, replacing the legacy `/websocket` endpoint the old
   client spoke. Purely an internal architecture change — connection behavior, error messages,
   sensors and actions all work exactly as before. If you run TrueNAS behind a reverse proxy with a
   path-specific bypass rule, update it from `/websocket` to `/api/current` (see
   [Remote access, reverse proxies & Cloudflare](README.md#remote-access-reverse-proxies--cloudflare)).
+- **Action error reporting (#40):** entity actions (VM/container/app control, service control,
+  cloudsync, snapshots, reboot/shutdown, scrub, alerts) now raise a proper error when the
+  underlying TrueNAS call actually fails, instead of failing silently.
+- **Quality & test hardening:** completed the Home Assistant **Bronze** and **Silver**
+  quality-scale tiers (`mypy --strict` typing, 99% CI test coverage, proper action-error
+  handling).
+
+### Fixed
+- **Scrub timestamp crash on never-scrubbed pools (#35, #39):** timestamp sensors no longer
+  error out for pools that have never been scrubbed (or while a scrub is actively running) —
+  both report cleanly as *unknown* until a real timestamp exists.
+
+### Requirements
+- Dependency bump: `aiotruenas>=1.1.0`.
 
 ## [2.4.1] — Deprecated update-listener fix
 
@@ -373,6 +408,11 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 - Handle JSON-RPC parsing errors to prevent crashes on unexpected API formats.
 - Modern type hints and `.get()` fallbacks to avoid `KeyError` crashes.
 
+[2.5.1]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/v2.5.1
+[2.5.0]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/v2.5.0
+[2.4.1]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/v2.4.1
+[2.4.0]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/v2.4.0
+[2.3.0]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/v2.3.0
 [2.2.0]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/v2.2.0
 [2.1.0]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/v2.1.0
 [2.0.0]: https://github.com/kayl-codes/homeassistant-truenas/releases/tag/2.0.0

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ The integration talks to TrueNAS over its modern JSON-RPC 2.0 **WebSocket** API 
 
 ## Reauthentication
 
-If the stored API key stops working (revoked, deleted, or its user's access disabled on
+If the stored API key stops working (revoked, deleted, or its user's account is disabled on
 TrueNAS), Home Assistant raises a **Repairs** issue instead of silently leaving every entity
 "unavailable". Open **Settings → Devices & Services** (or **Settings → Repairs**), click the
 TrueNAS notification and enter a new API key — the integration reconnects immediately and

--- a/README.md
+++ b/README.md
@@ -374,6 +374,15 @@ The integration talks to TrueNAS over its modern JSON-RPC 2.0 **WebSocket** API 
 * **An authentication gateway in front of TrueNAS does _not_ work** — for example **Cloudflare Access / Zero Trust**, Authelia, or HTTP basic-auth. These intercept the WebSocket handshake and redirect it to a login page (HTTP 302) or reject it (401/403) *before it ever reaches TrueNAS*, so the API key never gets a chance to authenticate. A headless integration cannot complete an interactive SSO login, so this is a hard limitation, not a bug. The integration detects this and reports it clearly instead of a generic error.
   * If you must reach TrueNAS through such a gateway, add a **bypass / service-token policy for the `/api/current` endpoint** so that path skips the interactive login — or simply use the LAN/VPN address instead.
 
+## Reauthentication
+
+If the stored API key stops working (revoked, deleted, or its user's access disabled on
+TrueNAS), Home Assistant raises a **Repairs** issue instead of silently leaving every entity
+"unavailable". Open **Settings → Devices & Services** (or **Settings → Repairs**), click the
+TrueNAS notification and enter a new API key — the integration reconnects immediately and
+existing entities, history and statistics are preserved. No need to remove and re-add the
+integration.
+
 ## Options
 
 After setup you can fine-tune the integration via **Settings → Devices & Services → TrueNAS → Configure**. Saving the options reloads the integration so changes take effect immediately.

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,5 +15,5 @@
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"
     ],
-    "version": "2.5.0"
+    "version": "2.5.1"
 }

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -94,6 +94,7 @@ async def async_setup_entry(
         "TrueNASDiskSensor": TrueNASDiskSensor,
         "TrueNASRsyncSensor": TrueNASRsyncSensor,
         "TrueNASReplicationSensor": TrueNASReplicationSensor,
+        "TrueNASSnapshotTaskSensor": TrueNASSnapshotTaskSensor,
     }
     await async_add_entities(hass, config_entry, dispatcher)
 

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -33,6 +33,7 @@ from custom_components.truenas_ce.entity import (
     _cleanup_orphaned_entities,
     format_unique_id,
 )
+from custom_components.truenas_ce.sensor_types import SENSOR_TYPES
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
 
@@ -164,16 +165,9 @@ async def test_async_setup_entry_creates_entities_via_real_platform_setup(
 async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
     hass: HomeAssistant,
 ) -> None:
-    """Every entity description's ``func`` must have a matching dispatcher
-    entry in its platform module -- a missing one raises ``KeyError`` deep
-    inside ``entity.async_add_entities`` and aborts that platform's entire
-    setup (see the ``TrueNASSnapshotTaskSensor`` regression: it existed as a
-    class and was referenced by a sensor description, but the ``sensor.py``
-    dispatcher dict never listed it, so every sensor -- not just snapshot
-    tasks -- went unavailable in production). Unlike the test above, this
-    enables the "snapshots" monitored group and returns one real snapshot-
-    task row, so the dispatcher lookup for ``TrueNASSnapshotTaskSensor``
-    actually executes instead of being skipped via an empty data set.
+    """A description's ``func`` must have a matching dispatcher entry in its
+    platform module -- a missing one raises ``KeyError`` and aborts that
+    platform's entire setup (the ``TrueNASSnapshotTaskSensor`` regression).
     """
 
     async def _query(method: str, *args: object, **kwargs: object) -> object:
@@ -181,7 +175,7 @@ async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
             return {}
         if method == "pool.snapshottask.query":
             return [{"id": 1, "dataset": "tank/data", "state": {"state": "PENDING"}}]
-        return None
+        raise AssertionError(f"unexpected query method: {method}")
 
     fake_api = SimpleNamespace(
         connected=MagicMock(return_value=True),
@@ -211,8 +205,11 @@ async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
+    snapshottask_description = next(
+        d for d in SENSOR_TYPES if d.func == "TrueNASSnapshotTaskSensor"
+    )
     ent_reg = er.async_get(hass)
-    unique_id = format_unique_id("TrueNAS", "snapshottask", 1)
+    unique_id = format_unique_id("TrueNAS", snapshottask_description.key, 1)
     entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
     assert entity_id is not None
     assert hass.states.get(entity_id) is not None

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -24,8 +24,15 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.truenas_ce as init_module
-from custom_components.truenas_ce.const import CONF_MONITORED_GROUPS, DOMAIN
-from custom_components.truenas_ce.entity import _cleanup_orphaned_entities
+from custom_components.truenas_ce.const import (
+    CONF_MONITORED_GROUPS,
+    DOMAIN,
+    MONITOR_GROUP_SNAPSHOTS,
+)
+from custom_components.truenas_ce.entity import (
+    _cleanup_orphaned_entities,
+    format_unique_id,
+)
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
 
@@ -152,3 +159,60 @@ async def test_async_setup_entry_creates_entities_via_real_platform_setup(
         await hass.async_block_till_done()
 
     assert hass.states.async_entity_ids("sensor")
+
+
+async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
+    hass: HomeAssistant,
+) -> None:
+    """Every entity description's ``func`` must have a matching dispatcher
+    entry in its platform module -- a missing one raises ``KeyError`` deep
+    inside ``entity.async_add_entities`` and aborts that platform's entire
+    setup (see the ``TrueNASSnapshotTaskSensor`` regression: it existed as a
+    class and was referenced by a sensor description, but the ``sensor.py``
+    dispatcher dict never listed it, so every sensor -- not just snapshot
+    tasks -- went unavailable in production). Unlike the test above, this
+    enables the "snapshots" monitored group and returns one real snapshot-
+    task row, so the dispatcher lookup for ``TrueNASSnapshotTaskSensor``
+    actually executes instead of being skipped via an empty data set.
+    """
+
+    async def _query(method: str, *args: object, **kwargs: object) -> object:
+        if method == "system.info":
+            return {}
+        if method == "pool.snapshottask.query":
+            return [{"id": 1, "dataset": "tank/data", "state": {"state": "PENDING"}}]
+        return None
+
+    fake_api = SimpleNamespace(
+        connected=MagicMock(return_value=True),
+        connect=AsyncMock(return_value=True),
+        close=AsyncMock(),
+        query=AsyncMock(side_effect=_query),
+        error="",
+        scheme="ws",
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "TrueNAS",
+            CONF_HOST: "truenas.local",
+            CONF_API_KEY: "test-key",
+            CONF_VERIFY_SSL: False,
+        },
+        options={CONF_MONITORED_GROUPS: [MONITOR_GROUP_SNAPSHOTS]},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.truenas_ce.coordinator.TrueNASAPI",
+        return_value=fake_api,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    unique_id = format_unique_id("TrueNAS", "snapshottask", 1)
+    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -171,11 +171,16 @@ async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
     """
 
     async def _query(method: str, *args: object, **kwargs: object) -> object:
+        # The coordinator's core jobs (disk, scrub, app, alerts, certificates,
+        # arc, smb, pool, update-check, ...) run unconditionally every update
+        # regardless of monitored groups, so they fall through to None here
+        # like a not-yet-responding TrueNAS -- only the one query this test
+        # actually cares about is special-cased.
         if method == "system.info":
             return {}
         if method == "pool.snapshottask.query":
             return [{"id": 1, "dataset": "tank/data", "state": {"state": "PENDING"}}]
-        raise AssertionError(f"unexpected query method: {method}")
+        return None
 
     fake_api = SimpleNamespace(
         connected=MagicMock(return_value=True),

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -14,6 +14,7 @@ repo's Windows dev machine).
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,13 +28,13 @@ import custom_components.truenas_ce as init_module
 from custom_components.truenas_ce.const import (
     CONF_MONITORED_GROUPS,
     DOMAIN,
+    GROUP_DATA_PATHS,
     MONITOR_GROUP_SNAPSHOTS,
 )
 from custom_components.truenas_ce.entity import (
     _cleanup_orphaned_entities,
     format_unique_id,
 )
-from custom_components.truenas_ce.sensor import TrueNASSnapshotTaskSensor
 from custom_components.truenas_ce.sensor_types import SENSOR_TYPES
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
@@ -111,7 +112,7 @@ async def test_cleanup_orphaned_entities_noop_after_failed_refresh(
 # ---------------------------
 #   async_add_entities (via a real platform-setup pass)
 # ---------------------------
-def _fake_api(extra_responses: dict[str, object] | None = None) -> SimpleNamespace:
+def _fake_api(extra_responses: dict[str, Any] | None = None) -> SimpleNamespace:
     """A fake TrueNASAPI returning an empty (but present) system.info payload.
 
     Every other query returns None -- matching the coordinator's normal
@@ -121,10 +122,15 @@ def _fake_api(extra_responses: dict[str, object] | None = None) -> SimpleNamespa
     unconditionally every update regardless of monitored groups, so a caller
     only needs to override the one query it actually cares about; this keeps
     the platform-forward pass real while avoiding any actual network I/O.
+
+    ``Any`` mirrors ``TrueNASAPI.query()``'s own return type -- per-method
+    structural types aren't modelled here because production code (see
+    ``apiparser.parse_api``) is deliberately defensive about API response
+    shapes rather than trusting a fixed schema.
     """
     responses = extra_responses or {}
 
-    async def _query(method: str, *args: object, **kwargs: object) -> object:
+    async def _query(method: str, *args: object, **kwargs: object) -> Any:
         if method in responses:
             return responses[method]
         return {} if method == "system.info" else None
@@ -201,8 +207,13 @@ async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
+    # Same group -> data_path mapping production code uses for orphan-cleanup
+    # (GROUP_DATA_PATHS), so this targets "the snapshot task description" by
+    # the same identity the rest of the codebase does -- not by which sensor
+    # class currently implements it.
+    (snapshottask_data_path,) = GROUP_DATA_PATHS[MONITOR_GROUP_SNAPSHOTS]
     snapshottask_description = next(
-        d for d in SENSOR_TYPES if d.func == TrueNASSnapshotTaskSensor.__name__
+        d for d in SENSOR_TYPES if d.data_path == snapshottask_data_path
     )
     ent_reg = er.async_get(hass)
     unique_id = format_unique_id("TrueNAS", snapshottask_description.key, 1)

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -33,6 +33,7 @@ from custom_components.truenas_ce.entity import (
     _cleanup_orphaned_entities,
     format_unique_id,
 )
+from custom_components.truenas_ce.sensor import TrueNASSnapshotTaskSensor
 from custom_components.truenas_ce.sensor_types import SENSOR_TYPES
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
@@ -110,15 +111,22 @@ async def test_cleanup_orphaned_entities_noop_after_failed_refresh(
 # ---------------------------
 #   async_add_entities (via a real platform-setup pass)
 # ---------------------------
-def _fake_api() -> SimpleNamespace:
+def _fake_api(extra_responses: dict[str, object] | None = None) -> SimpleNamespace:
     """A fake TrueNASAPI returning an empty (but present) system.info payload.
 
-    Every other query returns None, matching the coordinator's normal handling
-    of a not-yet-responding TrueNAS -- this keeps the platform-forward pass
-    real while avoiding any actual network I/O.
+    Every other query returns None -- matching the coordinator's normal
+    handling of a not-yet-responding TrueNAS -- unless ``extra_responses``
+    overrides it for a specific method. The coordinator's core jobs (disk,
+    scrub, app, alerts, certificates, arc, smb, pool, update-check, ...) run
+    unconditionally every update regardless of monitored groups, so a caller
+    only needs to override the one query it actually cares about; this keeps
+    the platform-forward pass real while avoiding any actual network I/O.
     """
+    responses = extra_responses or {}
 
-    async def _query(method: str, *args: object, **kwargs: object) -> dict | None:
+    async def _query(method: str, *args: object, **kwargs: object) -> object:
+        if method in responses:
+            return responses[method]
         return {} if method == "system.info" else None
 
     return SimpleNamespace(
@@ -169,26 +177,9 @@ async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
     platform module -- a missing one raises ``KeyError`` and aborts that
     platform's entire setup (the ``TrueNASSnapshotTaskSensor`` regression).
     """
-
-    async def _query(method: str, *args: object, **kwargs: object) -> object:
-        # The coordinator's core jobs (disk, scrub, app, alerts, certificates,
-        # arc, smb, pool, update-check, ...) run unconditionally every update
-        # regardless of monitored groups, so they fall through to None here
-        # like a not-yet-responding TrueNAS -- only the one query this test
-        # actually cares about is special-cased.
-        if method == "system.info":
-            return {}
-        if method == "pool.snapshottask.query":
-            return [{"id": 1, "dataset": "tank/data", "state": {"state": "PENDING"}}]
-        return None
-
-    fake_api = SimpleNamespace(
-        connected=MagicMock(return_value=True),
-        connect=AsyncMock(return_value=True),
-        close=AsyncMock(),
-        query=AsyncMock(side_effect=_query),
-        error="",
-        scheme="ws",
+    snapshottask_row = {"id": 1, "dataset": "tank/data", "state": {"state": "PENDING"}}
+    fake_api = _fake_api(
+        extra_responses={"pool.snapshottask.query": [snapshottask_row]}
     )
 
     entry = MockConfigEntry(
@@ -211,7 +202,7 @@ async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
         await hass.async_block_till_done()
 
     snapshottask_description = next(
-        d for d in SENSOR_TYPES if d.func == "TrueNASSnapshotTaskSensor"
+        d for d in SENSOR_TYPES if d.func == TrueNASSnapshotTaskSensor.__name__
     )
     ent_reg = er.async_get(hass)
     unique_id = format_unique_id("TrueNAS", snapshottask_description.key, 1)


### PR DESCRIPTION
## Proposed change

Production regression from v2.5.0: the `snapshottask` sensor description referenced `TrueNASSnapshotTaskSensor`, but the class was missing from `sensor.py`'s dispatcher map. Any config entry monitoring the **Snapshots** group hit a `KeyError` deep inside `entity.async_add_entities` during platform setup, which aborted the entire sensor platform's entity creation — not just snapshot tasks, **every** sensor entity went "Unavailable".

- Restored the missing `"TrueNASSnapshotTaskSensor"` dispatcher entry in `sensor.py`.
- Added a real-`hass` regression test (`test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher`) that enables the Snapshots group and asserts the entity is actually created through the dispatcher — the existing real-setup test used an empty `monitored_groups`, so it never exercised this code path despite 99% coverage.
- Bumped `manifest.json` to `2.5.1`.
- Backfilled `CHANGELOG.md`: split the stale `[Unreleased]` entry into a proper `[2.5.0]` section (it was never renamed after that release shipped), added the `[2.5.1]` hotfix entry, and added the missing `2.3.0`/`2.4.0`/`2.4.1` version links.
- Documented the `2.5.0` reauthentication flow in the README (it was shipped but never written up).

Verified live against a production Home Assistant instance: before the fix, `KeyError: 'TrueNASSnapshotTaskSensor'` in the log and all entities unavailable; after deploying the fix, clean setup log (dozens of entities registered, no errors) and normal sensor states.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information

Root cause: `TrueNASSnapshotTaskSensor` existed as a class and was referenced by an entity description, but was never added to the platform's dispatcher dict — likely lost during the 2.5.0 `aiotruenas` migration refactor.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix sensor platform regression by restoring the missing dispatcher entry for the snapshot task sensor and cut a 2.5.1 hotfix release with tests and docs updates.

Bug Fixes:
- Restore the TrueNASSnapshotTaskSensor entry in the sensor dispatcher to prevent KeyError and ensure snapshot task sensors and other sensors load correctly.

Documentation:
- Document the automatic reauthentication flow in the README and update the changelog with 2.5.0 and 2.5.1 sections and version links.

Tests:
- Add an end-to-end Home Assistant setup test that exercises the snapshot task sensor creation via the dispatcher to guard against regressions.

Chores:
- Bump the integration manifest version from 2.5.0 to 2.5.1.