### PR TITLE
fix: stop wiping app-stats entities when the domain is momentarily empty

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -327,7 +327,12 @@ def _process_dynamic_description(
 
     sub_data = data.get(description.data_path or "")
     if not sub_data:
-        return set(), live_bases
+        # Transient empty fetch of the whole domain: report no live base, so
+        # cleanup leaves the existing entities alone (same rule as
+        # ``_process_static_description``). Reporting the base as live here
+        # wiped every registry entry of the domain on each restart, because
+        # "live but nothing active" means "all of them are orphans".
+        return set(), set()
 
     active: set[str] = set()
     if getattr(description, "data_composite_references", ()):

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -109,6 +109,38 @@ async def test_cleanup_orphaned_entities_noop_after_failed_refresh(
     assert ent_reg.async_get(stale_entity.entity_id) is not None
 
 
+async def test_cleanup_keeps_entities_when_dynamic_domain_is_empty(
+    hass: HomeAssistant,
+) -> None:
+    """An empty ``app_stats`` payload must not wipe the app-stats entities.
+
+    ``app.stats`` is a subscription-fed domain: right after a restart the
+    coordinator has no sample yet, so the whole domain is legitimately empty
+    for one poll. Running the real ``_collect_active_unique_ids`` here (not a
+    patched one) is the point of this test -- it is the collection step that
+    used to report the base as live and hand cleanup a full set of "orphans".
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_NAME: "TrueNAS"})
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(
+        last_update_success=True,
+        config_entry=entry,
+        data={"app_stats": {}},
+    )
+
+    ent_reg = er.async_get(hass)
+    app_entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        format_unique_id("TrueNAS", "app_stats_cpu", "myapp"),
+        config_entry=entry,
+    )
+
+    _cleanup_orphaned_entities(hass, entry, coordinator)
+
+    assert ent_reg.async_get(app_entity.entity_id) is not None
+
+
 # ---------------------------
 #   async_add_entities (via a real platform-setup pass)
 # ---------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -395,7 +395,13 @@ def test_process_dynamic_description_with_composite_references() -> None:
     assert active == {init_module.format_unique_id("TrueNAS", "app_net", "a::eth0")}
 
 
-def test_process_dynamic_description_empty_sub_data_returns_live_base_only() -> None:
+def test_process_dynamic_description_empty_sub_data_reports_no_live_base() -> None:
+    """A momentarily empty domain must not be reported as live.
+
+    "Live base with nothing active" means "every entity below it is an orphan",
+    so returning the base here deleted all app_stats entities from the registry
+    on every restart -- app.stats is simply not populated yet on the first poll.
+    """
     description = _desc(
         key="app_stats",
         data_path="app_stats",
@@ -406,7 +412,22 @@ def test_process_dynamic_description_empty_sub_data_returns_live_base_only() -> 
         "TrueNAS", description, {"app_stats": {}}, False, set()
     )
     assert active == set()
-    assert live_bases == {init_module.format_unique_id("TrueNAS", "app_stats")}
+    assert live_bases == set()
+
+
+def test_process_dynamic_description_missing_data_path_reports_no_live_base() -> None:
+    """Same rule when the domain key is absent altogether, not just empty."""
+    description = _desc(
+        key="app_stats",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_reference="app_name",
+    )
+    active, live_bases = _process_dynamic_description(
+        "TrueNAS", description, {}, False, set()
+    )
+    assert active == set()
+    assert live_bases == set()
 
 
 # ---------------------------
@@ -438,6 +459,33 @@ def test_collect_active_unique_ids_combines_static_and_dynamic(
     assert init_module.format_unique_id("TrueNAS", "uptime") in active
     assert init_module.format_unique_id("TrueNAS", "app_stats", "myapp") in active
     assert init_module.format_unique_id("TrueNAS", "app_stats") in live_bases
+
+
+def test_collect_active_unique_ids_empty_dynamic_domain_yields_no_live_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty dynamic domain leaves cleanup nothing to match against.
+
+    Regression guard for the restart wipe: with an empty ``app_stats`` payload
+    the collected result must contain neither active ids nor a live base, so
+    ``_cleanup_orphaned_entities`` keeps the existing registry entries.
+    """
+    dynamic_desc = _desc(
+        key="app_stats",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_reference="app_name",
+    )
+    monkeypatch.setattr(init_module, "_ALL_DESCRIPTIONS", (dynamic_desc,))
+
+    coordinator = MagicMock()
+    coordinator.config_entry.options = {}
+    coordinator.data = {"app_stats": {}}
+
+    active, live_bases = _collect_active_unique_ids("TrueNAS", coordinator)
+
+    assert active == set()
+    assert live_bases == set()
 
 
 def test_collect_active_unique_ids_honors_behavior_toggle(


### PR DESCRIPTION
## Proposed change

`_process_dynamic_description` reported a dynamic domain's base as "live"
even when its `sub_data` was empty. `_cleanup_orphaned_entities` reads
"live base with zero active children" as "every entity below it is an
orphan" -- so an empty `app_stats` payload (which is subscription-fed and
legitimately empty right after every restart, before the first sample
arrives) deleted the whole app-stats entity set from the registry on each
restart, briefly surfacing and then auto-clearing an orphaned-statistics
repair issue.

Fix: an empty/missing `sub_data` now reports no live base at all (same
rule `_process_static_description` already follows), so cleanup leaves
existing entities alone until real data arrives.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Root cause found while investigating the recurring orphaned-statistics
repair issue that appeared and cleared itself ~60s after every HA
restart.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Prevent dynamic domains with empty data from being treated as live bases so app-stats entities are no longer wiped on restart.

Bug Fixes:
- Avoid deleting all app-stats entities when the dynamic domain payload is momentarily empty after restart.

Tests:
- Add regression tests ensuring empty or missing dynamic app_stats data does not report a live base or cause cleanup to remove existing entities.