### PR TITLE
fix: log expected EACCES call errors at debug instead of error level

### DIFF
--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -1,7 +1,7 @@
 """TrueNAS API."""
 
 import asyncio
-from logging import DEBUG, getLogger
+from logging import DEBUG, ERROR, getLogger
 from typing import Any
 
 from aiotruenas import TrueNASClient
@@ -97,6 +97,25 @@ def _classify_exception(exc: TrueNASError, *, during_call: bool) -> str:
             if isinstance(exc, exc_type)
         ),
         ERR_UNKNOWN,
+    )
+
+
+def _log_call_error(host: str, exc: TrueNASCallError) -> None:
+    """Log a TrueNAS call error, quietly for expected permission errors.
+
+    A read-only-scoped API key gets an ``EACCES`` response from admin-only
+    methods (e.g. ``smb.status``). That is a permanent, expected condition
+    for that key -- not an integration bug -- so logging it at ERROR with a
+    full traceback on every poll cycle (see issue #46) would flood the log
+    for no benefit; log it at debug instead.
+    """
+    permission_denied = exc.errname == "EACCES"
+    _LOGGER.log(
+        DEBUG if permission_denied else ERROR,
+        ERROR_API_FORMAT,
+        host,
+        exc,
+        exc_info=None if permission_denied else exc,
     )
 
 
@@ -237,7 +256,7 @@ class TrueNASAPI:
             data = await self._client.call(service, params)
         except TrueNASCallError as exc:
             self._error = exc.reason or str(exc) or ERR_UNKNOWN
-            _LOGGER.exception(ERROR_API_FORMAT, self._host, exc)
+            _log_call_error(self._host, exc)
             return None
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)
@@ -285,7 +304,7 @@ class TrueNASAPI:
             return await self._client.subscribe(event)
         except TrueNASCallError as exc:
             self._error = exc.reason or str(exc) or ERR_UNKNOWN
-            _LOGGER.exception(ERROR_API_FORMAT, self._host, exc)
+            _log_call_error(self._host, exc)
             return None, None
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)
@@ -364,7 +383,7 @@ class TrueNASAPI:
             return events
         except TrueNASCallError as exc:
             self._error = exc.reason or str(exc) or ERR_UNKNOWN
-            _LOGGER.exception(ERROR_API_FORMAT, self._host, exc)
+            _log_call_error(self._host, exc)
             return []
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)

--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -106,8 +106,8 @@ def _log_call_error(host: str, exc: TrueNASCallError) -> None:
     A read-only-scoped API key gets an ``EACCES`` response from admin-only
     methods (e.g. ``smb.status``). That is a permanent, expected condition
     for that key -- not an integration bug -- so logging it at ERROR with a
