### PR TITLE
chore: bump version to 2.5.2 for read-only API key log-noise fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.5.2] — Read-only API key log noise fix
+
+### Fixed
+- **Repeated ERROR-level log spam with a Read-Only Admin API key (#46):** calls like
+  `smb.status` return an `EACCES` permission error under a read-only-scoped key. That's an
+  expected, permanent condition for that key, not an integration bug, so every ~60s poll no
+  longer logs it at ERROR with a full traceback — it's now logged at DEBUG instead. Other call
+  errors are unaffected and still log at ERROR. Thanks to @jkadin for reporting.
+
 ## [2.5.1] — Sensor platform hotfix
 
 ### Fixed

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,7 +15,7 @@
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"
     ],
-    "version": "2.5.1",
+    "version": "2.5.2",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change
PR #49 (fixing #46 — repeated ERROR log noise for read-only-scoped API keys) merged to master without a version bump. This bumps `manifest.json` to 2.5.2 and adds the corresponding CHANGELOG entry, so a 2.5.2-rc1 prerelease can be cut for the reporter to verify.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Version-only/changelog change, no functional code touched.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the integration version to 2.5.2 and document the read-only API key log noise fix in the changelog.

Build:
- Update the integration manifest version from 2.5.1 to 2.5.2.

Documentation:
- Add a 2.5.2 changelog entry describing the reduction of repeated ERROR-level log spam for read-only-scoped API keys.