### PR TITLE
fix: pin and hash-lock pip installs in CI/release workflows

### DIFF
--- a/.github/generate_requirements.py
+++ b/.github/generate_requirements.py
@@ -1,20 +1,34 @@
 import configparser
+import json
+
+
+def _write_locked_requirements(packages: dict, path: str) -> None:
+    """Write a pip requirements file pinned and hashed from a Pipfile.lock section.
+
+    Every entry already carries its fully-resolved version and hashes, so the
+    output is compatible with `pip install --require-hashes`.
+    """
+    with open(path, "w") as f:
+        for name in sorted(packages):
+            spec = packages[name]
+            line = f"{name}{spec['version']}"
+            if markers := spec.get("markers"):
+                line += f"; {markers}"
+            for digest in spec["hashes"]:
+                line += f" --hash={digest}"
+            f.write(line + "\n")
 
 
 def main():
+    with open("Pipfile.lock") as f:
+        lock = json.load(f)
+    _write_locked_requirements(lock["default"], "requirements.txt")
+
     parser = configparser.ConfigParser()
     parser.read("Pipfile")
-
-    packages = "packages"
-    with open("requirements.txt", "w") as f:
-        for key in parser[packages]:
-            value = parser[packages][key]
-            f.write(key + value.replace('"', "") + "\n")
-
-    devpackages = "dev-packages"
     with open("requirements_tests.txt", "w") as f:
-        for key in parser[devpackages]:
-            value = parser[devpackages][key]
+        for key in parser["dev-packages"]:
+            value = parser["dev-packages"][key]
             f.write(key + value.replace('"', "") + "\n")
 
 

--- a/.github/generate_requirements.py
+++ b/.github/generate_requirements.py
@@ -11,6 +11,8 @@ def _write_locked_requirements(packages: dict, path: str) -> None:
     with open(path, "w") as f:
         for name in sorted(packages):
             spec = packages[name]
+            if extras := spec.get("extras"):
+                name += f"[{','.join(sorted(extras))}]"
             line = f"{name}{spec['version']}"
             if markers := spec.get("markers"):
                 line += f"; {markers}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
           pip install --require-hashes --only-binary ":all:" -r requirements.txt
           pip install -r requirements_tests.txt
       - name: Install pytest-homeassistant-custom-component (CI-only, Linux)
+        # --only-binary omitted: its mock-open==1.4.0 dependency has never
+        # published a wheel, only an sdist, on any release.
         run: |
-          pip install --only-binary ":all:" pytest-homeassistant-custom-component==0.13.348
+          pip install pytest-homeassistant-custom-component==0.13.348
       - name: Test with pytest
         run: pytest --cov=custom_components/truenas_ce --cov-report=term-missing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Ruff
-        run: pip install ruff
+        run: pip install --only-binary ":all:" ruff==0.15.21
       - name: Run Ruff Check
         run: ruff check .
       - name: Run Ruff Format
@@ -52,11 +52,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install --require-hashes --only-binary ":all:" -r requirements.txt
           pip install -r requirements_tests.txt
       - name: Install pytest-homeassistant-custom-component (CI-only, Linux)
         run: |
-          pip install pytest-homeassistant-custom-component
+          pip install --only-binary ":all:" pytest-homeassistant-custom-component==0.13.348
       - name: Test with pytest
         run: pytest --cov=custom_components/truenas_ce --cov-report=term-missing
 
@@ -78,9 +78,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install --require-hashes --only-binary ":all:" -r requirements.txt
           pip install -r requirements_tests.txt
-          pip install mypy
+          pip install --only-binary ":all:" mypy==2.3.0
       - name: Run mypy (strict, per pyproject.toml)
         run: mypy
 
@@ -98,7 +98,7 @@ jobs:
         with:
           python-version: '3.14'
       - name: Install Bandit
-        run: pip install bandit
+        run: pip install --only-binary ":all:" bandit==1.9.4
       - name: Security check - Bandit
         run: bandit -r custom_components/truenas_ce
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install requirements
         run: |
-          python3 -m pip install setuptools wheel PyGithub
+          python3 -m pip install --only-binary ":all:" setuptools==83.0.0 wheel==0.47.0 PyGithub==2.9.1
 
       - name: Update release notes
         env:


### PR DESCRIPTION
## Proposed change
SonarCloud flags the master branch quality gate red (`new_security_rating`) due to 19 open vulnerability findings (S8541/S8544) on unpinned/unhashed `pip install` calls in `.github/workflows/ci.yml` and `release.yml`. This PR pins and hash-locks those installs:

- `requirements.txt` is now generated from `Pipfile.lock` with exact versions + hashes, installed via `pip install --require-hashes --only-binary :all:`.
- Standalone tool installs (`ruff`, `mypy`, `bandit`, `pytest-homeassistant-custom-component`, `setuptools`/`wheel`/`PyGithub` in `release.yml`) are pinned to specific versions with `--only-binary :all:`.
- `requirements_tests.txt` still resolves from the loose `Pipfile` ranges as before: `Pipfile.lock` was locked on Windows and includes Windows-only transitive packages (`winrt-*`) with no Linux distribution at all, so hash-locking that file would break installs on the `ubuntu-latest` CI runner (verified via PyPI file-listing checks before implementing).

## Type of change
- [x] Code quality improvements to existing code or addition of tests

## Additional information
Remaining S8541/S8544 findings on the two `-r requirements_tests.txt` lines are being marked as an accepted risk in SonarCloud with the rationale above, rather than force-hash-locking a Windows-resolved lock file for a dev/test-only dependency tree that never ships to end users.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Pin and hash-lock Python dependencies for CI and release workflows to address security findings around unpinned pip installs.

Enhancements:
- Generate requirements.txt from Pipfile.lock with fully pinned, hash-locked dependencies suitable for pip --require-hashes.
- Keep requirements_tests.txt generation based on Pipfile dev-packages while simplifying its generation logic.
- Pin versions of Ruff, mypy, and Bandit in CI workflows and enforce binary-only installs where possible.
- Pin setuptools, wheel, and PyGithub versions in the release workflow and install them as wheels only.