-    full traceback on every poll cycle (see issue #46) would flood the log
-    for no benefit; log it at debug instead.
+    full traceback on every call would flood the log for no benefit; log it
+    at debug instead.
     """
     permission_denied = exc.errname == "EACCES"
     _LOGGER.log(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -374,6 +374,10 @@ async def test_query_non_permission_call_error_still_logs_error(
     error_records = [record for record in caplog.records if record.levelname == "ERROR"]
     assert error_records
     assert all(record.exc_info is not None for record in error_records)
+    assert any(
+        "truenas.local" in record.getMessage() and "boom" in record.getMessage()
+        for record in error_records
+    )
 
 
 # ---------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -357,10 +357,9 @@ async def test_query_permission_denied_logs_debug_not_error(
         assert await connected_api.query("smb.status") is None
     assert connected_api.error == "[EACCES] Not authorized"
     assert not any(record.levelname == "ERROR" for record in caplog.records)
-    assert any(
-        record.levelname == "DEBUG" and "API error" in record.getMessage()
-        for record in caplog.records
-    )
+    debug_records = [record for record in caplog.records if record.levelname == "DEBUG"]
+    assert any("API error" in record.getMessage() for record in debug_records)
+    assert all(record.exc_info is None for record in debug_records)
 
 
 async def test_query_non_permission_call_error_still_logs_error(
@@ -372,7 +371,9 @@ async def test_query_non_permission_call_error_still_logs_error(
     )
     with caplog.at_level("DEBUG", logger=api_module.__name__):
         assert await connected_api.query("system.info") is None
-    assert any(record.levelname == "ERROR" for record in caplog.records)
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert error_records
+    assert all(record.exc_info is not None for record in error_records)
 
 
 # ---------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -341,6 +341,40 @@ async def test_query_logs_summarized_payload_when_debug_enabled(
     assert "dict[1 keys]" in caplog.text
 
 
+async def test_query_permission_denied_logs_debug_not_error(
+    connected_api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A read-only API key's EACCES on an admin-only method (issue #46) must
+
+    stay quiet: DEBUG, no traceback -- not an ERROR flooding the log every
+    poll cycle.
+    """
+    connected_api._client.call.side_effect = TrueNASCallError(
+        "Not authorized", code=13, errname="EACCES", reason="[EACCES] Not authorized"
+    )
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        assert await connected_api.query("smb.status") is None
+    assert connected_api.error == "[EACCES] Not authorized"
+    assert not any(record.levelname == "ERROR" for record in caplog.records)
+    assert any(
+        record.levelname == "DEBUG" and "API error" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+async def test_query_non_permission_call_error_still_logs_error(
+    connected_api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    connected_api._client.call.side_effect = TrueNASCallError(
+        "boom", code=22, errname="EINVAL", reason="bad params"
+    )
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        assert await connected_api.query("system.info") is None
+    assert any(record.levelname == "ERROR" for record in caplog.records)
+
+
 # ---------------------------
 #   error / scheme properties
 # ---------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -410,6 +410,43 @@ async def test_subscribe_events_returns_none_on_failure(
     assert connected_api.error == "nope"
 
 
+async def test_subscribe_events_permission_denied_logs_debug_not_error(
+    connected_api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    connected_api._client.subscribe = AsyncMock(
+        side_effect=TrueNASCallError(
+            "Not authorized",
+            code=13,
+            errname="EACCES",
+            reason="[EACCES] Not authorized",
+        )
+    )
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        sub_id, queue = await connected_api.subscribe_events("app.stats")
+    assert sub_id is None
+    assert queue is None
+    assert not any(record.levelname == "ERROR" for record in caplog.records)
+
+
+async def test_subscribe_events_non_permission_call_error_still_logs_error(
+    connected_api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    connected_api._client.subscribe = AsyncMock(
+        side_effect=TrueNASCallError(
+            "boom", code=22, errname="EINVAL", reason="bad params"
+        )
+    )
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        sub_id, queue = await connected_api.subscribe_events("app.stats")
+    assert sub_id is None
+    assert queue is None
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert error_records
+    assert all(record.exc_info is not None for record in error_records)
+
+
 async def test_unsubscribe_events_calls_client(connected_api: TrueNASAPI) -> None:
     connected_api._client.unsubscribe = AsyncMock()
     await connected_api.unsubscribe_events("sub-123")
@@ -456,6 +493,41 @@ async def test_get_subscription_events_call_error(connected_api: TrueNASAPI) -> 
     result = await connected_api.get_subscription_events("sub-123")
     assert result == []
     assert connected_api.error == "nope"
+
+
+async def test_get_subscription_events_permission_denied_logs_debug_not_error(
+    connected_api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    connected_api._client.get_subscription_events = AsyncMock(
+        side_effect=TrueNASCallError(
+            "Not authorized",
+            code=13,
+            errname="EACCES",
+            reason="[EACCES] Not authorized",
+        )
+    )
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        result = await connected_api.get_subscription_events("sub-123")
+    assert result == []
+    assert not any(record.levelname == "ERROR" for record in caplog.records)
+
+
+async def test_get_subscription_events_non_permission_call_error_still_logs_error(
+    connected_api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    connected_api._client.get_subscription_events = AsyncMock(
+        side_effect=TrueNASCallError(
+            "boom", code=22, errname="EINVAL", reason="bad params"
+        )
+    )
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        result = await connected_api.get_subscription_events("sub-123")
+    assert result == []
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert error_records
+    assert all(record.exc_info is not None for record in error_records)
 
 
 async def test_get_subscription_events_generic_error(connected_api: TrueNASAPI) -> None:


### PR DESCRIPTION
## Proposed change
Fixes #46. Read-only-scoped API keys get an `EACCES`/"Not authorized" response from admin-only methods (e.g. `smb.status`), which is a permanent, expected condition for that key rather than an integration bug. `query()`/`subscribe_events()`/`get_subscription_events()` were logging every occurrence at ERROR with a full traceback, and since `smb.status` is polled every ~60s, this flooded the Home Assistant log. Permission-denied (`errname == "EACCES"`) call errors are now logged at DEBUG without a traceback; all other call errors are unchanged (still ERROR with traceback).

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Verified locally: `ruff check`, `ruff format --check`, `mypy`, `bandit`, and the full test suite (774 tests) all pass. Two new unit tests cover the EACCES-to-debug path and confirm non-permission `TrueNASCallError`s still log at ERROR.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust TrueNAS integration call error logging to avoid flooding Home Assistant logs for expected permission-denied responses.

Bug Fixes:
- Treat EACCES permission-denied TrueNAS call errors as expected conditions and log them at debug level without tracebacks, while preserving error-level logging for other call failures.

Tests:
- Add unit tests verifying debug-only logging for EACCES permission-denied call errors and error-level logging with tracebacks for other TrueNASCallError scenarios across query and event subscription APIs.