### PR TITLE
feat: Gold quality scale — discovery, discovery-update-info, docs-known-limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ After setup you can fine-tune the integration via **Settings → Devices & Servi
 ## Known Limitations
 
 * **Authentication gateways in front of TrueNAS are not supported.** Cloudflare Access, Authelia,
-  HTTP basic-auth and similar SSO/auth proxies intercept the WebSocket handshake before it reaches
+  HTTP basic auth and similar SSO/auth proxies intercept the WebSocket handshake before it reaches
   TrueNAS, so the API key never gets a chance to authenticate. See
   [Remote access, reverse proxies & Cloudflare](#remote-access-reverse-proxies--cloudflare) for
   supported alternatives (local IP/VPN, or a plain TLS-terminating reverse proxy).

--- a/README.md
+++ b/README.md
@@ -394,6 +394,37 @@ After setup you can fine-tune the integration via **Settings → Devices & Servi
   * *Hide RX/TX sensors for disconnected NICs* - when enabled, traffic sensors are only created for connected interfaces; when disabled (default), every interface gets RX/TX sensors.
 * **Monitored groups** - Enable or disable whole sensor groups: **UPS**, **Virtual Machines**, **Containers**, **Cloudsync**, **Replication**, **Rsync Tasks**, **Snapshot Tasks**, **Datasets** and **Directory Services**. Disabling a group skips its API query entirely (saving resources) and removes its entities and device from Home Assistant on the next reload. Core groups (system, network, pools, disks, apps, services, alerts) are always monitored.
 
+## Known Limitations
+
+* **Authentication gateways in front of TrueNAS are not supported.** Cloudflare Access, Authelia,
+  HTTP basic-auth and similar SSO/auth proxies intercept the WebSocket handshake before it reaches
+  TrueNAS, so the API key never gets a chance to authenticate. See
+  [Remote access, reverse proxies & Cloudflare](#remote-access-reverse-proxies--cloudflare) for
+  supported alternatives (local IP/VPN, or a plain TLS-terminating reverse proxy).
+* **TrueNAS development/nightly builds are not officially supported.** The integration is tested
+  against stable TrueNAS releases (currently 25.04–25.10.4); features may break without notice on a
+  development branch.
+* **Run buttons don't show a "running" spinner state.** The Cron Job, Pool Scrub and Snapshot Task
+  **Run** buttons trigger their action immediately, but a Home Assistant `ButtonEntity` has no
+  persistent "active" state of its own — this is a standard HA UX limitation, not a bug. The
+  corresponding sensor (e.g. scrub state, snapshot task state) does reflect an optimistic `RUNNING`
+  state right away and re-syncs to the real TrueNAS state on the next poll.
+* **A background job that starts and finishes between two polls may only be sampled in its final
+  state.** This applies to container restarts, and to Replication/Rsync/Snapshot tasks that run on a
+  *TrueNAS schedule* rather than through the integration's own Run button/action — the transient
+  "running" state can be missed if it starts and ends inside one poll interval. The persistent end
+  state always matches TrueNAS's own WebUI; only interim progress can be missed if it's fast enough.
+  Lowering the poll interval (see [Options](#options)) reduces the chance of missing it.
+* **The on-demand pool-scrub button has no threshold guard.** Pressing it starts a scrub immediately
+  regardless of how recently the pool was last scrubbed — TrueNAS's own scheduled-scrub frequency
+  setting is not checked. Use it deliberately, not as a substitute for a properly scheduled scrub.
+* **Container action targets aren't scoped to containers only.** `container_start` /
+  `container_stop` / `container_restart` target any `binary_sensor` entity from this integration (a
+  Home Assistant action-target limitation — actions can only scope by domain, not by a custom
+  sub-type), so VMs, apps, pool-health and network-link sensors also show up as pickable targets in
+  the UI even though only container sensors are actually supported. Picking a non-container target
+  fails at call time with a clear error.
+
 ## Removing the integration
 
 To completely remove the integration from Home Assistant:

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -334,7 +334,19 @@ async def _async_get_system_id(api: TrueNASAPI, host: str) -> str | None:
     except Exception as err:
         _LOGGER.debug("TrueNAS %s: failed to read system.global.id: %s", host, err)
         return None
-    return system_id if isinstance(system_id, str) and system_id else None
+
+    if isinstance(system_id, str) and system_id:
+        return system_id
+
+    if not isinstance(system_id, str):
+        _LOGGER.debug(
+            "TrueNAS %s: unexpected system.global.id payload (%s): %r",
+            host,
+            type(system_id).__name__,
+            system_id,
+        )
+
+    return None
 
 
 # ---------------------------
@@ -534,12 +546,16 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         Tries each configured entry's own stored API key against the newly
         discovered (and already-confirmed-TrueNAS) host. A successful login
         whose ``system.global.id`` matches the entry's stored id is proof
-        it's the same physical box under a new IP; a successful login with
-        no stored id yet (entries predating this check) is accepted as
-        best-effort confirmation and backfills the id for next time. Returns
-        True (and updates+reloads the entry) on a match, False otherwise.
+        it's the same physical box under a new IP. A successful login with
+        no stored id yet (entries predating this check) is only accepted as
+        best-effort confirmation when this is the sole configured entry, so
+        there's no other entry it could be confused with; with more than one
+        entry configured, an id-less match is skipped rather than risk
+        migrating the wrong entry. Returns True (and updates+reloads the
+        entry) on a match, False otherwise.
         """
-        for entry in self.hass.config_entries.async_entries(DOMAIN):
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
             if entry.data.get(CONF_HOST) == host:
                 continue
 
@@ -568,6 +584,8 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
             stored_id = entry.data.get(CONF_SYSTEM_ID)
             if stored_id and system_id != stored_id:
                 continue  # same key, different box -- not a match
+            if not stored_id and len(entries) > 1:
+                continue  # no id to confirm identity, and ambiguous
 
             new_data = dict(entry.data)
             new_data[CONF_HOST] = host

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -303,6 +303,41 @@ def _guess_ip() -> str:
 
 
 # ---------------------------
+#   _async_try_connect
+# ---------------------------
+async def _async_try_connect(api: TrueNASAPI, host: str, context: str) -> bool:
+    """Attempt ``api.connect()``, returning False (and logging) on any failure.
+
+    Shared by the zeroconf probe and the rediscovery match: both need to try
+    one candidate connection and move on to the next on any problem rather
+    than raising, so an unexpected exception here must not abort the whole
+    discovery/rediscovery flow.
+    """
+    try:
+        return await api.connect()
+    except Exception as err:
+        _LOGGER.debug("TrueNAS %s: %s: %s", host, context, err)
+        return False
+
+
+# ---------------------------
+#   _async_get_system_id
+# ---------------------------
+async def _async_get_system_id(api: TrueNASAPI, host: str) -> str | None:
+    """Fetch ``system.global.id``, returning None (and logging) on failure.
+
+    A failed identity lookup must never block configuration/rediscovery, so
+    any exception here is swallowed and treated the same as "no id yet".
+    """
+    try:
+        system_id = await api.query("system.global.id")
+    except Exception as err:
+        _LOGGER.debug("TrueNAS %s: failed to read system.global.id: %s", host, err)
+        return None
+    return system_id if isinstance(system_id, str) and system_id else None
+
+
+# ---------------------------
 #   TrueNASConfigFlow
 # ---------------------------
 class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -349,18 +384,9 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 
         conn, errorcode = await api.connection_test()
         if conn:
-            try:
-                system_id = await api.query("system.global.id")
-            except Exception as err:
-                # A failed identity lookup must not block configuration.
-                _LOGGER.debug(
-                    "TrueNAS %s: failed to read system.global.id: %s",
-                    config.get(CONF_HOST),
-                    err,
-                )
-            else:
-                if isinstance(system_id, str) and system_id:
-                    config[CONF_SYSTEM_ID] = system_id
+            system_id = await _async_get_system_id(api, config.get(CONF_HOST, ""))
+            if system_id:
+                config[CONF_SYSTEM_ID] = system_id
         await api.disconnect()
 
         if not conn:
@@ -492,12 +518,9 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         for scheme in ("wss", "ws"):
             api = TrueNASAPI(host, "-", verify_ssl=False, scheme=scheme)
             try:
-                try:
-                    await api.connect()
-                except Exception:
-                    _LOGGER.debug(
-                        "TrueNAS probe: %s (%s) is not reachable", host, scheme
-                    )
+                if not await _async_try_connect(
+                    api, host, f"probe ({scheme}) is not reachable"
+                ):
                     continue
                 if api.error == ERR_INVALID_KEY:
                     return True
@@ -526,33 +549,19 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                 entry.data.get(CONF_VERIFY_SSL, DEFAULT_SSL_VERIFY),
             )
             try:
-                try:
-                    if not await api.connect():
-                        continue
-                except Exception as err:
-                    # A connection-level failure (DNS, refused, SSL, ...)
-                    # must not abort rediscovery for the other entries;
-                    # treat it the same as "not a match" and move on, like
-                    # _probe_is_truenas does.
-                    _LOGGER.debug(
-                        "TrueNAS %s: failed to connect while checking for a "
-                        "rediscovery match: %s",
-                        host,
-                        err,
-                    )
+                # A connection-level failure (DNS, refused, SSL, ...) must not
+                # abort rediscovery for the other entries; treat it the same
+                # as "not a match" and move on, like _probe_is_truenas does.
+                if not await _async_try_connect(
+                    api,
+                    host,
+                    "failed to connect while checking for a rediscovery match",
+                ):
                     continue
-                try:
-                    system_id = await api.query("system.global.id")
-                except Exception as err:
-                    # A failed identity lookup must not abort rediscovery;
-                    # fall back to the same best-effort match used for
-                    # entries that predate this check (see docstring).
-                    _LOGGER.debug(
-                        "TrueNAS %s: failed to read system.global.id: %s",
-                        host,
-                        err,
-                    )
-                    system_id = None
+                # A failed identity lookup must not abort rediscovery either;
+                # fall back to the same best-effort match used for entries
+                # that predate this check (see docstring).
+                system_id = await _async_get_system_id(api, host)
             finally:
                 await api.disconnect()
 

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -349,9 +349,17 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 
         conn, errorcode = await api.connection_test()
         if conn:
-            system_id = await api.query("system.global.id")
-            if isinstance(system_id, str) and system_id:
-                config[CONF_SYSTEM_ID] = system_id
+            try:
+                system_id = await api.query("system.global.id")
+            except Exception:
+                # A failed identity lookup must not block configuration.
+                _LOGGER.debug(
+                    "TrueNAS %s: failed to read system.global.id",
+                    config.get(CONF_HOST),
+                )
+            else:
+                if isinstance(system_id, str) and system_id:
+                    config[CONF_SYSTEM_ID] = system_id
         await api.disconnect()
 
         if not conn:
@@ -424,6 +432,13 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         if not errors:
             await self._validate_connection(truenas_config, errors)
 
+        # Once the box's stable identity is known, key the entry's unique_id
+        # on it rather than on the (zeroconf-set) host, so rediscovery and
+        # de-duplication survive the host/IP changing later.
+        system_id = truenas_config.get(CONF_SYSTEM_ID)
+        if not errors and isinstance(system_id, str) and system_id:
+            await self.async_set_unique_id(system_id)
+
         # Save instance
         if not errors:
             return self.async_create_entry(
@@ -466,11 +481,22 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     async def _probe_is_truenas(host: str) -> bool:
-        """Return True only if ``host`` rejects a bogus key as invalid."""
+        """Return True only if ``host`` rejects a bogus key as invalid.
+
+        Any unexpected connection-level error (refused, DNS, handshake, ...)
+        is treated the same as "not TrueNAS" so a misbehaving non-TrueNAS
+        device cannot abort zeroconf discovery for the whole flow.
+        """
         for scheme in ("wss", "ws"):
             api = TrueNASAPI(host, "-", verify_ssl=False, scheme=scheme)
             try:
-                await api.connect()
+                try:
+                    await api.connect()
+                except Exception:
+                    _LOGGER.debug(
+                        "TrueNAS probe: %s (%s) is not reachable", host, scheme
+                    )
+                    continue
                 if api.error == ERR_INVALID_KEY:
                     return True
             finally:
@@ -510,9 +536,13 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 
             new_data = dict(entry.data)
             new_data[CONF_HOST] = host
+            update_kwargs: dict[str, Any] = {"data": new_data}
             if isinstance(system_id, str) and system_id:
                 new_data[CONF_SYSTEM_ID] = system_id
-            self.hass.config_entries.async_update_entry(entry, data=new_data)
+                # Migrate the entry's unique_id onto the stable box identity
+                # too, so future rediscovery keys on it rather than the host.
+                update_kwargs["unique_id"] = system_id
+            self.hass.config_entries.async_update_entry(entry, **update_kwargs)
             await self.hass.config_entries.async_reload(entry.entry_id)
             return True
         return False

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .api import TrueNASAPI
 from .const import (
@@ -37,6 +38,7 @@ from .const import (
     CONF_DATASET_PASSPHRASES,
     CONF_MONITORED_GROUPS,
     CONF_POLL_INTERVAL,
+    CONF_SYSTEM_ID,
     DEFAULT_BEHAVIORS,
     DEFAULT_CRONJOB_SKIP_DISABLED,
     DEFAULT_DATA_UNIT,
@@ -346,6 +348,10 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
             return
 
         conn, errorcode = await api.connection_test()
+        if conn:
+            system_id = await api.query("system.global.id")
+            if isinstance(system_id, str) and system_id:
+                config[CONF_SYSTEM_ID] = system_id
         await api.disconnect()
 
         if not conn:
@@ -426,6 +432,101 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                 options=self._legacy_options or None,
             )
         return None
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle a TrueNAS instance discovered over mDNS.
+
+        TrueNAS SCALE only advertises the generic ``_http._tcp`` service
+        type shared by countless unrelated devices (printers, routers,
+        media servers, ...), so the zeroconf type match alone cannot tell
+        TrueNAS apart. Instead, probe the discovered host with a bogus API
+        key: only a genuine TrueNAS JSON-RPC endpoint answers the WebSocket
+        handshake and then rejects it specifically as an invalid key
+        (``ERR_INVALID_KEY``). Any other outcome (connection refused,
+        handshake timeout, ...) means some other device is behind that
+        _http._tcp announcement, so the flow aborts silently without ever
+        showing the user anything.
+        """
+        host = discovery_info.host
+        self._async_abort_entries_match({CONF_HOST: host})
+        await self.async_set_unique_id(host)
+        self._abort_if_unique_id_configured()
+
+        if not await self._probe_is_truenas(host):
+            return self.async_abort(reason="not_truenas")
+
+        if await self._async_update_rediscovered_entry(host):
+            return self.async_abort(reason="already_configured")
+
+        self.truenas_config[CONF_HOST] = host
+        self.context["title_placeholders"] = {CONF_NAME: host}
+        return await self.async_step_zeroconf_confirm()
+
+    @staticmethod
+    async def _probe_is_truenas(host: str) -> bool:
+        """Return True only if ``host`` rejects a bogus key as invalid."""
+        for scheme in ("wss", "ws"):
+            api = TrueNASAPI(host, "-", verify_ssl=False, scheme=scheme)
+            try:
+                await api.connect()
+                if api.error == ERR_INVALID_KEY:
+                    return True
+            finally:
+                await api.disconnect()
+        return False
+
+    async def _async_update_rediscovered_entry(self, host: str) -> bool:
+        """Update an existing entry's host if ``host`` is the same box, moved.
+
+        Tries each configured entry's own stored API key against the newly
+        discovered (and already-confirmed-TrueNAS) host. A successful login
+        whose ``system.global.id`` matches the entry's stored id is proof
+        it's the same physical box under a new IP; a successful login with
+        no stored id yet (entries predating this check) is accepted as
+        best-effort confirmation and backfills the id for next time. Returns
+        True (and updates+reloads the entry) on a match, False otherwise.
+        """
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_HOST) == host:
+                continue
+
+            api = TrueNASAPI(
+                host,
+                entry.data.get(CONF_API_KEY, ""),
+                entry.data.get(CONF_VERIFY_SSL, DEFAULT_SSL_VERIFY),
+            )
+            try:
+                if not await api.connect():
+                    continue
+                system_id = await api.query("system.global.id")
+            finally:
+                await api.disconnect()
+
+            stored_id = entry.data.get(CONF_SYSTEM_ID)
+            if stored_id and system_id != stored_id:
+                continue  # same key, different box -- not a match
+
+            new_data = dict(entry.data)
+            new_data[CONF_HOST] = host
+            if isinstance(system_id, str) and system_id:
+                new_data[CONF_SYSTEM_ID] = system_id
+            self.hass.config_entries.async_update_entry(entry, data=new_data)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return True
+        return False
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ask the user to confirm setup of the discovered TrueNAS host."""
+        if user_input is not None:
+            return await self.async_step_user()
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={CONF_HOST: self.truenas_config[CONF_HOST]},
+        )
 
     def _find_legacy_config(self) -> ConfigEntry | None:
         """Return a legacy ``truenas`` entry to optionally take over, if any.
@@ -561,9 +662,12 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
             config[CONF_API_KEY] = user_input[CONF_API_KEY]
             await self._validate_connection(config, errors)
             if not errors:
+                data_updates = {CONF_API_KEY: user_input[CONF_API_KEY]}
+                if CONF_SYSTEM_ID in config:
+                    data_updates[CONF_SYSTEM_ID] = config[CONF_SYSTEM_ID]
                 return self.async_update_reload_and_abort(
                     reauth_entry,
-                    data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
+                    data_updates=data_updates,
                 )
 
         return self.async_show_form(

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -334,6 +334,55 @@ async def _async_safe_disconnect(api: TrueNASAPI) -> None:
         await api.disconnect()
 
 
+# Ports the ``ws``/``wss`` schemes already default to; an mDNS announcement
+# naming one of them adds nothing over probing the bare host.
+_DEFAULT_WS_PORTS = frozenset({80, 443})
+
+
+# ---------------------------
+#   _probe_candidates
+# ---------------------------
+def _probe_candidates(host: str, port: int | None) -> list[str]:
+    """Return the host strings to probe for ``host``, most likely first.
+
+    TrueNAS only advertises the generic ``_http._tcp`` service, whose port is
+    the web UI's -- normally 80, which ``ws`` already defaults to (as ``wss``
+    does 443). Probing the bare host therefore stays first so a standard box
+    reachable over ``wss`` is not forced onto the advertised plain-HTTP port.
+    A genuinely non-default port is appended as a fallback, so an instance
+    behind a custom port or reverse proxy is no longer misread as "not
+    TrueNAS". ``aiotruenas`` builds its URL from the host verbatim, so
+    ``host:port`` is a valid host string here (see ``_sanitize_host``).
+    """
+    if port is None or port in _DEFAULT_WS_PORTS:
+        return [host]
+    return [host, f"{host}:{port}"]
+
+
+# ---------------------------
+#   _async_probe_candidate
+# ---------------------------
+async def _async_probe_candidate(host: str) -> bool:
+    """Return True only if ``host`` rejects a bogus API key as invalid.
+
+    Only a genuine TrueNAS JSON-RPC endpoint completes the WebSocket
+    handshake and then answers ``ERR_INVALID_KEY``; every other outcome is
+    treated as "not TrueNAS".
+    """
+    for scheme in ("wss", "ws"):
+        api = TrueNASAPI(host, "-", verify_ssl=False, scheme=scheme)
+        try:
+            if not await _async_try_connect(
+                api, host, f"probe ({scheme}) is not reachable"
+            ):
+                continue
+            if api.error == ERR_INVALID_KEY:
+                return True
+        finally:
+            await _async_safe_disconnect(api)
+    return False
+
+
 # ---------------------------
 #   _async_get_system_id
 # ---------------------------
@@ -523,36 +572,35 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(host)
         self._abort_if_unique_id_configured()
 
-        if not await self._probe_is_truenas(host):
+        # The probe reports back which endpoint actually answered, so a box
+        # found only on its advertised non-default port is configured with
+        # that port instead of silently falling back to the default one.
+        probed_host = await self._probe_is_truenas(host, discovery_info.port)
+        if probed_host is None:
             return self.async_abort(reason="not_truenas")
 
-        if await self._async_update_rediscovered_entry(host):
+        if await self._async_update_rediscovered_entry(probed_host):
             return self.async_abort(reason="already_configured")
 
-        self.truenas_config[CONF_HOST] = host
-        self.context["title_placeholders"] = {CONF_NAME: host}
+        self.truenas_config[CONF_HOST] = probed_host
+        self.context["title_placeholders"] = {CONF_NAME: probed_host}
         return await self.async_step_zeroconf_confirm()
 
     @staticmethod
-    async def _probe_is_truenas(host: str) -> bool:
-        """Return True only if ``host`` rejects a bogus key as invalid.
+    async def _probe_is_truenas(host: str, port: int | None = None) -> str | None:
+        """Return the ``host[:port]`` that answers as TrueNAS, or None.
 
         Any unexpected connection-level error (refused, DNS, handshake, ...)
         is treated the same as "not TrueNAS" so a misbehaving non-TrueNAS
         device cannot abort zeroconf discovery for the whole flow.
+
+        The returned value is what the entry must be configured with, so a
+        box found only on its advertised non-default port keeps that port.
         """
-        for scheme in ("wss", "ws"):
-            api = TrueNASAPI(host, "-", verify_ssl=False, scheme=scheme)
-            try:
-                if not await _async_try_connect(
-                    api, host, f"probe ({scheme}) is not reachable"
-                ):
-                    continue
-                if api.error == ERR_INVALID_KEY:
-                    return True
-            finally:
-                await _async_safe_disconnect(api)
-        return False
+        for candidate in _probe_candidates(host, port):
+            if await _async_probe_candidate(candidate):
+                return candidate
+        return None
 
     async def _async_update_rediscovered_entry(self, host: str) -> bool:
         """Update an existing entry's host if ``host`` is the same box, moved.

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -439,6 +439,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         system_id = truenas_config.get(CONF_SYSTEM_ID)
         if not errors and isinstance(system_id, str) and system_id:
             await self.async_set_unique_id(system_id)
+            self._abort_if_unique_id_configured()
 
         # Save instance
         if not errors:

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -526,7 +526,20 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                 entry.data.get(CONF_VERIFY_SSL, DEFAULT_SSL_VERIFY),
             )
             try:
-                if not await api.connect():
+                try:
+                    if not await api.connect():
+                        continue
+                except Exception as err:
+                    # A connection-level failure (DNS, refused, SSL, ...)
+                    # must not abort rediscovery for the other entries;
+                    # treat it the same as "not a match" and move on, like
+                    # _probe_is_truenas does.
+                    _LOGGER.debug(
+                        "TrueNAS %s: failed to connect while checking for a "
+                        "rediscovery match: %s",
+                        host,
+                        err,
+                    )
                     continue
                 try:
                     system_id = await api.query("system.global.id")

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -351,11 +351,12 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         if conn:
             try:
                 system_id = await api.query("system.global.id")
-            except Exception:
+            except Exception as err:
                 # A failed identity lookup must not block configuration.
                 _LOGGER.debug(
-                    "TrueNAS %s: failed to read system.global.id",
+                    "TrueNAS %s: failed to read system.global.id: %s",
                     config.get(CONF_HOST),
+                    err,
                 )
             else:
                 if isinstance(system_id, str) and system_id:
@@ -526,7 +527,18 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 if not await api.connect():
                     continue
-                system_id = await api.query("system.global.id")
+                try:
+                    system_id = await api.query("system.global.id")
+                except Exception as err:
+                    # A failed identity lookup must not abort rediscovery;
+                    # fall back to the same best-effort match used for
+                    # entries that predate this check (see docstring).
+                    _LOGGER.debug(
+                        "TrueNAS %s: failed to read system.global.id: %s",
+                        host,
+                        err,
+                    )
+                    system_id = None
             finally:
                 await api.disconnect()
 

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -321,6 +321,20 @@ async def _async_try_connect(api: TrueNASAPI, host: str, context: str) -> bool:
 
 
 # ---------------------------
+#   _async_safe_disconnect
+# ---------------------------
+async def _async_safe_disconnect(api: TrueNASAPI) -> None:
+    """Disconnect ``api``, swallowing any error.
+
+    Mirrors :func:`_async_try_connect`/:func:`_async_get_system_id`: cleanup
+    in a probe/rediscovery ``finally`` block must never raise, or it would
+    abort the whole discovery flow for every remaining candidate.
+    """
+    with contextlib.suppress(Exception):
+        await api.disconnect()
+
+
+# ---------------------------
 #   _async_get_system_id
 # ---------------------------
 async def _async_get_system_id(api: TrueNASAPI, host: str) -> str | None:
@@ -537,7 +551,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                 if api.error == ERR_INVALID_KEY:
                     return True
             finally:
-                await api.disconnect()
+                await _async_safe_disconnect(api)
         return False
 
     async def _async_update_rediscovered_entry(self, host: str) -> bool:
@@ -579,7 +593,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                 # that predate this check (see docstring).
                 system_id = await _async_get_system_id(api, host)
             finally:
-                await api.disconnect()
+                await _async_safe_disconnect(api)
 
             stored_id = entry.data.get(CONF_SYSTEM_ID)
             if stored_id and system_id != stored_id:

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -207,6 +207,12 @@ SCHEMA_SERVICE_ALERT_LIST = vol.Schema(
 CONF_CRONJOB_SKIP_DISABLED = "cronjob_skip_disabled"
 CONF_DATA_UNIT = "data_unit"
 
+# Stable per-installation identifier (``system.global.id``, a 128-bit UUID),
+# recorded on every successful connection test. Lets a later zeroconf
+# rediscovery of the same physical box under a new IP be told apart from an
+# unrelated device, without needing any pre-authentication probe for it.
+CONF_SYSTEM_ID = "system_id"
+
 # Orphaned long-term statistics cleanup (Repairs issue + diagnostic button).
 CONF_STATISTICS_CLEANUP_IGNORED = "statistics_cleanup_ignored"
 ISSUE_STATISTICS_ORPHANED = "statistics_orphaned"

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,5 +15,8 @@
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"
     ],
-    "version": "2.5.1"
+    "version": "2.5.1",
+    "zeroconf": [
+        "_http._tcp.local."
+    ]
 }

--- a/custom_components/truenas_ce/quality_scale.yaml
+++ b/custom_components/truenas_ce/quality_scale.yaml
@@ -85,20 +85,38 @@ rules:
   devices: done
   diagnostics: done
   discovery:
-    status: todo
+    status: done
     comment: |
-      TrueNAS advertises via mDNS; evaluate zeroconf discovery for the config
-      flow.
+      TrueNAS SCALE only advertises the generic _http._tcp mDNS type shared
+      by countless unrelated devices, with no distinguishing TXT record.
+      async_step_zeroconf therefore probes the discovered host with a
+      deliberately-wrong API key: a TrueNAS JSON-RPC endpoint answers the
+      WebSocket handshake and rejects it specifically as invalid
+      (ERR_INVALID_KEY), while any other _http._tcp device fails earlier
+      (connection refused, handshake timeout, ...). Only a confirmed
+      TrueNAS host reaches the zeroconf_confirm form; everything else
+      aborts silently, so unrelated devices never surface UI.
   discovery-update-info:
-    status: todo
-    comment: Follows the discovery rule.
+    status: done
+    comment: |
+      A rediscovered TrueNAS box (e.g. after a DHCP lease change) auto-updates
+      its config entry's host. Every successful connection test now also
+      records system.global.id (a stable, per-installation 128-bit UUID) on
+      the entry. When zeroconf confirms a host is genuinely TrueNAS, each
+      existing entry's own stored API key is tried against that host; a
+      successful login whose global.id matches (or, for entries predating
+      this check, any successful login) confirms it's the same box under a
+      new IP, so the entry's host is updated and reloaded silently. See
+      TrueNASConfigFlow._async_update_rediscovered_entry in config_flow.py.
   docs-data-update: done
   docs-examples: done
   docs-known-limitations:
-    status: todo
+    status: done
     comment: |
-      Scattered hints exist (reverse-proxy/Cloudflare section); consolidate a
-      dedicated known-limitations section in the README.
+      README has a dedicated "Known Limitations" section consolidating the
+      previously-scattered hints (reverse-proxy/Cloudflare auth gateways,
+      development-branch support, run-button UX, inter-poll sampling gaps,
+      scrub threshold, container-target scoping).
   docs-supported-devices: done
   docs-supported-functions: done
   docs-troubleshooting: done

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -40,6 +40,10 @@
                     "migrate_import": "Take over existing configuration",
                     "migrate_manual": "Set up from scratch"
                 }
+            },
+            "zeroconf_confirm": {
+                "title": "Discovered TrueNAS",
+                "description": "A TrueNAS instance was discovered at {host}. Do you want to set it up?"
             }
         },
         "error": {
@@ -66,7 +70,8 @@
         "abort": {
             "already_configured": "This TrueNAS host is already configured.",
             "reconfigure_successful": "Reconfigure successful.",
-            "reauth_successful": "Reauthentication successful."
+            "reauth_successful": "Reauthentication successful.",
+            "not_truenas": "The discovered device does not appear to be a TrueNAS instance."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -40,6 +40,10 @@
                     "migrate_import": "Vorhandene Konfiguration übernehmen",
                     "migrate_manual": "Von Grund auf einrichten"
                 }
+            },
+            "zeroconf_confirm": {
+                "title": "TrueNAS entdeckt",
+                "description": "Eine TrueNAS-Instanz wurde unter {host} entdeckt. Möchtest du sie einrichten?"
             }
         },
         "error": {
@@ -66,7 +70,8 @@
         "abort": {
             "already_configured": "Dieser TrueNAS-Host ist bereits konfiguriert.",
             "reconfigure_successful": "Neukonfiguration erfolgreich.",
-            "reauth_successful": "Erneute Authentifizierung erfolgreich."
+            "reauth_successful": "Erneute Authentifizierung erfolgreich.",
+            "not_truenas": "Das entdeckte Gerät scheint keine TrueNAS-Instanz zu sein."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -40,6 +40,10 @@
                     "migrate_import": "Take over existing configuration",
                     "migrate_manual": "Set up from scratch"
                 }
+            },
+            "zeroconf_confirm": {
+                "title": "Discovered TrueNAS",
+                "description": "A TrueNAS instance was discovered at {host}. Do you want to set it up?"
             }
         },
         "error": {
@@ -66,7 +70,8 @@
         "abort": {
             "already_configured": "This TrueNAS host is already configured.",
             "reconfigure_successful": "Reconfigure successful.",
-            "reauth_successful": "Reauthentication successful."
+            "reauth_successful": "Reauthentication successful.",
+            "not_truenas": "The discovered device does not appear to be a TrueNAS instance."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -40,6 +40,10 @@
                     "migrate_import": "Adoptar la configuración existente",
                     "migrate_manual": "Configurar desde cero"
                 }
+            },
+            "zeroconf_confirm": {
+                "title": "TrueNAS descubierto",
+                "description": "Se descubrió una instancia de TrueNAS en {host}. ¿Desea configurarla?"
             }
         },
         "error": {
@@ -66,7 +70,8 @@
         "abort": {
             "already_configured": "Este host de TrueNAS ya está configurado.",
             "reconfigure_successful": "Reconfiguración exitosa.",
-            "reauth_successful": "Reautenticación exitosa."
+            "reauth_successful": "Reautenticación exitosa.",
+            "not_truenas": "El dispositivo descubierto no parece ser una instancia de TrueNAS."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -40,6 +40,10 @@
                     "migrate_import": "Adotar a configuração existente",
                     "migrate_manual": "Configurar do zero"
                 }
+            },
+            "zeroconf_confirm": {
+                "title": "TrueNAS descoberto",
+                "description": "Uma instância do TrueNAS foi descoberta em {host}. Deseja configurá-la?"
             }
         },
         "error": {
@@ -66,7 +70,8 @@
         "abort": {
             "already_configured": "Este host TrueNAS já está configurado.",
             "reconfigure_successful": "Reconfiguração bem-sucedida.",
-            "reauth_successful": "Reautenticação bem-sucedida."
+            "reauth_successful": "Reautenticação bem-sucedida.",
+            "not_truenas": "O dispositivo descoberto não parece ser uma instância do TrueNAS."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -40,6 +40,10 @@
                     "migrate_import": "Перенять существующую конфигурацию",
                     "migrate_manual": "Настроить с нуля"
                 }
+            },
+            "zeroconf_confirm": {
+                "title": "Обнаружен TrueNAS",
+                "description": "Обнаружен экземпляр TrueNAS по адресу {host}. Настроить его?"
             }
         },
         "error": {
@@ -66,7 +70,8 @@
         "abort": {
             "already_configured": "Этот хост TrueNAS уже настроен.",
             "reconfigure_successful": "Перенастройка выполнена успешно.",
-            "reauth_successful": "Повторная аутентификация выполнена успешно."
+            "reauth_successful": "Повторная аутентификация выполнена успешно.",
+            "not_truenas": "Обнаруженное устройство не похоже на экземпляр TrueNAS."
         }
     },
     "options": {

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -40,6 +40,10 @@
                     "migrate_import": "Prevziať existujúcu konfiguráciu",
                     "migrate_manual": "Nastaviť od začiatku"
                 }
