### PR TITLE
fix: keep zeroconf probe connection failures at debug, not error

### DIFF
--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -176,8 +176,18 @@ class TrueNASAPI:
     # ---------------------------
     #   connect
     # ---------------------------
-    async def connect(self) -> bool:
-        """Connect and log in. Return connected boolean."""
+    async def connect(self, *, quiet: bool = False) -> bool:
+        """Connect and log in. Return connected boolean.
+
+        Parameters
+        ----------
+        quiet:
+            Log a connection failure at debug instead of error. Used by
+            zeroconf discovery, which probes many non-TrueNAS devices on the
+            network and expects most connection attempts to fail -- logging
+            those at error with a full traceback would flood the log for no
+            benefit.
+        """
         if self._closed:
             self._error = ERR_UNKNOWN
             _LOGGER.error(
@@ -192,11 +202,12 @@ class TrueNASAPI:
             await self._client.connect()
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=False)
-            _LOGGER.error(
+            _LOGGER.log(
+                DEBUG if quiet else ERROR,
                 "Error while communicating with host %s: %s",
                 self._host,
                 exc,
-                exc_info=exc,
+                exc_info=None if quiet else exc,
             )
             return False
 

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -311,10 +311,12 @@ async def _async_try_connect(api: TrueNASAPI, host: str, context: str) -> bool:
     Shared by the zeroconf probe and the rediscovery match: both need to try
     one candidate connection and move on to the next on any problem rather
     than raising, so an unexpected exception here must not abort the whole
-    discovery/rediscovery flow.
+    discovery/rediscovery flow. ``quiet=True`` keeps ``connect()``'s own
+    failure logging at debug too, since most probed candidates are expected
+    to not be TrueNAS at all.
     """
     try:
-        return await api.connect()
+        return await api.connect(quiet=True)
     except Exception as err:
         _LOGGER.debug("TrueNAS %s: %s: %s", host, context, err)
         return False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -229,12 +229,14 @@ async def test_connect_quiet_logs_debug_not_error(
         assert await api.connect(quiet=True) is False
     assert api.error == ERR_CONNECTION_REFUSED
     assert not any(record.levelname == "ERROR" for record in caplog.records)
-    debug_records = [record for record in caplog.records if record.levelname == "DEBUG"]
-    assert any(
-        "Error while communicating with host" in record.getMessage()
-        for record in debug_records
-    )
-    assert all(record.exc_info is None for record in debug_records)
+    connect_debug_records = [
+        record
+        for record in caplog.records
+        if record.levelname == "DEBUG"
+        and "Error while communicating with host" in record.getMessage()
+    ]
+    assert len(connect_debug_records) == 1
+    assert connect_debug_records[0].exc_info is None
 
 
 # ---------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -203,6 +203,40 @@ async def test_connect_maps_exception_and_returns_false(api: TrueNASAPI) -> None
     assert api.error == ERR_UNKNOWN_HOSTNAME
 
 
+async def test_connect_failure_logs_error_by_default(
+    api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    api._client.connect.side_effect = TrueNASConnectionRefusedError("refused")
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        assert await api.connect() is False
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert error_records
+    assert all(record.exc_info is not None for record in error_records)
+
+
+async def test_connect_quiet_logs_debug_not_error(
+    api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Zeroconf discovery probes many non-TrueNAS devices (issue #46 follow-
+
+    up): a failed probe connection must stay quiet -- DEBUG, no traceback --
+    instead of flooding the log with an ERROR per candidate.
+    """
+    api._client.connect.side_effect = TrueNASConnectionRefusedError("refused")
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        assert await api.connect(quiet=True) is False
+    assert api.error == ERR_CONNECTION_REFUSED
+    assert not any(record.levelname == "ERROR" for record in caplog.records)
+    debug_records = [record for record in caplog.records if record.levelname == "DEBUG"]
+    assert any(
+        "Error while communicating with host" in record.getMessage()
+        for record in debug_records
+    )
+    assert all(record.exc_info is None for record in debug_records)
+
+
 # ---------------------------
 #   disconnect / close
 # ---------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -251,6 +251,22 @@ async def test_probe_is_truenas_true_on_invalid_key() -> None:
     api.disconnect.assert_awaited_once()
 
 
+async def test_probe_is_truenas_connects_quietly() -> None:
+    """Probing must not flood the log: most _http._tcp devices aren't TrueNAS.
+
+    Regression test for the follow-up to issue #46: zeroconf discovery
+    connecting to every non-TrueNAS device on the LAN was logging a full
+    ERROR traceback per candidate.
+    """
+    api = MagicMock()
+    api.connect = AsyncMock()
+    api.disconnect = AsyncMock()
+    api.error = ERR_INVALID_KEY
+    with patch.object(config_flow, "TrueNASAPI", return_value=api):
+        assert await TrueNASConfigFlow._probe_is_truenas("1.2.3.4") == "1.2.3.4"
+    api.connect.assert_awaited_once_with(quiet=True)
+
+
 async def test_probe_is_truenas_false_when_not_truenas() -> None:
     """Any other error means some unrelated _http._tcp device, not TrueNAS."""
     api = MagicMock()
@@ -365,6 +381,7 @@ async def test_async_update_rediscovered_entry_migrates_unique_id() -> None:
     assert kwargs["data"][CONF_HOST] == "5.6.7.8"
     assert kwargs["data"][CONF_SYSTEM_ID] == "box-guid-123"
     flow.hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    api.connect.assert_awaited_once_with(quiet=True)
 
 
 async def test_async_update_rediscovered_entry_skips_unique_id_when_id_unknown() -> (


### PR DESCRIPTION
## Proposed change

TrueNAS SCALE only advertises the generic `_http._tcp` mDNS service, shared by countless unrelated devices (printers, routers, media servers, ...). Zeroconf discovery therefore probes every such device on the network, and most connection attempts are expected to fail -- but `TrueNASAPI.connect()` unconditionally logged those failures at ERROR with a full traceback, flooding the log once per non-TrueNAS candidate.

Reported as a follow-up on #46, after the original read-only-API-key log-spam fix (#49) shipped: with a working key, the log spam moved from `smb.status` EACCES errors to zeroconf probe connection failures against unrelated LAN devices.

`connect()` now accepts a `quiet` flag that keeps its own failure logging at debug instead of error; the shared discovery/rediscovery helper in `config_flow.py` passes it so probing stays silent, while a user's actual connection attempt in the setup flow still logs loudly as before.

Fixes #46 (follow-up).

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

No behavior change to the discovery logic itself (still "any connection failure or non-invalid-key response means not TrueNAS") -- only the log level for expected probe failures changes.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Reduce log verbosity for expected TrueNAS zeroconf probe connection failures while preserving loud logging for user-initiated connections.

Bug Fixes:
- Prevent zeroconf-based TrueNAS discovery from flooding logs with ERROR-level tracebacks when probing non-TrueNAS _http._tcp devices.

Tests:
- Add tests verifying default connect() logs connection failures at ERROR with a traceback.
- Add tests verifying quiet connect() logs connection failures at DEBUG without a traceback and that zeroconf probing uses quiet connections.