### PR TITLE
fix: suppress aiotruenas insecure-TLS warning during zeroconf probing

### DIFF
--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -1,7 +1,10 @@
 """TrueNAS API."""
 
 import asyncio
-from logging import DEBUG, ERROR, getLogger
+import contextlib
+import contextvars
+from collections.abc import Iterator
+from logging import DEBUG, ERROR, Filter, LogRecord, getLogger
 from typing import Any
 
 from aiotruenas import TrueNASClient
@@ -49,6 +52,55 @@ _LOGGER = getLogger(__name__)
 # Full payloads can be huge (e.g. pool.query with topology or app.query), so
 # they are summarized and truncated to keep debug logs readable.
 _LOG_PAYLOAD_LIMIT = 500
+
+# Set for the duration of a quiet connect() so the filter below can drop
+# aiotruenas's own "verify_ssl=False" warning for that call only. A plain
+# module-level flag would leak across concurrent connects (e.g. a real,
+# non-quiet connection racing a zeroconf probe); a ContextVar stays scoped to
+# the current asyncio task instead.
+_quiet_insecure_tls_warning: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_quiet_insecure_tls_warning", default=False
+)
+
+# Message aiotruenas.client logs at WARNING from its own TrueNASClient
+# whenever verify_ssl=False, unconditionally -- including for every zeroconf
+# probe candidate, most of which are unrelated devices on the network
+# (reported as a second follow-up on issue #46). It is genuinely useful for a
+# user's real, configured connection, so it is only filtered out while
+# _quiet_insecure_tls_warning is set, i.e. during probing.
+_INSECURE_TLS_WARNING_PREFIX = "TrueNASClient configured with verify_ssl=False"
+
+
+class _QuietInsecureTlsWarningFilter(Filter):
+    """Drop aiotruenas's insecure-TLS warning while probing quietly."""
+
+    def filter(self, record: LogRecord) -> bool:
+        return not (
+            _quiet_insecure_tls_warning.get()
+            and record.getMessage().startswith(_INSECURE_TLS_WARNING_PREFIX)
+        )
+
+
+getLogger("aiotruenas.client").addFilter(_QuietInsecureTlsWarningFilter())
+
+
+@contextlib.contextmanager
+def _quiet_insecure_tls_warnings(active: bool) -> Iterator[None]:
+    """Drop aiotruenas's insecure-TLS warning for the duration of the block.
+
+    No-op unless ``active``, so a real (non-probing) connect still sees the
+    warning.
+    """
+    if not active:
+        yield
+        return
+
+    token = _quiet_insecure_tls_warning.set(True)
+    try:
+        yield
+    finally:
+        _quiet_insecure_tls_warning.reset(token)
+
 
 # aiotruenas exception -> ERR_* mapping (see const.py). Order matters: more
 # specific subclasses must be checked before their base classes, so this is
@@ -182,11 +234,13 @@ class TrueNASAPI:
         Parameters
         ----------
         quiet:
-            Log a connection failure at debug instead of error. Used by
-            zeroconf discovery, which probes many non-TrueNAS devices on the
-            network and expects most connection attempts to fail -- logging
-            those at error with a full traceback would flood the log for no
-            benefit.
+            Log a connection failure at debug instead of error, and drop
+            aiotruenas's own "verify_ssl=False" warning too. Used by zeroconf
+            discovery, which probes many non-TrueNAS devices on the network
+            and expects most connection attempts to fail -- logging those at
+            error with a full traceback (or the insecure-TLS warning, which
+            fires before the failure is even known) would flood the log for
+            no benefit.
         """
         if self._closed:
             self._error = ERR_UNKNOWN
@@ -199,7 +253,8 @@ class TrueNASAPI:
             return True
 
         try:
-            await self._client.connect()
+            with _quiet_insecure_tls_warnings(quiet):
+                await self._client.connect()
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=False)
             _LOGGER.log(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ network I/O happens.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -237,6 +238,54 @@ async def test_connect_quiet_logs_debug_not_error(
     ]
     assert len(connect_debug_records) == 1
     assert connect_debug_records[0].exc_info is None
+
+
+async def test_connect_quiet_suppresses_insecure_tls_warning(
+    api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression test for the second issue #46 follow-up.
+
+    aiotruenas's own ``TrueNASClient`` logs a "verify_ssl=False" warning
+    unconditionally, from inside ``connect()`` -- including for every
+    zeroconf-probed candidate, most of which are unrelated devices on the
+    network. During a quiet probe that warning must not leak out either.
+    """
+
+    async def _connect_and_warn() -> None:
+        logging.getLogger("aiotruenas.client").warning(
+            "TrueNASClient configured with verify_ssl=False for '%s'.",
+            "1.2.3.4",
+        )
+
+    api._client.connect.side_effect = _connect_and_warn
+    with caplog.at_level("WARNING", logger="aiotruenas.client"):
+        assert await api.connect(quiet=True) is True
+    assert not caplog.records
+
+
+async def test_connect_non_quiet_keeps_insecure_tls_warning(
+    api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A real (non-probing) connection must still surface the warning."""
+
+    async def _connect_and_warn() -> None:
+        logging.getLogger("aiotruenas.client").warning(
+            "TrueNASClient configured with verify_ssl=False for '%s'.",
+            "truenas.local",
+        )
+
+    api._client.connect.side_effect = _connect_and_warn
+    with caplog.at_level("WARNING", logger="aiotruenas.client"):
+        assert await api.connect() is True
+    assert any(
+        record.levelname == "WARNING"
+        and record.getMessage().startswith(
+            "TrueNASClient configured with verify_ssl=False"
+        )
+        for record in caplog.records
+    )
 
 
 # ---------------------------


### PR DESCRIPTION
## Proposed change

Follow-up to #46/#51: `aiotruenas.client` logs `TrueNASClient configured with verify_ssl=False for '<host>'` at WARNING unconditionally whenever it builds an SSL context, from inside its own `connect()`. Zeroconf discovery probes every `_http._tcp` device on the LAN (most of them unrelated to TrueNAS), so this warning fired once per probed candidate even after #51 quieted the probe's own connection-failure logging — reported by @jkadin as a second, remaining log-noise source on #46.

`TrueNASAPI.connect(quiet=True)` now also drops that specific warning for the duration of the call, via a `logging.Filter` on the `aiotruenas.client` logger gated by a task-scoped `ContextVar` — so a concurrent, real (non-quiet) connection still surfaces the warning as intended.

Validated live against a running Home Assistant instance: since the restart, the warning appears exactly once (for the real, configured TrueNAS host with SSL verification intentionally disabled), with no repeats from zeroconf probing and no TrueNAS-related ERROR log entries.

## Type of change

- [x] Bugfix

## Additional information

Related to #46.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Suppress aiotruenas insecure TLS warnings during quiet zeroconf connection probes while preserving them for real connections.

Bug Fixes:
- Ensure quiet TrueNASAPI connections used for zeroconf probing no longer emit repetitive insecure-TLS warnings from aiotruenas.
- Keep insecure-TLS warnings visible for non-quiet, user-initiated TrueNAS connections despite the new suppression during probing.

Tests:
- Add regression tests verifying that insecure-TLS warnings are suppressed for quiet zeroconf connections but still logged for normal connections.