+            },
+            "zeroconf_confirm": {
+                "title": "Objavený TrueNAS",
+                "description": "Na adrese {host} bola objavená inštancia TrueNAS. Chcete ju nastaviť?"
             }
         },
         "error": {
@@ -66,7 +70,8 @@
         "abort": {
             "already_configured": "Tento TrueNAS host je už nakonfigurovaný.",
             "reconfigure_successful": "Rekonfigurácia úspešná.",
-            "reauth_successful": "Opätovná autentifikácia úspešná."
+            "reauth_successful": "Opätovná autentifikácia úspešná.",
+            "not_truenas": "Zdá sa, že objavené zariadenie nie je inštanciou TrueNAS."
         }
     },
     "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -246,7 +246,7 @@ async def test_probe_is_truenas_true_on_invalid_key() -> None:
     api.disconnect = AsyncMock()
     api.error = ERR_INVALID_KEY
     with patch.object(config_flow, "TrueNASAPI", return_value=api) as mock_api:
-        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is True
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") == "1.2.3.4"
     mock_api.assert_called_once_with("1.2.3.4", "-", verify_ssl=False, scheme="wss")
     api.disconnect.assert_awaited_once()
 
@@ -258,7 +258,7 @@ async def test_probe_is_truenas_false_when_not_truenas() -> None:
     api.disconnect = AsyncMock()
     api.error = ERR_CONNECTION_REFUSED
     with patch.object(config_flow, "TrueNASAPI", return_value=api) as mock_api:
