### PR TITLE
feat: implement Gold quality-scale entity-translations

### DIFF
--- a/custom_components/truenas_ce/binary_sensor_types.py
+++ b/custom_components/truenas_ce/binary_sensor_types.py
@@ -123,7 +123,7 @@ class TrueNASBinarySensorEntityDescription(
 SENSOR_TYPES: tuple[TrueNASBinarySensorEntityDescription, ...] = (
     TrueNASBinarySensorEntityDescription(
         key="disk_issues",
-        name="Disk/Pool issues",
+        translation_key="disk_issues",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         ha_group="System",
@@ -135,7 +135,7 @@ SENSOR_TYPES: tuple[TrueNASBinarySensorEntityDescription, ...] = (
     ),
     TrueNASBinarySensorEntityDescription(
         key="pool_healthy",
-        name="healthy",
+        translation_key="pool_healthy",
         icon_enabled="mdi:database",
         icon_disabled="mdi:database-off",
         device_class=None,
@@ -215,7 +215,7 @@ SENSOR_TYPES: tuple[TrueNASBinarySensorEntityDescription, ...] = (
     ),
     TrueNASBinarySensorEntityDescription(
         key="interface",
-        name="Link",
+        translation_key="interface",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         ha_group="Network",
@@ -243,7 +243,7 @@ SENSOR_TYPES: tuple[TrueNASBinarySensorEntityDescription, ...] = (
     ),
     TrueNASBinarySensorEntityDescription(
         key="certificate_expired",
-        name="Expired",
+        translation_key="certificate_expired",
         icon_enabled="mdi:certificate-alert",
         icon_disabled="mdi:certificate-check",
         device_class=BinarySensorDeviceClass.PROBLEM,

--- a/custom_components/truenas_ce/button_types.py
+++ b/custom_components/truenas_ce/button_types.py
@@ -34,7 +34,7 @@ ICON_RUN = "mdi:play-circle-outline"
 SENSOR_TYPES: tuple[TrueNASButtonEntityDescription, ...] = (
     TrueNASButtonEntityDescription(
         key="snapshottask_run",
-        name="Run",
+        translation_key="snapshottask_run",
         icon=ICON_RUN,
         api_method=API_SNAPSHOTTASK_RUN,
         ha_group="Snapshot tasks",
@@ -45,7 +45,7 @@ SENSOR_TYPES: tuple[TrueNASButtonEntityDescription, ...] = (
     ),
     TrueNASButtonEntityDescription(
         key="rsync_run",
-        name="Run",
+        translation_key="rsync_run",
         icon=ICON_RUN,
         api_method=API_RSYNCTASK_RUN,
         ha_group="Rsync tasks",
@@ -56,7 +56,7 @@ SENSOR_TYPES: tuple[TrueNASButtonEntityDescription, ...] = (
     ),
     TrueNASButtonEntityDescription(
         key="replication_run",
-        name="Run",
+        translation_key="replication_run",
         icon=ICON_RUN,
         api_method=API_REPLICATION_RUN,
         ha_group="Replication",
@@ -67,7 +67,7 @@ SENSOR_TYPES: tuple[TrueNASButtonEntityDescription, ...] = (
     ),
     TrueNASButtonEntityDescription(
         key="cloudsync_run",
-        name="Run",
+        translation_key="cloudsync_run",
         icon=ICON_RUN,
         api_method=API_CLOUDSYNC_SYNC,
         ha_group="Cloudsync",
@@ -78,7 +78,7 @@ SENSOR_TYPES: tuple[TrueNASButtonEntityDescription, ...] = (
     ),
     TrueNASButtonEntityDescription(
         key="cronjob_run",
-        name="Run",
+        translation_key="cronjob_run",
         icon=ICON_RUN,
         api_method=API_CRONJOB_RUN,
         ha_group="Cron Jobs",
@@ -89,7 +89,7 @@ SENSOR_TYPES: tuple[TrueNASButtonEntityDescription, ...] = (
     ),
     TrueNASButtonEntityDescription(
         key="scrub_run",
-        name="Run scrub",
+        translation_key="scrub_run",
         icon="mdi:broom",
         ha_group="Pools",
         data_path="scrub",

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -36,6 +36,12 @@ _LOGGER = getLogger(__name__)
 
 _UNKNOWN_KEY = "<unknown>"
 
+# Mirrors the strings.json/translations lookup key format Home Assistant's
+# own Entity._name_internal builds for platform translations.
+_NAME_TRANSLATION_KEY_FORMAT = (
+    "component.{platform}.entity.{domain}.{translation_key}.name"
+)
+
 
 # ---------------------------
 #   format_unique_id
@@ -456,11 +462,15 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         translation_key = self.entity_description.translation_key
         platform_data = self.platform_data
         if translation_key and platform_data:
-            name_translation_key = (
-                f"component.{platform_data.platform_name}.entity."
-                f"{platform_data.domain}.{translation_key}.name"
+            name_translation_key = _NAME_TRANSLATION_KEY_FORMAT.format(
+                platform=platform_data.platform_name,
+                domain=platform_data.domain,
+                translation_key=translation_key,
             )
-            translated = platform_data.platform_translations.get(name_translation_key)
+            platform_translations: dict[str, str] = getattr(
+                platform_data, "platform_translations", {}
+            )
+            translated = platform_translations.get(name_translation_key)
             if translated:
                 return translated
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -445,15 +445,32 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         self._refresh_data()
         super()._handle_coordinator_update()
 
+    def _translated_description_name(self) -> str | None:
+        """Resolve the description's name, preferring loaded translations.
+
+        This entity builds its own name (below) instead of relying on HA's
+        has_entity_name machinery, so translation_key lookups have to be
+        replicated manually -- mirrors Entity._name_internal's platform-
+        translations lookup (homeassistant.helpers.entity).
+        """
+        translation_key = self.entity_description.translation_key
+        platform_data = self.platform_data
+        if translation_key and platform_data:
+            name_translation_key = (
+                f"component.{platform_data.platform_name}.entity."
+                f"{platform_data.domain}.{translation_key}.name"
+            )
+            translated = platform_data.platform_translations.get(name_translation_key)
+            if translated:
+                return translated
+
+        desc_name = self.entity_description.name
+        return desc_name if isinstance(desc_name, str) else None
+
     @property
     def name(self) -> str | None:
         """Return the name for this entity."""
-        # Descriptions set name to a str or None (never UNDEFINED); normalize so
-        # an entity without its own name falls back to the device name instead
-        # of showing "None".
-        desc_name = self.entity_description.name
-        if not isinstance(desc_name, str):
-            desc_name = None
+        desc_name = self._translated_description_name()
 
         if not self._uid:
             return desc_name

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -453,24 +453,19 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         Entity._name_internal uses to build its lookup key), so a future
         core change that renames or removes it only needs a fix here.
         """
-        try:
-            return self._name_translation_key
-        except AttributeError:
-            return None
+        return getattr(self, "_name_translation_key", None)
 
     def _translated_description_name(self) -> str | None:
         """Resolve the description's name, preferring loaded translations.
 
         This entity builds its own name (below) instead of relying on HA's
         has_entity_name machinery, so the platform-translations lookup has
-        to be triggered manually. A description with no name (`None`/empty)
-        is explicitly unnamed -- skip the translation lookup entirely
-        rather than risk a stray translation_key giving it one.
+        to be triggered manually. Most descriptions only set translation_key
+        and leave `name` at its EntityDescription default (UNDEFINED, not a
+        str), so the translation lookup must run regardless of `name` --
+        `desc_name` is only a fallback for the few statically-named/unnamed
+        descriptions that set `name` explicitly.
         """
-        desc_name = self.entity_description.name
-        if not isinstance(desc_name, str) or not desc_name:
-            return None
-
         platform_translations: dict[str, str] | None = getattr(
             self.platform_data, "platform_translations", None
         )
@@ -484,7 +479,8 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             if translated:
                 return translated
 
-        return desc_name
+        desc_name = self.entity_description.name
+        return desc_name if isinstance(desc_name, str) else None
 
     @property
     def name(self) -> str | None:

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -455,8 +455,14 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         lookup key can't silently diverge from core's format. That attribute
         is a private HA-core implementation detail, so a future core change
         that renames or removes it must degrade to the literal description
-        name instead of crashing entity setup.
+        name instead of crashing entity setup. A description with no name
+        (`None`/empty) is explicitly unnamed -- skip the translation lookup
+        entirely rather than risk a stray translation_key giving it one.
         """
+        desc_name = self.entity_description.name
+        if not isinstance(desc_name, str) or not desc_name:
+            return None
+
         platform_translations: dict[str, str] | None = getattr(
             self.platform_data, "platform_translations", None
         )
@@ -473,8 +479,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             if translated:
                 return translated
 
-        desc_name = self.entity_description.name
-        return desc_name if isinstance(desc_name, str) else None
+        return desc_name
 
     @property
     def name(self) -> str | None:

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -454,10 +454,13 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         same cached_property HA core's own Entity._name_internal uses) so the
         lookup key can't silently diverge from core's format.
         """
-        if self.platform_data:
+        platform_translations = getattr(
+            self.platform_data, "platform_translations", None
+        )
+        if platform_translations:
             name_translation_key = self._name_translation_key
             translated = (
-                self.platform_data.platform_translations.get(name_translation_key)
+                platform_translations.get(name_translation_key)
                 if name_translation_key
                 else None
             )

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -452,13 +452,19 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         has_entity_name machinery, so the platform-translations lookup has to
         be triggered manually -- reuses Entity._name_translation_key (the
         same cached_property HA core's own Entity._name_internal uses) so the
-        lookup key can't silently diverge from core's format.
+        lookup key can't silently diverge from core's format. That attribute
+        is a private HA-core implementation detail, so a future core change
+        that renames or removes it must degrade to the literal description
+        name instead of crashing entity setup.
         """
         platform_translations: dict[str, str] | None = getattr(
             self.platform_data, "platform_translations", None
         )
         if platform_translations:
-            name_translation_key = self._name_translation_key
+            try:
+                name_translation_key = self._name_translation_key
+            except AttributeError:
+                name_translation_key = None
             translated = (
                 platform_translations.get(name_translation_key)
                 if name_translation_key

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -454,7 +454,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         same cached_property HA core's own Entity._name_internal uses) so the
         lookup key can't silently diverge from core's format.
         """
-        platform_translations = getattr(
+        platform_translations: dict[str, str] | None = getattr(
             self.platform_data, "platform_translations", None
         )
         if platform_translations:

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -36,12 +36,6 @@ _LOGGER = getLogger(__name__)
 
 _UNKNOWN_KEY = "<unknown>"
 
-# Mirrors the strings.json/translations lookup key format Home Assistant's
-# own Entity._name_internal builds for platform translations.
-_NAME_TRANSLATION_KEY_FORMAT = (
-    "component.{platform}.entity.{domain}.{translation_key}.name"
-)
-
 
 # ---------------------------
 #   format_unique_id
@@ -455,22 +449,18 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         """Resolve the description's name, preferring loaded translations.
 
         This entity builds its own name (below) instead of relying on HA's
-        has_entity_name machinery, so translation_key lookups have to be
-        replicated manually -- mirrors Entity._name_internal's platform-
-        translations lookup (homeassistant.helpers.entity).
+        has_entity_name machinery, so the platform-translations lookup has to
+        be triggered manually -- reuses Entity._name_translation_key (the
+        same cached_property HA core's own Entity._name_internal uses) so the
+        lookup key can't silently diverge from core's format.
         """
-        translation_key = self.entity_description.translation_key
-        platform_data = self.platform_data
-        if translation_key and platform_data:
-            name_translation_key = _NAME_TRANSLATION_KEY_FORMAT.format(
-                platform=platform_data.platform_name,
-                domain=platform_data.domain,
-                translation_key=translation_key,
+        if self.platform_data:
+            name_translation_key = self._name_translation_key
+            translated = (
+                self.platform_data.platform_translations.get(name_translation_key)
+                if name_translation_key
+                else None
             )
-            platform_translations: dict[str, str] = getattr(
-                platform_data, "platform_translations", {}
-            )
-            translated = platform_translations.get(name_translation_key)
             if translated:
                 return translated
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -445,19 +445,27 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         self._refresh_data()
         super()._handle_coordinator_update()
 
+    def _core_name_translation_key(self) -> str | None:
+        """Return Entity._name_translation_key, degrading gracefully.
+
+        Isolates the one place this entity touches a private HA-core
+        implementation detail (the same cached_property HA core's own
+        Entity._name_internal uses to build its lookup key), so a future
+        core change that renames or removes it only needs a fix here.
+        """
+        try:
+            return self._name_translation_key
+        except AttributeError:
+            return None
+
     def _translated_description_name(self) -> str | None:
         """Resolve the description's name, preferring loaded translations.
 
         This entity builds its own name (below) instead of relying on HA's
-        has_entity_name machinery, so the platform-translations lookup has to
-        be triggered manually -- reuses Entity._name_translation_key (the
-        same cached_property HA core's own Entity._name_internal uses) so the
-        lookup key can't silently diverge from core's format. That attribute
-        is a private HA-core implementation detail, so a future core change
-        that renames or removes it must degrade to the literal description
-        name instead of crashing entity setup. A description with no name
-        (`None`/empty) is explicitly unnamed -- skip the translation lookup
-        entirely rather than risk a stray translation_key giving it one.
+        has_entity_name machinery, so the platform-translations lookup has
+        to be triggered manually. A description with no name (`None`/empty)
+        is explicitly unnamed -- skip the translation lookup entirely
+        rather than risk a stray translation_key giving it one.
         """
         desc_name = self.entity_description.name
         if not isinstance(desc_name, str) or not desc_name:
@@ -467,10 +475,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             self.platform_data, "platform_translations", None
         )
         if platform_translations:
-            try:
-                name_translation_key = self._name_translation_key
-            except AttributeError:
-                name_translation_key = None
+            name_translation_key = self._core_name_translation_key()
             translated = (
                 platform_translations.get(name_translation_key)
                 if name_translation_key

--- a/custom_components/truenas_ce/quality_scale.yaml
+++ b/custom_components/truenas_ce/quality_scale.yaml
@@ -126,10 +126,20 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations:
-    status: todo
+    status: done
     comment: |
-      Only the diagnostic buttons use translation_key; the remaining entities
-      carry hard-coded English names in their descriptions.
+      Every entity description that carries static suffix text now sets
+      translation_key (matching its key) instead of a literal name, with the
+      English text moved to strings.json's entity.<platform>.<key>.name (and
+      mirrored in translations/*.json). Dynamic/multi-object entities (pool,
+      dataset, disk, ...) build their own name by prefixing the translated
+      suffix with the object's data-driven identifier, so
+      TrueNASEntity._translated_description_name resolves translation_key via
+      the loaded platform translations (mirroring Entity._name_internal),
+      falling back to the literal name when no translation is loaded (e.g. in
+      unit tests that construct entities directly). Entities with no suffix
+      text (name="" or name=None -- the "unnamed" main feature of a device)
+      are unaffected since there is nothing to translate.
   exception-translations:
     status: todo
     comment: |

--- a/custom_components/truenas_ce/sensor_types.py
+++ b/custom_components/truenas_ce/sensor_types.py
@@ -226,7 +226,7 @@ class TrueNASSensorEntityDescription(SensorEntityDescription, TrueNASEntityDescr
 SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     TrueNASSensorEntityDescription(
         key="alerts",
-        name="Alerts",
+        translation_key="alerts",
         icon="mdi:alert",
         native_unit_of_measurement=None,
         device_class=None,
@@ -243,7 +243,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_smb_connections",
-        name="SMB connections",
+        translation_key="system_smb_connections",
         icon="mdi:folder-network",
         native_unit_of_measurement=None,
         device_class=None,
@@ -258,7 +258,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_uptime",
-        name="Uptime",
+        translation_key="system_uptime",
         icon="mdi:clock-outline",
         native_unit_of_measurement=None,
         device_class=SensorDeviceClass.UPTIME,
@@ -274,7 +274,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_cpu_temperature",
-        name="Temperature",
+        translation_key="system_cpu_temperature",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -291,7 +291,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_load_shortterm",
-        name="CPU load shortterm",
+        translation_key="system_load_shortterm",
         icon=ICON_GAUGE,
         native_unit_of_measurement=None,
         device_class=None,
@@ -306,7 +306,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_load_midterm",
-        name="CPU load midterm",
+        translation_key="system_load_midterm",
         icon=ICON_GAUGE,
         native_unit_of_measurement=None,
         device_class=None,
@@ -321,7 +321,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_load_longterm",
-        name="CPU load longterm",
+        translation_key="system_load_longterm",
         icon=ICON_GAUGE,
         native_unit_of_measurement=None,
         device_class=None,
@@ -336,7 +336,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_cpu_usage",
-        name="CPU usage",
+        translation_key="system_cpu_usage",
         icon="mdi:cpu-64-bit",
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=None,
@@ -352,7 +352,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_memory_usage",
-        name="Memory usage",
+        translation_key="system_memory_usage",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=None,
@@ -368,7 +368,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_cache_size-arc_value",
-        name="ARC size",
+        translation_key="system_cache_size-arc_value",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
@@ -385,7 +385,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_memory_total",
-        name="Memory total",
+        translation_key="system_memory_total",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
@@ -403,7 +403,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="system_memory_free",
-        name="Memory free",
+        translation_key="system_memory_free",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
@@ -459,7 +459,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_free",
-        name="free",
+        translation_key="pool_free",
         icon=ICON_DATABASE_SETTINGS,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
@@ -477,7 +477,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_size",
-        name="size",
+        translation_key="pool_size",
         icon=ICON_DATABASE_SETTINGS,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
@@ -495,7 +495,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_allocated",
-        name="allocated",
+        translation_key="pool_allocated",
         icon=ICON_DATABASE_SETTINGS,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
@@ -513,7 +513,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_errors",
-        name="errors",
+        translation_key="pool_errors",
         icon="mdi:alert-circle-outline",
         native_unit_of_measurement=None,
         device_class=None,
@@ -529,7 +529,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_fragmentation",
-        name="fragmentation",
+        translation_key="pool_fragmentation",
         icon="mdi:chart-pie",
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=None,
@@ -545,7 +545,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_scrub_start",
-        name="Scrub started",
+        translation_key="pool_scrub_start",
         icon="mdi:broom",
         native_unit_of_measurement=None,
         device_class=SensorDeviceClass.TIMESTAMP,
@@ -560,7 +560,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_scrub_end",
-        name="Scrub finished",
+        translation_key="pool_scrub_end",
         icon="mdi:broom-clock",
         native_unit_of_measurement=None,
         device_class=SensorDeviceClass.TIMESTAMP,
@@ -575,7 +575,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="pool_scrub_state",
-        name="Scrub state",
+        translation_key="pool_scrub_state",
         icon="mdi:broom",
         native_unit_of_measurement=None,
         device_class=None,
@@ -658,7 +658,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="traffic_rx",
-        name="RX",
+        translation_key="traffic_rx",
         icon="mdi:download-network-outline",
         native_unit_of_measurement=UnitOfDataRate.KIBIBYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
@@ -677,7 +677,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="traffic_tx",
-        name="TX",
+        translation_key="traffic_tx",
         icon="mdi:upload-network-outline",
         native_unit_of_measurement=UnitOfDataRate.KIBIBYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
@@ -696,7 +696,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="ups_charge",
-        name="Charge",
+        translation_key="ups_charge",
         icon="mdi:battery-charging",
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
@@ -711,7 +711,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="ups_runtime",
-        name="Runtime",
+        translation_key="ups_runtime",
         icon="mdi:timer-outline",
         native_unit_of_measurement=UnitOfTime.SECONDS,
         device_class=SensorDeviceClass.DURATION,
@@ -726,7 +726,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="ups_load",
-        name="Load",
+        translation_key="ups_load",
         icon="mdi:gauge",
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=None,
@@ -741,7 +741,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="ups_voltage",
-        name="Voltage",
+        translation_key="ups_voltage",
         icon="mdi:sine-wave",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
@@ -756,7 +756,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="ups_current",
-        name="Current",
+        translation_key="ups_current",
         icon="mdi:current-ac",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
@@ -771,7 +771,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="ups_frequency",
-        name="Frequency",
+        translation_key="ups_frequency",
         icon="mdi:sine-wave",
         native_unit_of_measurement=UnitOfFrequency.HERTZ,
         device_class=SensorDeviceClass.FREQUENCY,
@@ -786,7 +786,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="ups_temperature",
-        name="Temperature",
+        translation_key="ups_temperature",
         icon="mdi:thermometer",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -801,7 +801,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="directoryservices",
-        name="Status",
+        translation_key="directoryservices",
         icon="mdi:domain",
         native_unit_of_measurement=None,
         device_class=None,
@@ -817,7 +817,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="certificate_expiry",
-        name="Time until expiry",
+        translation_key="certificate_expiry",
         icon="mdi:certificate",
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
@@ -832,7 +832,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="certificate_expiration_time",
-        name="Expiration time",
+        translation_key="certificate_expiration_time",
         icon="mdi:certificate",
         native_unit_of_measurement=None,
         device_class=SensorDeviceClass.TIMESTAMP,
@@ -847,7 +847,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="arc_data_hit_percent",
-        name="Data hit ratio",
+        translation_key="arc_data_hit_percent",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=None,
@@ -862,7 +862,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="arc_metadata_hit_percent",
-        name="Metadata hit ratio",
+        translation_key="arc_metadata_hit_percent",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=None,
@@ -877,7 +877,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="arc_l2_hit_percent",
-        name="L2 ARC hit ratio",
+        translation_key="arc_l2_hit_percent",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         device_class=None,
@@ -892,7 +892,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="app_stats_cpu",
-        name="CPU",
+        translation_key="app_stats_cpu",
         icon="mdi:cpu-64-bit",
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         suggested_display_precision=2,
@@ -911,7 +911,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="app_stats_memory",
-        name="RAM",
+        translation_key="app_stats_memory",
         icon="mdi:memory",
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.MEBIBYTES,
@@ -931,7 +931,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="app_stats_network_rx",
-        name="Network RX",
+        translation_key="app_stats_network_rx",
         icon="mdi:download-network-outline",
         native_unit_of_measurement=UnitOfDataRate.KIBIBYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KIBIBYTES_PER_SECOND,
@@ -952,7 +952,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="app_stats_network_tx",
-        name="Network TX",
+        translation_key="app_stats_network_tx",
         icon="mdi:upload-network-outline",
         native_unit_of_measurement=UnitOfDataRate.KIBIBYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KIBIBYTES_PER_SECOND,
@@ -973,7 +973,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="app_stats_blkio_read",
-        name="Block I/O Read",
+        translation_key="app_stats_blkio_read",
         icon="mdi:database-arrow-right",
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.MEBIBYTES,
@@ -993,7 +993,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     ),
     TrueNASSensorEntityDescription(
         key="app_stats_blkio_write",
-        name="Block I/O Write",
+        translation_key="app_stats_blkio_write",
         icon="mdi:database-arrow-left",
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.MEBIBYTES,

--- a/custom_components/truenas_ce/sensor_types.py
+++ b/custom_components/truenas_ce/sensor_types.py
@@ -367,7 +367,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         data_attributes_list=DEVICE_ATTRIBUTES_MEMORY,
     ),
     TrueNASSensorEntityDescription(
-        key="system_cache_size_arc_value",
+        key="system_cache_size-arc_value",
         translation_key="system_cache_size_arc_value",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfInformation.BYTES,

--- a/custom_components/truenas_ce/sensor_types.py
+++ b/custom_components/truenas_ce/sensor_types.py
@@ -367,8 +367,8 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         data_attributes_list=DEVICE_ATTRIBUTES_MEMORY,
     ),
     TrueNASSensorEntityDescription(
-        key="system_cache_size-arc_value",
-        translation_key="system_cache_size-arc_value",
+        key="system_cache_size_arc_value",
+        translation_key="system_cache_size_arc_value",
         icon=ICON_MEMORY,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -144,15 +144,173 @@
             },
             "scrub_run": {
                 "name": "Run scrub"
+            },
+            "snapshottask_run": {
+                "name": "Run"
+            },
+            "rsync_run": {
+                "name": "Run"
+            },
+            "replication_run": {
+                "name": "Run"
+            },
+            "cloudsync_run": {
+                "name": "Run"
+            },
+            "cronjob_run": {
+                "name": "Run"
             }
         },
         "sensor": {
             "alerts": {
+                "name": "Alerts",
                 "state_attributes": {
                     "uuids": {
                         "name": "Alert UUIDs"
                     }
                 }
+            },
+            "system_smb_connections": {
+                "name": "SMB connections"
+            },
+            "system_uptime": {
+                "name": "Uptime"
+            },
+            "system_cpu_temperature": {
+                "name": "Temperature"
+            },
+            "system_load_shortterm": {
+                "name": "CPU load shortterm"
+            },
+            "system_load_midterm": {
+                "name": "CPU load midterm"
+            },
+            "system_load_longterm": {
+                "name": "CPU load longterm"
+            },
+            "system_cpu_usage": {
+                "name": "CPU usage"
+            },
+            "system_memory_usage": {
+                "name": "Memory usage"
+            },
+            "system_cache_size-arc_value": {
+                "name": "ARC size"
+            },
+            "system_memory_total": {
+                "name": "Memory total"
+            },
+            "system_memory_free": {
+                "name": "Memory free"
+            },
+            "pool_free": {
+                "name": "free"
+            },
+            "pool_size": {
+                "name": "size"
+            },
+            "pool_allocated": {
+                "name": "allocated"
+            },
+            "pool_errors": {
+                "name": "errors"
+            },
+            "pool_fragmentation": {
+                "name": "fragmentation"
+            },
+            "pool_scrub_start": {
+                "name": "Scrub started"
+            },
+            "pool_scrub_end": {
+                "name": "Scrub finished"
+            },
+            "pool_scrub_state": {
+                "name": "Scrub state"
+            },
+            "traffic_rx": {
+                "name": "RX"
+            },
+            "traffic_tx": {
+                "name": "TX"
+            },
+            "ups_charge": {
+                "name": "Charge"
+            },
+            "ups_runtime": {
+                "name": "Runtime"
+            },
+            "ups_load": {
+                "name": "Load"
+            },
+            "ups_voltage": {
+                "name": "Voltage"
+            },
+            "ups_current": {
+                "name": "Current"
+            },
+            "ups_frequency": {
+                "name": "Frequency"
+            },
+            "ups_temperature": {
+                "name": "Temperature"
+            },
+            "directoryservices": {
+                "name": "Status"
+            },
+            "certificate_expiry": {
+                "name": "Time until expiry"
+            },
+            "certificate_expiration_time": {
+                "name": "Expiration time"
+            },
+            "arc_data_hit_percent": {
+                "name": "Data hit ratio"
+            },
+            "arc_metadata_hit_percent": {
+                "name": "Metadata hit ratio"
+            },
+            "arc_l2_hit_percent": {
+                "name": "L2 ARC hit ratio"
+            },
+            "app_stats_cpu": {
+                "name": "CPU"
+            },
+            "app_stats_memory": {
+                "name": "RAM"
+            },
+            "app_stats_network_rx": {
+                "name": "Network RX"
+            },
+            "app_stats_network_tx": {
+                "name": "Network TX"
+            },
+            "app_stats_blkio_read": {
+                "name": "Block I/O Read"
+            },
+            "app_stats_blkio_write": {
+                "name": "Block I/O Write"
+            }
+        },
+        "binary_sensor": {
+            "disk_issues": {
+                "name": "Disk/Pool issues"
+            },
+            "pool_healthy": {
+                "name": "healthy"
+            },
+            "interface": {
+                "name": "Link"
+            },
+            "certificate_expired": {
+                "name": "Expired"
+            }
+        },
+        "switch": {
+            "cloudsync_switch": {
+                "name": "Enabled"
+            },
+            "cronjob_switch": {
+                "name": "Enabled"
             }
         }
     }

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -194,7 +194,7 @@
             "system_memory_usage": {
                 "name": "Memory usage"
             },
-            "system_cache_size-arc_value": {
+            "system_cache_size_arc_value": {
                 "name": "ARC size"
             },
             "system_memory_total": {

--- a/custom_components/truenas_ce/switch_types.py
+++ b/custom_components/truenas_ce/switch_types.py
@@ -34,7 +34,7 @@ SENSOR_TYPES: tuple[TrueNASSwitchEntityDescription, ...] = (
     ),
     TrueNASSwitchEntityDescription(
         key="cloudsync_switch",
-        name="Enabled",
+        translation_key="cloudsync_switch",
         icon="mdi:calendar-check",
         ha_group="Cloudsync",
         data_path="cloudsync",
@@ -46,7 +46,7 @@ SENSOR_TYPES: tuple[TrueNASSwitchEntityDescription, ...] = (
     ),
     TrueNASSwitchEntityDescription(
         key="cronjob_switch",
-        name="Enabled",
+        translation_key="cronjob_switch",
         icon="mdi:calendar-check",
         ha_group="Cron Jobs",
         data_path="cronjob",

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -144,15 +144,173 @@
             },
             "scrub_run": {
                 "name": "Scrub ausführen"
+            },
+            "snapshottask_run": {
+                "name": "Ausführen"
+            },
+            "rsync_run": {
+                "name": "Ausführen"
+            },
+            "replication_run": {
+                "name": "Ausführen"
+            },
+            "cloudsync_run": {
+                "name": "Ausführen"
+            },
+            "cronjob_run": {
+                "name": "Ausführen"
             }
         },
         "sensor": {
             "alerts": {
+                "name": "Warnungen",
                 "state_attributes": {
                     "uuids": {
                         "name": "Alert UUIDs"
                     }
                 }
+            },
+            "system_smb_connections": {
+                "name": "SMB-Verbindungen"
+            },
+            "system_uptime": {
+                "name": "Laufzeit"
+            },
+            "system_cpu_temperature": {
+                "name": "Temperatur"
+            },
+            "system_load_shortterm": {
+                "name": "CPU-Last kurzfristig"
+            },
+            "system_load_midterm": {
+                "name": "CPU-Last mittelfristig"
+            },
+            "system_load_longterm": {
+                "name": "CPU-Last langfristig"
+            },
+            "system_cpu_usage": {
+                "name": "CPU-Auslastung"
+            },
+            "system_memory_usage": {
+                "name": "Speicherauslastung"
+            },
+            "system_cache_size-arc_value": {
+                "name": "ARC-Größe"
+            },
+            "system_memory_total": {
+                "name": "Speicher gesamt"
+            },
+            "system_memory_free": {
+                "name": "Speicher frei"
+            },
+            "pool_free": {
+                "name": "Frei"
+            },
+            "pool_size": {
+                "name": "Größe"
+            },
+            "pool_allocated": {
+                "name": "Belegt"
+            },
+            "pool_errors": {
+                "name": "Fehler"
+            },
+            "pool_fragmentation": {
+                "name": "Fragmentierung"
+            },
+            "pool_scrub_start": {
+                "name": "Scrub gestartet"
+            },
+            "pool_scrub_end": {
+                "name": "Scrub abgeschlossen"
+            },
+            "pool_scrub_state": {
+                "name": "Scrub-Status"
+            },
+            "traffic_rx": {
+                "name": "RX"
+            },
+            "traffic_tx": {
+                "name": "TX"
+            },
+            "ups_charge": {
+                "name": "Ladung"
+            },
+            "ups_runtime": {
+                "name": "Laufzeit"
+            },
+            "ups_load": {
+                "name": "Last"
+            },
+            "ups_voltage": {
+                "name": "Spannung"
+            },
+            "ups_current": {
+                "name": "Stromstärke"
+            },
+            "ups_frequency": {
+                "name": "Frequenz"
+            },
+            "ups_temperature": {
+                "name": "Temperatur"
+            },
+            "directoryservices": {
+                "name": "Status"
+            },
+            "certificate_expiry": {
+                "name": "Zeit bis Ablauf"
+            },
+            "certificate_expiration_time": {
+                "name": "Ablaufzeitpunkt"
+            },
+            "arc_data_hit_percent": {
+                "name": "Daten-Trefferquote"
+            },
+            "arc_metadata_hit_percent": {
+                "name": "Metadaten-Trefferquote"
+            },
+            "arc_l2_hit_percent": {
+                "name": "L2-ARC-Trefferquote"
+            },
+            "app_stats_cpu": {
+                "name": "CPU"
+            },
+            "app_stats_memory": {
+                "name": "RAM"
+            },
+            "app_stats_network_rx": {
+                "name": "Netzwerk RX"
+            },
+            "app_stats_network_tx": {
+                "name": "Netzwerk TX"
+            },
+            "app_stats_blkio_read": {
+                "name": "Block-E/A Lesen"
+            },
+            "app_stats_blkio_write": {
+                "name": "Block-E/A Schreiben"
+            }
+        },
+        "binary_sensor": {
+            "disk_issues": {
+                "name": "Datenträger-/Pool-Probleme"
+            },
+            "pool_healthy": {
+                "name": "Gesund"
+            },
+            "interface": {
+                "name": "Verbindung"
+            },
+            "certificate_expired": {
+                "name": "Abgelaufen"
+            }
+        },
+        "switch": {
+            "cloudsync_switch": {
+                "name": "Aktiviert"
+            },
+            "cronjob_switch": {
+                "name": "Aktiviert"
             }
         }
     }

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -194,7 +194,7 @@
             "system_memory_usage": {
                 "name": "Speicherauslastung"
             },
-            "system_cache_size-arc_value": {
+            "system_cache_size_arc_value": {
                 "name": "ARC-Größe"
             },
             "system_memory_total": {

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -144,15 +144,173 @@
             },
             "scrub_run": {
                 "name": "Run scrub"
+            },
+            "snapshottask_run": {
+                "name": "Run"
+            },
+            "rsync_run": {
+                "name": "Run"
+            },
+            "replication_run": {
+                "name": "Run"
+            },
+            "cloudsync_run": {
+                "name": "Run"
+            },
+            "cronjob_run": {
+                "name": "Run"
             }
         },
         "sensor": {
             "alerts": {
+                "name": "Alerts",
                 "state_attributes": {
                     "uuids": {
                         "name": "Alert UUIDs"
                     }
                 }
+            },
+            "system_smb_connections": {
+                "name": "SMB connections"
+            },
+            "system_uptime": {
+                "name": "Uptime"
+            },
+            "system_cpu_temperature": {
+                "name": "Temperature"
+            },
+            "system_load_shortterm": {
+                "name": "CPU load shortterm"
+            },
+            "system_load_midterm": {
+                "name": "CPU load midterm"
+            },
+            "system_load_longterm": {
+                "name": "CPU load longterm"
+            },
+            "system_cpu_usage": {
+                "name": "CPU usage"
+            },
+            "system_memory_usage": {
+                "name": "Memory usage"
+            },
+            "system_cache_size-arc_value": {
+                "name": "ARC size"
+            },
+            "system_memory_total": {
+                "name": "Memory total"
+            },
+            "system_memory_free": {
+                "name": "Memory free"
+            },
+            "pool_free": {
+                "name": "free"
+            },
+            "pool_size": {
+                "name": "size"
+            },
+            "pool_allocated": {
+                "name": "allocated"
+            },
+            "pool_errors": {
+                "name": "errors"
+            },
+            "pool_fragmentation": {
+                "name": "fragmentation"
+            },
+            "pool_scrub_start": {
+                "name": "Scrub started"
+            },
+            "pool_scrub_end": {
+                "name": "Scrub finished"
+            },
+            "pool_scrub_state": {
+                "name": "Scrub state"
+            },
+            "traffic_rx": {
+                "name": "RX"
+            },
+            "traffic_tx": {
+                "name": "TX"
+            },
+            "ups_charge": {
+                "name": "Charge"
+            },
+            "ups_runtime": {
+                "name": "Runtime"
+            },
+            "ups_load": {
+                "name": "Load"
+            },
+            "ups_voltage": {
+                "name": "Voltage"
+            },
+            "ups_current": {
+                "name": "Current"
+            },
+            "ups_frequency": {
+                "name": "Frequency"
+            },
+            "ups_temperature": {
+                "name": "Temperature"
+            },
+            "directoryservices": {
+                "name": "Status"
+            },
+            "certificate_expiry": {
+                "name": "Time until expiry"
+            },
+            "certificate_expiration_time": {
+                "name": "Expiration time"
+            },
+            "arc_data_hit_percent": {
+                "name": "Data hit ratio"
+            },
+            "arc_metadata_hit_percent": {
+                "name": "Metadata hit ratio"
+            },
+            "arc_l2_hit_percent": {
+                "name": "L2 ARC hit ratio"
+            },
+            "app_stats_cpu": {
+                "name": "CPU"
+            },
+            "app_stats_memory": {
+                "name": "RAM"
+            },
+            "app_stats_network_rx": {
+                "name": "Network RX"
+            },
+            "app_stats_network_tx": {
+                "name": "Network TX"
+            },
+            "app_stats_blkio_read": {
+                "name": "Block I/O Read"
+            },
+            "app_stats_blkio_write": {
+                "name": "Block I/O Write"
+            }
+        },
+        "binary_sensor": {
+            "disk_issues": {
+                "name": "Disk/Pool issues"
+            },
+            "pool_healthy": {
+                "name": "healthy"
+            },
+            "interface": {
+                "name": "Link"
+            },
+            "certificate_expired": {
+                "name": "Expired"
+            }
+        },
+        "switch": {
+            "cloudsync_switch": {
+                "name": "Enabled"
+            },
+            "cronjob_switch": {
+                "name": "Enabled"
             }
         }
     }

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -194,7 +194,7 @@
             "system_memory_usage": {
                 "name": "Memory usage"
             },
-            "system_cache_size-arc_value": {
+            "system_cache_size_arc_value": {
                 "name": "ARC size"
             },
             "system_memory_total": {

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -144,15 +144,173 @@
             },
             "scrub_run": {
                 "name": "Ejecutar scrub"
+            },
+            "snapshottask_run": {
+                "name": "Ejecutar"
+            },
+            "rsync_run": {
+                "name": "Ejecutar"
+            },
+            "replication_run": {
+                "name": "Ejecutar"
+            },
+            "cloudsync_run": {
+                "name": "Ejecutar"
+            },
+            "cronjob_run": {
+                "name": "Ejecutar"
             }
         },
         "sensor": {
             "alerts": {
+                "name": "Alertas",
                 "state_attributes": {
                     "uuids": {
                         "name": "Alert UUIDs"
                     }
                 }
+            },
+            "system_smb_connections": {
+                "name": "Conexiones SMB"
+            },
+            "system_uptime": {
+                "name": "Tiempo de actividad"
+            },
+            "system_cpu_temperature": {
+                "name": "Temperatura"
+            },
+            "system_load_shortterm": {
+                "name": "Carga de CPU a corto plazo"
+            },
+            "system_load_midterm": {
+                "name": "Carga de CPU a medio plazo"
+            },
+            "system_load_longterm": {
+                "name": "Carga de CPU a largo plazo"
+            },
+            "system_cpu_usage": {
+                "name": "Uso de CPU"
+            },
+            "system_memory_usage": {
+                "name": "Uso de memoria"
+            },
+            "system_cache_size-arc_value": {
+                "name": "Tamaño de ARC"
+            },
+            "system_memory_total": {
+                "name": "Memoria total"
+            },
+            "system_memory_free": {
+                "name": "Memoria libre"
+            },
+            "pool_free": {
+                "name": "Libre"
+            },
+            "pool_size": {
+                "name": "Tamaño"
+            },
+            "pool_allocated": {
+                "name": "Asignado"
+            },
+            "pool_errors": {
+                "name": "Errores"
+            },
+            "pool_fragmentation": {
+                "name": "Fragmentación"
+            },
+            "pool_scrub_start": {
+                "name": "Scrub iniciado"
+            },
+            "pool_scrub_end": {
+                "name": "Scrub finalizado"
+            },
+            "pool_scrub_state": {
+                "name": "Estado del scrub"
+            },
+            "traffic_rx": {
+                "name": "RX"
+            },
+            "traffic_tx": {
+                "name": "TX"
+            },
+            "ups_charge": {
+                "name": "Carga"
+            },
+            "ups_runtime": {
+                "name": "Autonomía"
+            },
+            "ups_load": {
+                "name": "Carga"
+            },
+            "ups_voltage": {
+                "name": "Voltaje"
+            },
+            "ups_current": {
+                "name": "Corriente"
+            },
+            "ups_frequency": {
+                "name": "Frecuencia"
+            },
+            "ups_temperature": {
+                "name": "Temperatura"
+            },
+            "directoryservices": {
+                "name": "Estado"
+            },
+            "certificate_expiry": {
+                "name": "Tiempo hasta la expiración"
+            },
+            "certificate_expiration_time": {
+                "name": "Fecha de expiración"
+            },
+            "arc_data_hit_percent": {
+                "name": "Tasa de aciertos de datos"
+            },
+            "arc_metadata_hit_percent": {
+                "name": "Tasa de aciertos de metadatos"
+            },
+            "arc_l2_hit_percent": {
+                "name": "Tasa de aciertos de L2 ARC"
+            },
+            "app_stats_cpu": {
+                "name": "CPU"
+            },
+            "app_stats_memory": {
+                "name": "RAM"
+            },
+            "app_stats_network_rx": {
+                "name": "Red RX"
+            },
+            "app_stats_network_tx": {
+                "name": "Red TX"
+            },
+            "app_stats_blkio_read": {
+                "name": "E/S de bloque (lectura)"
+            },
+            "app_stats_blkio_write": {
+                "name": "E/S de bloque (escritura)"
+            }
+        },
+        "binary_sensor": {
+            "disk_issues": {
+                "name": "Problemas de disco/pool"
+            },
+            "pool_healthy": {
+                "name": "Sano"
+            },
+            "interface": {
+                "name": "Enlace"
+            },
+            "certificate_expired": {
+                "name": "Caducado"
+            }
+        },
+        "switch": {
+            "cloudsync_switch": {
+                "name": "Habilitado"
+            },
+            "cronjob_switch": {
+                "name": "Habilitado"
             }
         }
     }

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -194,7 +194,7 @@
             "system_memory_usage": {
                 "name": "Uso de memoria"
             },
-            "system_cache_size-arc_value": {
+            "system_cache_size_arc_value": {
                 "name": "Tamaño de ARC"
             },
             "system_memory_total": {

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -194,7 +194,7 @@
             "system_memory_usage": {
                 "name": "Uso de memória"
             },
-            "system_cache_size-arc_value": {
+            "system_cache_size_arc_value": {
                 "name": "Tamanho do ARC"
             },
             "system_memory_total": {

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -144,15 +144,173 @@
             },
             "scrub_run": {
                 "name": "Executar scrub"
+            },
+            "snapshottask_run": {
+                "name": "Executar"
+            },
+            "rsync_run": {
+                "name": "Executar"
+            },
+            "replication_run": {
+                "name": "Executar"
+            },
+            "cloudsync_run": {
+                "name": "Executar"
+            },
+            "cronjob_run": {
+                "name": "Executar"
             }
         },
         "sensor": {
             "alerts": {
+                "name": "Alertas",
                 "state_attributes": {
                     "uuids": {
                         "name": "Alert UUIDs"
                     }
                 }
+            },
+            "system_smb_connections": {
+                "name": "Conexões SMB"
+            },
+            "system_uptime": {
+                "name": "Tempo de atividade"
+            },
+            "system_cpu_temperature": {
+                "name": "Temperatura"
+            },
+            "system_load_shortterm": {
+                "name": "Carga de CPU a curto prazo"
+            },
+            "system_load_midterm": {
+                "name": "Carga de CPU a médio prazo"
+            },
+            "system_load_longterm": {
+                "name": "Carga de CPU a longo prazo"
+            },
+            "system_cpu_usage": {
+                "name": "Uso de CPU"
+            },
+            "system_memory_usage": {
+                "name": "Uso de memória"
+            },
+            "system_cache_size-arc_value": {
+                "name": "Tamanho do ARC"
+            },
+            "system_memory_total": {
+                "name": "Memória total"
+            },
+            "system_memory_free": {
+                "name": "Memória livre"
+            },
+            "pool_free": {
+                "name": "Livre"
+            },
+            "pool_size": {
+                "name": "Tamanho"
+            },
+            "pool_allocated": {
+                "name": "Alocado"
+            },
+            "pool_errors": {
+                "name": "Erros"
+            },
+            "pool_fragmentation": {
+                "name": "Fragmentação"
+            },
+            "pool_scrub_start": {
+                "name": "Scrub iniciado"
+            },
+            "pool_scrub_end": {
+                "name": "Scrub concluído"
+            },
+            "pool_scrub_state": {
+                "name": "Status do scrub"
+            },
+            "traffic_rx": {
+                "name": "RX"
+            },
+            "traffic_tx": {
+                "name": "TX"
+            },
+            "ups_charge": {
+                "name": "Carga"
+            },
+            "ups_runtime": {
+                "name": "Autonomia"
+            },
+            "ups_load": {
+                "name": "Carga"
+            },
+            "ups_voltage": {
+                "name": "Tensão"
+            },
+            "ups_current": {
+                "name": "Corrente"
+            },
+            "ups_frequency": {
+                "name": "Frequência"
+            },
+            "ups_temperature": {
+                "name": "Temperatura"
+            },
+            "directoryservices": {
+                "name": "Status"
+            },
+            "certificate_expiry": {
+                "name": "Tempo até expirar"
+            },
+            "certificate_expiration_time": {
+                "name": "Data de expiração"
+            },
+            "arc_data_hit_percent": {
+                "name": "Taxa de acerto de dados"
+            },
+            "arc_metadata_hit_percent": {
+                "name": "Taxa de acerto de metadados"
+            },
+            "arc_l2_hit_percent": {
+                "name": "Taxa de acerto do L2 ARC"
+            },
+            "app_stats_cpu": {
+                "name": "CPU"
+            },
+            "app_stats_memory": {
+                "name": "RAM"
+            },
+            "app_stats_network_rx": {
+                "name": "Rede RX"
+            },
+            "app_stats_network_tx": {
+                "name": "Rede TX"
+            },
+            "app_stats_blkio_read": {
+                "name": "E/S de bloco (leitura)"
+            },
+            "app_stats_blkio_write": {
+                "name": "E/S de bloco (escrita)"
+            }
+        },
+        "binary_sensor": {
+            "disk_issues": {
+                "name": "Problemas de disco/pool"
+            },
+            "pool_healthy": {
+                "name": "Saudável"
+            },
+            "interface": {
+                "name": "Link"
+            },
+            "certificate_expired": {
+                "name": "Expirado"
+            }
+        },
+        "switch": {
+            "cloudsync_switch": {
+                "name": "Habilitado"
+            },
+            "cronjob_switch": {
+                "name": "Habilitado"
             }
         }
     }

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -194,7 +194,7 @@
             "system_memory_usage": {
                 "name": "Использование памяти"
             },
-            "system_cache_size-arc_value": {
+            "system_cache_size_arc_value": {
                 "name": "Размер ARC"
             },
             "system_memory_total": {

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -144,15 +144,173 @@
             },
             "scrub_run": {
                 "name": "Запустить scrub"
+            },
+            "snapshottask_run": {
+                "name": "Запустить"
+            },
+            "rsync_run": {
+                "name": "Запустить"
+            },
+            "replication_run": {
+                "name": "Запустить"
+            },
+            "cloudsync_run": {
+                "name": "Запустить"
+            },
+            "cronjob_run": {
+                "name": "Запустить"
             }
         },
         "sensor": {
             "alerts": {
+                "name": "Оповещения",
                 "state_attributes": {
                     "uuids": {
                         "name": "Alert UUIDs"
                     }
                 }
+            },
+            "system_smb_connections": {
+                "name": "SMB-подключения"
+            },
+            "system_uptime": {
+                "name": "Время работы"
+            },
+            "system_cpu_temperature": {
+                "name": "Температура"
+            },
+            "system_load_shortterm": {
+                "name": "Загрузка ЦП (кратковременная)"
+            },
+            "system_load_midterm": {
+                "name": "Загрузка ЦП (среднесрочная)"
+            },
+            "system_load_longterm": {
+                "name": "Загрузка ЦП (долгосрочная)"
+            },
+            "system_cpu_usage": {
+                "name": "Загрузка ЦП"
+            },
+            "system_memory_usage": {
+                "name": "Использование памяти"
+            },
+            "system_cache_size-arc_value": {
+                "name": "Размер ARC"
+            },
+            "system_memory_total": {
+                "name": "Память всего"
+            },
+            "system_memory_free": {
+                "name": "Свободная память"
+            },
+            "pool_free": {
+                "name": "Свободно"
+            },
+            "pool_size": {
+                "name": "Размер"
+            },
+            "pool_allocated": {
+                "name": "Занято"
+            },
+            "pool_errors": {
+                "name": "Ошибки"
+            },
+            "pool_fragmentation": {
+                "name": "Фрагментация"
+            },
+            "pool_scrub_start": {
+                "name": "Scrub запущен"
+            },
+            "pool_scrub_end": {
+                "name": "Scrub завершён"
+            },
+            "pool_scrub_state": {
+                "name": "Статус scrub"
+            },
+            "traffic_rx": {
+                "name": "RX"
+            },
+            "traffic_tx": {
+                "name": "TX"
+            },
+            "ups_charge": {
+                "name": "Заряд"
+            },
+            "ups_runtime": {
+                "name": "Время работы"
+            },
+            "ups_load": {
+                "name": "Нагрузка"
+            },
+            "ups_voltage": {
+                "name": "Напряжение"
+            },
+            "ups_current": {
+                "name": "Ток"
+            },
+            "ups_frequency": {
+                "name": "Частота"
+            },
+            "ups_temperature": {
+                "name": "Температура"
+            },
+            "directoryservices": {
+                "name": "Статус"
+            },
+            "certificate_expiry": {
+                "name": "Время до истечения"
+            },
+            "certificate_expiration_time": {
+                "name": "Дата истечения"
+            },
+            "arc_data_hit_percent": {
+                "name": "Процент попаданий (данные)"
+            },
+            "arc_metadata_hit_percent": {
+                "name": "Процент попаданий (метаданные)"
+            },
+            "arc_l2_hit_percent": {
+                "name": "Процент попаданий L2 ARC"
+            },
+            "app_stats_cpu": {
+                "name": "CPU"
+            },
+            "app_stats_memory": {
+                "name": "RAM"
+            },
+            "app_stats_network_rx": {
+                "name": "Сеть RX"
+            },
+            "app_stats_network_tx": {
+                "name": "Сеть TX"
+            },
+            "app_stats_blkio_read": {
+                "name": "Блочный ввод/вывод (чтение)"
+            },
+            "app_stats_blkio_write": {
+                "name": "Блочный ввод/вывод (запись)"
+            }
+        },
+        "binary_sensor": {
+            "disk_issues": {
+                "name": "Проблемы диска/пула"
+            },
+            "pool_healthy": {
+                "name": "Исправен"
+            },
+            "interface": {
+                "name": "Соединение"
+            },
+            "certificate_expired": {
+                "name": "Истёк"
+            }
+        },
+        "switch": {
+            "cloudsync_switch": {
+                "name": "Включено"
+            },
+            "cronjob_switch": {
+                "name": "Включено"
             }
         }
     }

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -194,7 +194,7 @@
             "system_memory_usage": {
                 "name": "Využitie pamäte"
             },
-            "system_cache_size-arc_value": {
+            "system_cache_size_arc_value": {
                 "name": "Veľkosť ARC"
             },
             "system_memory_total": {

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -144,15 +144,173 @@
             },
             "scrub_run": {
                 "name": "Spustiť scrub"
+            },
+            "snapshottask_run": {
+                "name": "Spustiť"
+            },
+            "rsync_run": {
+                "name": "Spustiť"
+            },
+            "replication_run": {
+                "name": "Spustiť"
+            },
+            "cloudsync_run": {
+                "name": "Spustiť"
+            },
+            "cronjob_run": {
+                "name": "Spustiť"
             }
         },
         "sensor": {
             "alerts": {
+                "name": "Upozornenia",
                 "state_attributes": {
                     "uuids": {
                         "name": "Alert UUIDs"
                     }
                 }
+            },
+            "system_smb_connections": {
+                "name": "SMB pripojenia"
+            },
+            "system_uptime": {
+                "name": "Doba prevádzky"
+            },
+            "system_cpu_temperature": {
+                "name": "Teplota"
+            },
+            "system_load_shortterm": {
+                "name": "Záťaž CPU krátkodobá"
+            },
+            "system_load_midterm": {
+                "name": "Záťaž CPU strednodobá"
+            },
+            "system_load_longterm": {
+                "name": "Záťaž CPU dlhodobá"
+            },
+            "system_cpu_usage": {
+                "name": "Využitie CPU"
+            },
+            "system_memory_usage": {
+                "name": "Využitie pamäte"
+            },
+            "system_cache_size-arc_value": {
+                "name": "Veľkosť ARC"
+            },
+            "system_memory_total": {
+                "name": "Pamäť spolu"
+            },
+            "system_memory_free": {
+                "name": "Voľná pamäť"
+            },
+            "pool_free": {
+                "name": "Voľné"
+            },
+            "pool_size": {
+                "name": "Veľkosť"
+            },
+            "pool_allocated": {
+                "name": "Alokované"
+            },
+            "pool_errors": {
+                "name": "Chyby"
+            },
+            "pool_fragmentation": {
+                "name": "Fragmentácia"
+            },
+            "pool_scrub_start": {
+                "name": "Scrub spustený"
+            },
+            "pool_scrub_end": {
+                "name": "Scrub dokončený"
+            },
+            "pool_scrub_state": {
+                "name": "Stav scrub"
+            },
+            "traffic_rx": {
+                "name": "RX"
+            },
+            "traffic_tx": {
+                "name": "TX"
+            },
+            "ups_charge": {
+                "name": "Nabitie"
+            },
+            "ups_runtime": {
+                "name": "Výdrž"
+            },
+            "ups_load": {
+                "name": "Záťaž"
+            },
+            "ups_voltage": {
+                "name": "Napätie"
+            },
+            "ups_current": {
+                "name": "Prúd"
+            },
+            "ups_frequency": {
+                "name": "Frekvencia"
+            },
+            "ups_temperature": {
+                "name": "Teplota"
+            },
+            "directoryservices": {
+                "name": "Stav"
+            },
+            "certificate_expiry": {
+                "name": "Čas do vypršania"
+            },
+            "certificate_expiration_time": {
+                "name": "Čas vypršania"
+            },
+            "arc_data_hit_percent": {
+                "name": "Podiel zásahov (dáta)"
+            },
+            "arc_metadata_hit_percent": {
+                "name": "Podiel zásahov (metadáta)"
+            },
+            "arc_l2_hit_percent": {
+                "name": "Podiel zásahov L2 ARC"
+            },
+            "app_stats_cpu": {
+                "name": "CPU"
+            },
+            "app_stats_memory": {
+                "name": "RAM"
+            },
+            "app_stats_network_rx": {
+                "name": "Sieť RX"
+            },
+            "app_stats_network_tx": {
+                "name": "Sieť TX"
+            },
+            "app_stats_blkio_read": {
+                "name": "Blokový V/V (čítanie)"
+            },
+            "app_stats_blkio_write": {
+                "name": "Blokový V/V (zápis)"
+            }
+        },
+        "binary_sensor": {
+            "disk_issues": {
+                "name": "Problémy disku/poolu"
+            },
+            "pool_healthy": {
+                "name": "V poriadku"
+            },
+            "interface": {
+                "name": "Spojenie"
+            },
+            "certificate_expired": {
+                "name": "Vypršané"
+            }
+        },
+        "switch": {
+            "cloudsync_switch": {
+                "name": "Povolené"
+            },
+            "cronjob_switch": {
+                "name": "Povolené"
             }
         }
     }

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -344,6 +344,25 @@ def test_name_translation_lookup(
     assert entity.name == expected_name
 
 
+def test_name_translation_lookup_without_literal_name() -> None:
+    """Descriptions that only set translation_key (no literal `name`) must
+    still resolve via platform_translations -- `name` defaults to
+    EntityDescription's UNDEFINED sentinel, not a str or None.
+    """
+    desc = TrueNASEntityDescription(
+        key="uptime", translation_key="uptime", data_path="system_info"
+    )
+    entity = _make_entity(description=desc)
+    entity.platform_data = SimpleNamespace(
+        platform_name="truenas_ce",
+        domain="sensor",
+        platform_translations={
+            "component.truenas_ce.entity.sensor.uptime.name": "Laufzeit"
+        },
+    )
+    assert entity.name == "Laufzeit"
+
+
 def test_unique_id_static_description() -> None:
     entity = _make_entity()
     assert entity.unique_id == "truenas-uptime"

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -314,38 +314,32 @@ def test_name_referenced_entity_no_desc_name() -> None:
     assert entity.name == "sda"
 
 
-def test_name_prefers_loaded_translation_over_literal_name() -> None:
+@pytest.mark.parametrize(
+    ("platform_translations", "expected_name"),
+    [
+        pytest.param(
+            {"component.truenas_ce.entity.sensor.uptime.name": "Laufzeit"},
+            "Laufzeit",
+            id="translation_hit",
+        ),
+        pytest.param({}, "Uptime", id="translation_missing"),
+        pytest.param(None, "Uptime", id="no_platform_data"),
+    ],
+)
+def test_name_translation_lookup(
+    platform_translations: dict[str, str] | None, expected_name: str
+) -> None:
     desc = TrueNASEntityDescription(
         key="uptime", name="Uptime", translation_key="uptime", data_path="system_info"
     )
     entity = _make_entity(description=desc)
-    entity.platform_data = SimpleNamespace(
-        platform_name="truenas_ce",
-        domain="sensor",
-        platform_translations={
-            "component.truenas_ce.entity.sensor.uptime.name": "Laufzeit"
-        },
-    )
-    assert entity.name == "Laufzeit"
-
-
-def test_name_falls_back_to_literal_when_translation_missing() -> None:
-    desc = TrueNASEntityDescription(
-        key="uptime", name="Uptime", translation_key="uptime", data_path="system_info"
-    )
-    entity = _make_entity(description=desc)
-    entity.platform_data = SimpleNamespace(
-        platform_name="truenas_ce", domain="sensor", platform_translations={}
-    )
-    assert entity.name == "Uptime"
-
-
-def test_name_without_platform_data_uses_literal_name() -> None:
-    desc = TrueNASEntityDescription(
-        key="uptime", name="Uptime", translation_key="uptime", data_path="system_info"
-    )
-    entity = _make_entity(description=desc)
-    assert entity.name == "Uptime"
+    if platform_translations is not None:
+        entity.platform_data = SimpleNamespace(
+            platform_name="truenas_ce",
+            domain="sensor",
+            platform_translations=platform_translations,
+        )
+    assert entity.name == expected_name
 
 
 def test_unique_id_static_description() -> None:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -311,6 +312,40 @@ def test_name_referenced_entity_no_desc_name() -> None:
         uid="d1", data={"devname": "sda", "guid": "g1"}, description=desc
     )
     assert entity.name == "sda"
+
+
+def test_name_prefers_loaded_translation_over_literal_name() -> None:
+    desc = TrueNASEntityDescription(
+        key="uptime", name="Uptime", translation_key="uptime", data_path="system_info"
+    )
+    entity = _make_entity(description=desc)
+    entity.platform_data = SimpleNamespace(
+        platform_name="truenas_ce",
+        domain="sensor",
+        platform_translations={
+            "component.truenas_ce.entity.sensor.uptime.name": "Laufzeit"
+        },
+    )
+    assert entity.name == "Laufzeit"
+
+
+def test_name_falls_back_to_literal_when_translation_missing() -> None:
+    desc = TrueNASEntityDescription(
+        key="uptime", name="Uptime", translation_key="uptime", data_path="system_info"
+    )
+    entity = _make_entity(description=desc)
+    entity.platform_data = SimpleNamespace(
+        platform_name="truenas_ce", domain="sensor", platform_translations={}
+    )
+    assert entity.name == "Uptime"
+
+
+def test_name_without_platform_data_uses_literal_name() -> None:
+    desc = TrueNASEntityDescription(
+        key="uptime", name="Uptime", translation_key="uptime", data_path="system_info"
+    )
+    entity = _make_entity(description=desc)
+    assert entity.name == "Uptime"
 
 
 def test_unique_id_static_description() -> None:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -339,6 +339,8 @@ def test_name_translation_lookup(
             domain="sensor",
             platform_translations=platform_translations,
         )
+    else:
+        entity.platform_data = None
     assert entity.name == expected_name
 
 


### PR DESCRIPTION
## Proposed change

Implements the Gold quality-scale `entity-translations` rule: entity names now
resolve through Home Assistant's translation system instead of being
hard-coded in English.

- `TrueNASEntity._translated_description_name` resolves `translation_key` via
  the loaded platform translations (mirroring HA's `Entity._name_internal`),
  falling back to the literal name when no translation is loaded.
- 52 entity descriptions across sensor/binary_sensor/switch/button switch
  from a literal `name` to `translation_key` (matching key); the English text
  moved to `strings.json`'s `entity.<platform>.<key>.name` and is mirrored in
  `translations/{en,de,es,pt_BR,ru,sk}.json`.
- Added targeted tests for the translation-hit / fallback / no-platform-data
  code paths in `TrueNASEntity.name`.
- `quality_scale.yaml`: `entity-translations` marked `done`.

## Type of change

- [ ] Bugfix
- [x] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Two of three remaining Gold rules (`exception-translations`,
`icon-translations`) are still open and will follow in separate PRs.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement Home Assistant translation-based naming for TrueNAS entities and mark the entity-translations quality scale rule as completed.

New Features:
- Resolve TrueNASEntity description names via Home Assistant platform translations using translation_key instead of hard-coded English names.

Enhancements:
- Refactor entity name handling to centralize translation lookup and graceful fallback to literal description names when translations are unavailable.
- Populate strings and translations files for sensor, binary sensor, switch, and button entity names across supported locales.
- Update quality_scale.yaml to reflect completed entity-translations compliance for the integration.

Tests:
- Add tests covering translation hit, translation fallback, and behavior when platform translation data is absent for entity names.