-        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is False
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is None
     assert mock_api.call_count == 2
     assert api.disconnect.await_count == 2
 
@@ -278,7 +278,7 @@ async def test_probe_is_truenas_falls_back_from_wss_to_ws() -> None:
     with patch.object(
         config_flow, "TrueNASAPI", side_effect=[wss_api, ws_api]
     ) as mock_api:
-        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is True
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") == "1.2.3.4"
     assert mock_api.call_count == 2
     mock_api.assert_any_call("1.2.3.4", "-", verify_ssl=False, scheme="ws")
 
@@ -289,7 +289,7 @@ async def test_probe_is_truenas_false_when_connect_raises() -> None:
     api.connect = AsyncMock(side_effect=OSError("connection refused"))
     api.disconnect = AsyncMock()
     with patch.object(config_flow, "TrueNASAPI", return_value=api) as mock_api:
-        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is False
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is None
     assert mock_api.call_count == 2
     assert api.disconnect.await_count == 2
 
@@ -301,8 +301,42 @@ async def test_probe_is_truenas_true_when_disconnect_raises() -> None:
     api.disconnect = AsyncMock(side_effect=OSError("already closed"))
     api.error = ERR_INVALID_KEY
     with patch.object(config_flow, "TrueNASAPI", return_value=api):
-        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is True
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") == "1.2.3.4"
     api.disconnect.assert_awaited_once()
+
+
+async def test_probe_is_truenas_falls_back_to_advertised_port() -> None:
+    """A box reachable only on its advertised port keeps that port."""
+    default_api = MagicMock()
+    default_api.connect = AsyncMock()
+    default_api.disconnect = AsyncMock()
+    default_api.error = ERR_CONNECTION_REFUSED
+
+    port_api = MagicMock()
+    port_api.connect = AsyncMock()
+    port_api.disconnect = AsyncMock()
+    port_api.error = ERR_INVALID_KEY
+
+    with patch.object(
+        config_flow,
+        "TrueNASAPI",
+        side_effect=[default_api, default_api, port_api],
+    ) as mock_api:
+        probed = await TrueNASConfigFlow._probe_is_truenas("1.2.3.4", 8443)
+    assert probed == "1.2.3.4:8443"
+    mock_api.assert_any_call("1.2.3.4:8443", "-", verify_ssl=False, scheme="wss")
+
+
+@pytest.mark.parametrize("port", [None, 80, 443])
+async def test_probe_is_truenas_ignores_default_ports(port: int | None) -> None:
+    """Default ports add nothing over the bare host, so they are not retried."""
+    api = MagicMock()
+    api.connect = AsyncMock()
+    api.disconnect = AsyncMock()
+    api.error = ERR_CONNECTION_REFUSED
+    with patch.object(config_flow, "TrueNASAPI", return_value=api) as mock_api:
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4", port) is None
+    assert mock_api.call_count == 2  # wss + ws on the bare host only
 
 
 # ---------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -217,6 +217,22 @@ async def test_validate_connection_failure_maps_error() -> None:
     assert errors[CONF_HOST] == ERR_MALFORMED_RESULT
 
 
+async def test_validate_connection_system_id_lookup_failure_does_not_block() -> None:
+    """A broken system.global.id lookup must not fail the whole connection test."""
+    flow = TrueNASConfigFlow()
+    config = {CONF_HOST: "nas.local", CONF_API_KEY: "key", CONF_VERIFY_SSL: True}
+    errors: dict[str, str] = {}
+    api = MagicMock()
+    api.connection_test = AsyncMock(return_value=(True, ""))
+    api.query = AsyncMock(side_effect=RuntimeError("boom"))
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        await flow._validate_connection(config, errors)
+    assert not errors
+    assert CONF_SYSTEM_ID not in config
+    api.disconnect.assert_awaited_once()
+
+
 # ---------------------------
 #   TrueNASConfigFlow._probe_is_truenas
 # ---------------------------
@@ -262,6 +278,69 @@ async def test_probe_is_truenas_falls_back_from_wss_to_ws() -> None:
         assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is True
     assert mock_api.call_count == 2
     mock_api.assert_any_call("1.2.3.4", "-", verify_ssl=False, scheme="ws")
+
+
+async def test_probe_is_truenas_false_when_connect_raises() -> None:
+    """An unexpected connect() error is treated as "not TrueNAS", not a crash."""
+    api = MagicMock()
+    api.connect = AsyncMock(side_effect=OSError("connection refused"))
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api) as mock_api:
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is False
+    assert mock_api.call_count == 2
+    assert api.disconnect.await_count == 2
+
+
+# ---------------------------
+#   TrueNASConfigFlow._async_update_rediscovered_entry
+# ---------------------------
+async def test_async_update_rediscovered_entry_migrates_unique_id() -> None:
+    """A confirmed same-box rediscovery also migrates the entry's unique_id."""
+    flow = TrueNASConfigFlow()
+    flow.hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_API_KEY: "key", CONF_VERIFY_SSL: True}
+    flow.hass.config_entries.async_entries.return_value = [entry]
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    api = MagicMock()
+    api.connect = AsyncMock(return_value=True)
+    api.query = AsyncMock(return_value="box-guid-123")
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await flow._async_update_rediscovered_entry("5.6.7.8") is True
+
+    flow.hass.config_entries.async_update_entry.assert_called_once()
+    _, kwargs = flow.hass.config_entries.async_update_entry.call_args
+    assert kwargs["unique_id"] == "box-guid-123"
+    assert kwargs["data"][CONF_HOST] == "5.6.7.8"
+    assert kwargs["data"][CONF_SYSTEM_ID] == "box-guid-123"
+    flow.hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+async def test_async_update_rediscovered_entry_skips_unique_id_when_id_unknown() -> (
+    None
+):
+    """A backfill without a resolvable system id still migrates the host only."""
+    flow = TrueNASConfigFlow()
+    flow.hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_API_KEY: "key", CONF_VERIFY_SSL: True}
+    flow.hass.config_entries.async_entries.return_value = [entry]
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    api = MagicMock()
+    api.connect = AsyncMock(return_value=True)
+    api.query = AsyncMock(return_value=None)
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await flow._async_update_rediscovered_entry("5.6.7.8") is True
+
+    _, kwargs = flow.hass.config_entries.async_update_entry.call_args
+    assert "unique_id" not in kwargs
+    assert kwargs["data"][CONF_HOST] == "5.6.7.8"
 
 
 # ---------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -211,10 +211,12 @@ async def test_validate_connection_failure_maps_error() -> None:
     errors: dict[str, str] = {}
     api = MagicMock()
     api.connection_test = AsyncMock(return_value=(False, ERR_MALFORMED_RESULT))
+    api.query = AsyncMock()
     api.disconnect = AsyncMock()
     with patch.object(config_flow, "TrueNASAPI", return_value=api):
         await flow._validate_connection(config, errors)
     assert errors[CONF_HOST] == ERR_MALFORMED_RESULT
+    api.query.assert_not_awaited()
 
 
 async def test_validate_connection_system_id_lookup_failure_does_not_block() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -345,6 +345,31 @@ async def test_async_update_rediscovered_entry_skips_unique_id_when_id_unknown()
     assert kwargs["data"][CONF_HOST] == "5.6.7.8"
 
 
+async def test_async_update_rediscovered_entry_skips_id_unknown_when_ambiguous() -> (
+    None
+):
+    """An id-less match is skipped when more than one entry is configured."""
+    flow = TrueNASConfigFlow()
+    flow.hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_API_KEY: "key", CONF_VERIFY_SSL: True}
+    other_entry = MagicMock()
+    other_entry.data = {CONF_HOST: "9.9.9.9", CONF_API_KEY: "other-key"}
+    flow.hass.config_entries.async_entries.return_value = [entry, other_entry]
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    api = MagicMock()
+    api.connect = AsyncMock(return_value=True)
+    api.query = AsyncMock(return_value=None)
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await flow._async_update_rediscovered_entry("5.6.7.8") is False
+
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+    flow.hass.config_entries.async_reload.assert_not_awaited()
+
+
 async def test_async_update_rediscovered_entry_skips_mismatched_system_id() -> None:
     """A different probed system id must not merge two distinct TrueNAS boxes."""
     flow = TrueNASConfigFlow()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -371,6 +371,54 @@ async def test_async_update_rediscovered_entry_skips_mismatched_system_id() -> N
     flow.hass.config_entries.async_reload.assert_not_awaited()
 
 
+async def test_async_update_rediscovered_entry_skips_entry_when_connect_raises() -> (
+    None
+):
+    """A connection-level error on one entry must not abort rediscovery."""
+    flow = TrueNASConfigFlow()
+    flow.hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_API_KEY: "key", CONF_VERIFY_SSL: True}
+    flow.hass.config_entries.async_entries.return_value = [entry]
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    api = MagicMock()
+    api.connect = AsyncMock(side_effect=RuntimeError("boom"))
+    api.query = AsyncMock()
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await flow._async_update_rediscovered_entry("5.6.7.8") is False
+
+    api.disconnect.assert_awaited_once()
+    api.query.assert_not_called()
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+    flow.hass.config_entries.async_reload.assert_not_awaited()
+
+
+async def test_async_update_rediscovered_entry_updates_host_when_query_raises() -> None:
+    """Host is migrated even if the system id lookup fails for legacy entries."""
+    flow = TrueNASConfigFlow()
+    flow.hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_API_KEY: "key", CONF_VERIFY_SSL: True}
+    flow.hass.config_entries.async_entries.return_value = [entry]
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    api = MagicMock()
+    api.connect = AsyncMock(return_value=True)
+    api.query = AsyncMock(side_effect=RuntimeError("boom"))
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await flow._async_update_rediscovered_entry("5.6.7.8") is True
+
+    _, kwargs = flow.hass.config_entries.async_update_entry.call_args
+    assert kwargs["data"][CONF_HOST] == "5.6.7.8"
+    assert CONF_SYSTEM_ID not in kwargs["data"]
+    assert "unique_id" not in kwargs
+
+
 # ---------------------------
 #   TrueNASConfigFlow._find_legacy_config
 # ---------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -345,6 +345,32 @@ async def test_async_update_rediscovered_entry_skips_unique_id_when_id_unknown()
     assert kwargs["data"][CONF_HOST] == "5.6.7.8"
 
 
+async def test_async_update_rediscovered_entry_skips_mismatched_system_id() -> None:
+    """A different probed system id must not merge two distinct TrueNAS boxes."""
+    flow = TrueNASConfigFlow()
+    flow.hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {
+        CONF_HOST: "1.2.3.4",
+        CONF_API_KEY: "key",
+        CONF_VERIFY_SSL: True,
+        CONF_SYSTEM_ID: "stored-system-id",
+    }
+    flow.hass.config_entries.async_entries.return_value = [entry]
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    api = MagicMock()
+    api.connect = AsyncMock(return_value=True)
+    api.query = AsyncMock(return_value="different-system-id")
+    api.disconnect = AsyncMock()
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await flow._async_update_rediscovered_entry("5.6.7.8") is False
+
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+    flow.hass.config_entries.async_reload.assert_not_awaited()
+
+
 # ---------------------------
 #   TrueNASConfigFlow._find_legacy_config
 # ---------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -232,6 +232,7 @@ async def test_validate_connection_system_id_lookup_failure_does_not_block() -> 
         await flow._validate_connection(config, errors)
     assert not errors
     assert CONF_SYSTEM_ID not in config
+    api.query.assert_awaited_once_with("system.global.id")
     api.disconnect.assert_awaited_once()
 
 
@@ -291,6 +292,17 @@ async def test_probe_is_truenas_false_when_connect_raises() -> None:
         assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is False
     assert mock_api.call_count == 2
     assert api.disconnect.await_count == 2
+
+
+async def test_probe_is_truenas_true_when_disconnect_raises() -> None:
+    """A broken disconnect() must not abort the probe for the whole flow."""
+    api = MagicMock()
+    api.connect = AsyncMock()
+    api.disconnect = AsyncMock(side_effect=OSError("already closed"))
+    api.error = ERR_INVALID_KEY
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is True
+    api.disconnect.assert_awaited_once()
 
 
 # ---------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -25,8 +25,10 @@ from custom_components.truenas_ce.config_flow import (
     configured_instances,
 )
 from custom_components.truenas_ce.const import (
+    CONF_SYSTEM_ID,
     DOMAIN,
     ERR_CERT_VERIFY_FAILED,
+    ERR_CONNECTION_REFUSED,
     ERR_INVALID_KEY,
     ERR_MALFORMED_RESULT,
     LEGACY_DOMAIN,
@@ -193,10 +195,13 @@ async def test_validate_connection_success_sets_no_errors() -> None:
     errors: dict[str, str] = {}
     api = MagicMock()
     api.connection_test = AsyncMock(return_value=(True, ""))
+    api.query = AsyncMock(return_value="test-global-id")
     api.disconnect = AsyncMock()
     with patch.object(config_flow, "TrueNASAPI", return_value=api):
         await flow._validate_connection(config, errors)
     assert not errors
+    assert config[CONF_SYSTEM_ID] == "test-global-id"
+    api.query.assert_awaited_once_with("system.global.id")
     api.disconnect.assert_awaited_once()
 
 
@@ -210,6 +215,53 @@ async def test_validate_connection_failure_maps_error() -> None:
     with patch.object(config_flow, "TrueNASAPI", return_value=api):
         await flow._validate_connection(config, errors)
     assert errors[CONF_HOST] == ERR_MALFORMED_RESULT
+
+
+# ---------------------------
+#   TrueNASConfigFlow._probe_is_truenas
+# ---------------------------
+async def test_probe_is_truenas_true_on_invalid_key() -> None:
+    """A bogus-key rejection proves it's a real TrueNAS JSON-RPC endpoint."""
+    api = MagicMock()
+    api.connect = AsyncMock()
+    api.disconnect = AsyncMock()
+    api.error = ERR_INVALID_KEY
+    with patch.object(config_flow, "TrueNASAPI", return_value=api) as mock_api:
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is True
+    mock_api.assert_called_once_with("1.2.3.4", "-", verify_ssl=False, scheme="wss")
+    api.disconnect.assert_awaited_once()
+
+
+async def test_probe_is_truenas_false_when_not_truenas() -> None:
+    """Any other error means some unrelated _http._tcp device, not TrueNAS."""
+    api = MagicMock()
+    api.connect = AsyncMock()
+    api.disconnect = AsyncMock()
+    api.error = ERR_CONNECTION_REFUSED
+    with patch.object(config_flow, "TrueNASAPI", return_value=api) as mock_api:
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is False
+    assert mock_api.call_count == 2
+    assert api.disconnect.await_count == 2
+
+
+async def test_probe_is_truenas_falls_back_from_wss_to_ws() -> None:
+    """A wss failure still tries plain ws before giving up."""
+    wss_api = MagicMock()
+    wss_api.connect = AsyncMock()
+    wss_api.disconnect = AsyncMock()
+    wss_api.error = ERR_CONNECTION_REFUSED
+
+    ws_api = MagicMock()
+    ws_api.connect = AsyncMock()
+    ws_api.disconnect = AsyncMock()
+    ws_api.error = ERR_INVALID_KEY
+
+    with patch.object(
+        config_flow, "TrueNASAPI", side_effect=[wss_api, ws_api]
+    ) as mock_api:
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") is True
+    assert mock_api.call_count == 2
+    mock_api.assert_any_call("1.2.3.4", "-", verify_ssl=False, scheme="ws")
 
 
 # ---------------------------

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -239,7 +239,9 @@ def _zeroconf_discovery_info(host: str = "192.168.1.50") -> ZeroconfServiceInfo:
 
 async def test_zeroconf_flow_confirms_and_creates_entry(hass: HomeAssistant) -> None:
     with patch.object(
-        config_flow.TrueNASConfigFlow, "_probe_is_truenas", AsyncMock(return_value=True)
+        config_flow.TrueNASConfigFlow,
+        "_probe_is_truenas",
+        AsyncMock(return_value="192.168.1.50"),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -266,11 +268,39 @@ async def test_zeroconf_flow_confirms_and_creates_entry(hass: HomeAssistant) -> 
     assert result["data"][CONF_HOST] == "192.168.1.50"
 
 
+async def test_zeroconf_flow_keeps_advertised_port(hass: HomeAssistant) -> None:
+    """A box found only on its advertised port is configured with that port."""
+    with patch.object(
+        config_flow.TrueNASConfigFlow,
+        "_probe_is_truenas",
+        AsyncMock(return_value="192.168.1.50:8443"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info(),
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["description_placeholders"] == {CONF_HOST: "192.168.1.50:8443"}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    with (
+        patch(f"{_API_PATH}.connection_test", AsyncMock(return_value=(True, None))),
+        patch(f"{_API_PATH}.query", AsyncMock(return_value=None)),
+        patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_input(**{CONF_HOST: "192.168.1.50:8443"})
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == "192.168.1.50:8443"
+
+
 async def test_zeroconf_flow_aborts_when_not_truenas(hass: HomeAssistant) -> None:
     with patch.object(
         config_flow.TrueNASConfigFlow,
         "_probe_is_truenas",
-        AsyncMock(return_value=False),
+        AsyncMock(return_value=None),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -310,7 +340,7 @@ async def test_zeroconf_flow_updates_rediscovered_entry_host(
         patch.object(
             config_flow.TrueNASConfigFlow,
             "_probe_is_truenas",
-            AsyncMock(return_value=True),
+            AsyncMock(return_value="192.168.1.50"),
         ),
         patch(f"{_API_PATH}.connect", AsyncMock(return_value=True)),
         patch(f"{_API_PATH}.query", AsyncMock(return_value="new-global-id")),
@@ -343,7 +373,7 @@ async def test_zeroconf_flow_ignores_entry_with_mismatched_system_id(
         patch.object(
             config_flow.TrueNASConfigFlow,
             "_probe_is_truenas",
-            AsyncMock(return_value=True),
+            AsyncMock(return_value="192.168.1.50"),
         ),
         patch(f"{_API_PATH}.connect", AsyncMock(return_value=True)),
         patch(f"{_API_PATH}.query", AsyncMock(return_value="different-id")),

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -15,6 +15,7 @@ module when the package is absent, e.g. on the local Windows dev machine.
 
 from __future__ import annotations
 
+import ipaddress
 from collections.abc import Iterator
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -25,8 +26,10 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_NAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.truenas_ce import config_flow
 from custom_components.truenas_ce.const import (
     CONF_BEHAVIORS,
     CONF_CRONJOB_SKIP_DISABLED,
@@ -34,6 +37,7 @@ from custom_components.truenas_ce.const import (
     CONF_DATASET_PASSPHRASES,
     CONF_MONITORED_GROUPS,
     CONF_POLL_INTERVAL,
+    CONF_SYSTEM_ID,
     DEFAULT_CRONJOB_SKIP_DISABLED,
     DEFAULT_DATA_UNIT,
     DEFAULT_HOST,
@@ -164,6 +168,141 @@ async def test_user_flow_connection_error_maps_to_ha_error(hass: HomeAssistant) 
         )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: ERR_INVALID_KEY}
+
+
+# ---------------------------
+#   zeroconf step
+# ---------------------------
+def _zeroconf_discovery_info(host: str = "192.168.1.50") -> ZeroconfServiceInfo:
+    return ZeroconfServiceInfo(
+        ip_address=ipaddress.ip_address(host),
+        ip_addresses=[ipaddress.ip_address(host)],
+        port=80,
+        hostname="truenas.local.",
+        type="_http._tcp.local.",
+        name="truenas._http._tcp.local.",
+        properties={},
+    )
+
+
+async def test_zeroconf_flow_confirms_and_creates_entry(hass: HomeAssistant) -> None:
+    with patch.object(
+        config_flow.TrueNASConfigFlow, "_probe_is_truenas", AsyncMock(return_value=True)
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info(),
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"] == {CONF_HOST: "192.168.1.50"}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(f"{_API_PATH}.connection_test", AsyncMock(return_value=(True, None))),
+        patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_input(**{CONF_HOST: "192.168.1.50"})
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == "192.168.1.50"
+
+
+async def test_zeroconf_flow_aborts_when_not_truenas(hass: HomeAssistant) -> None:
+    with patch.object(
+        config_flow.TrueNASConfigFlow,
+        "_probe_is_truenas",
+        AsyncMock(return_value=False),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info(),
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_truenas"
+
+
+async def test_zeroconf_flow_aborts_on_already_configured_host(
+    hass: HomeAssistant,
+) -> None:
+    existing = MockConfigEntry(
+        domain=DOMAIN, data=_user_input(**{CONF_HOST: "192.168.1.50"})
+    )
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_zeroconf_discovery_info(),
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_flow_updates_rediscovered_entry_host(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=_user_input(**{CONF_HOST: "old-host.example.com"})
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(
+            config_flow.TrueNASConfigFlow,
+            "_probe_is_truenas",
+            AsyncMock(return_value=True),
+        ),
+        patch(f"{_API_PATH}.connect", AsyncMock(return_value=True)),
+        patch(f"{_API_PATH}.query", AsyncMock(return_value="new-global-id")),
+        patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info(),
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == "192.168.1.50"
+    assert entry.data[CONF_SYSTEM_ID] == "new-global-id"
+
+
+async def test_zeroconf_flow_ignores_entry_with_mismatched_system_id(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=_user_input(
+            **{CONF_HOST: "old-host.example.com", CONF_SYSTEM_ID: "old-id"}
+        ),
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(
+            config_flow.TrueNASConfigFlow,
+            "_probe_is_truenas",
+            AsyncMock(return_value=True),
+        ),
+        patch(f"{_API_PATH}.connect", AsyncMock(return_value=True)),
+        patch(f"{_API_PATH}.query", AsyncMock(return_value="different-id")),
+        patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info(),
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert entry.data[CONF_HOST] == "old-host.example.com"
 
 
 # ---------------------------

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -226,6 +226,7 @@ async def test_zeroconf_flow_confirms_and_creates_entry(hass: HomeAssistant) -> 
 
     with (
         patch(f"{_API_PATH}.connection_test", AsyncMock(return_value=(True, None))),
+        patch(f"{_API_PATH}.query", AsyncMock(return_value=None)),
         patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
     ):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -128,6 +128,28 @@ async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
     assert result["data"][CONF_HOST] == "truenas.example.com"
 
 
+async def test_user_flow_creates_entry_with_system_id_as_unique_id(
+    hass: HomeAssistant,
+) -> None:
+    """Once the box's stable identity is known it becomes the entry's unique_id."""
+    with (
+        patch(f"{_API_PATH}.connection_test", AsyncMock(return_value=(True, None))),
+        patch(f"{_API_PATH}.query", AsyncMock(return_value="box-guid-123")),
+        patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_input()
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SYSTEM_ID] == "box-guid-123"
+    entry = hass.config_entries.async_get_entry(result["result"].entry_id)
+    assert entry is not None
+    assert entry.unique_id == "box-guid-123"
+
+
 async def test_user_flow_name_already_exists(hass: HomeAssistant) -> None:
     existing = MockConfigEntry(
         domain=DOMAIN, data=_user_input(**{CONF_HOST: "other-host.example.com"})
@@ -272,6 +294,7 @@ async def test_zeroconf_flow_updates_rediscovered_entry_host(
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == "192.168.1.50"
     assert entry.data[CONF_SYSTEM_ID] == "new-global-id"
+    assert entry.unique_id == "new-global-id"
 
 
 async def test_zeroconf_flow_ignores_entry_with_mismatched_system_id(

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -150,6 +150,36 @@ async def test_user_flow_creates_entry_with_system_id_as_unique_id(
     assert entry.unique_id == "box-guid-123"
 
 
+async def test_user_flow_aborts_on_duplicate_system_id(hass: HomeAssistant) -> None:
+    """A second entry for the same box (different host) must not be created.
+
+    The user-flow host-uniqueness guard alone would miss this, since the new
+    entry uses a different host; the system_id-based unique_id check must
+    catch it instead.
+    """
+    existing = MockConfigEntry(
+        domain=DOMAIN,
+        data=_user_input(**{CONF_HOST: "old-host.example.com"}),
+        unique_id="box-guid-123",
+    )
+    existing.add_to_hass(hass)
+
+    with (
+        patch(f"{_API_PATH}.connection_test", AsyncMock(return_value=(True, None))),
+        patch(f"{_API_PATH}.query", AsyncMock(return_value="box-guid-123")),
+        patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            _user_input(**{CONF_HOST: "new-host.example.com", CONF_NAME: "New Name"}),
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 async def test_user_flow_name_already_exists(hass: HomeAssistant) -> None:
     existing = MockConfigEntry(
         domain=DOMAIN, data=_user_input(**{CONF_HOST: "other-host.example.com"})

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -428,6 +428,58 @@ async def test_reauth_flow_updates_api_key(hass: HomeAssistant) -> None:
     assert entry.data[CONF_API_KEY] == "new-key"
 
 
+async def test_reauth_flow_stores_system_id_on_success(hass: HomeAssistant) -> None:
+    """A successful reauth also picks up system.global.id, if resolvable."""
+    entry = MockConfigEntry(domain=DOMAIN, data=_user_input())
+    entry.add_to_hass(hass)
+
+    with (
+        patch(f"{_API_PATH}.connection_test", AsyncMock(return_value=(True, None))),
+        patch(f"{_API_PATH}.query", AsyncMock(return_value="box-guid-123")),
+        patch(f"{_API_PATH}.disconnect", AsyncMock(return_value=None)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+            },
+            data=entry.data,
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_API_KEY: "new-key"}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_API_KEY] == "new-key"
+    assert entry.data[CONF_SYSTEM_ID] == "box-guid-123"
+
+
+@pytest.mark.usefixtures("_mock_connection_ok")
+async def test_reauth_flow_succeeds_without_system_id_when_lookup_fails(
+    hass: HomeAssistant,
+) -> None:
+    """A failed system.global.id lookup must not block reauthentication."""
+    entry = MockConfigEntry(domain=DOMAIN, data=_user_input())
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+        },
+        data=entry.data,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_API_KEY: "new-key"}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_API_KEY] == "new-key"
+    assert CONF_SYSTEM_ID not in entry.data
+
+
 async def test_reauth_flow_shows_error_on_failed_connection(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Proposed change
Implements three Home Assistant Gold quality-scale rules:

- **discovery**: TrueNAS SCALE only advertises the generic `_http._tcp` mDNS type. `async_step_zeroconf` probes the discovered host with a deliberately-wrong API key — a TrueNAS JSON-RPC endpoint answers the WebSocket handshake and rejects it specifically (`ERR_INVALID_KEY`), while any other `_http._tcp` device fails earlier. Only a confirmed TrueNAS host reaches the confirm form.
- **discovery-update-info**: A rediscovered TrueNAS box (e.g. after a DHCP lease change) auto-updates its config entry's host. Every successful connection now records `system.global.id` on the entry; when zeroconf confirms a host is genuinely TrueNAS, existing entries' stored API keys are tried against it, and a matching/successful login silently updates+reloads the entry with the new host.
- **docs-known-limitations**: README gains a consolidated "Known Limitations" section, replacing previously-scattered hints.

## Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information
Part of the ongoing Gold quality-scale effort (`quality_scale.yaml`). The three remaining Gold rules (`entity-translations`, `exception-translations`, `icon-translations`) are being tackled in follow-up branches/PRs. `manifest.json`'s `quality_scale` field stays at `silver` until all Gold rules are done.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Add mDNS-based discovery and rediscovery improvements for the TrueNAS integration and document current limitations.

New Features:
- Support zeroconf discovery of TrueNAS instances via the generic _http._tcp mDNS service, including a confirmation step and manifest zeroconf declaration.
- Use the TrueNAS system.global.id value as a stable per-installation identifier to key config entry unique_ids and prevent duplicate entries for the same box.
- Automatically update an existing config entry when the same TrueNAS box is rediscovered under a new host or IP address.

Enhancements:
- Record the TrueNAS system.global.id on successful connections and reauth flows without blocking setup when the lookup fails.
- Harden config flow connection handling with shared helpers for safe connect, disconnect, and system ID lookup during probes and rediscovery.
- Mark the discovery, discovery-update-info, and docs-known-limitations quality-scale rules as completed in quality_scale.yaml.

Documentation:
- Add a consolidated Known Limitations section to the README describing unsupported auth gateways, development builds, run-button UX, polling gaps, scrub threshold behavior, and container action targeting.

Tests:
- Expand config flow tests to cover system ID storage, zeroconf discovery and abort paths, rediscovery host/unique_id migration, and reauth behavior with and without system ID.