### PR TITLE
feat: add translation_key/translation_placeholders to all user-facing exceptions

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -71,7 +71,6 @@ from .switch_types import SENSOR_TYPES as SWITCH_SENSOR_TYPES
 from .update_types import SENSOR_TYPES as UPDATE_SENSOR_TYPES
 
 _LOGGER = getLogger(__name__)
-_UNKNOWN_ERROR = "Unknown error"
 
 # This integration is config-entry only; it has no configuration.yaml schema.
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -348,7 +347,7 @@ def _process_dynamic_description(
 # ---------------------------
 def _resolve_config_entry(
     hass: HomeAssistant, entry_id: str | None
-) -> tuple[TrueNASConfigEntry | None, dict[str, str]]:
+) -> tuple[TrueNASConfigEntry | None, dict[str, Any]]:
     """Resolve the target config entry; return (entry, {}) or (None, error_dict).
 
     Services are registered in ``async_setup`` (before any entry exists), so the
@@ -366,13 +365,26 @@ def _resolve_config_entry(
                     "error": (
                         f"TrueNAS instance {entry_id} is not loaded "
                         f"(state: {entry.state.value})"
-                    )
+                    ),
+                    "translation_key": "config_entry_not_loaded",
+                    "translation_placeholders": {
+                        "entry_id": entry_id,
+                        "state": entry.state.value,
+                    },
                 }
             return entry, {}
-        return None, {"error": f"TrueNAS instance {entry_id} not found"}
+        return None, {
+            "error": f"TrueNAS instance {entry_id} not found",
+            "translation_key": "config_entry_not_found",
+            "translation_placeholders": {"entry_id": entry_id},
+        }
 
     if not loaded:
-        return None, {"error": "No TrueNAS instances configured"}
+        return None, {
+            "error": "No TrueNAS instances configured",
+            "translation_key": "no_config_entries",
+            "translation_placeholders": {},
+        }
     if len(loaded) != 1:
         return (
             None,
@@ -380,7 +392,9 @@ def _resolve_config_entry(
                 "error": (
                     f"Multiple TrueNAS instances ({len(loaded)}); "
                     "please specify config_entry"
-                )
+                ),
+                "translation_key": "multiple_config_entries",
+                "translation_placeholders": {"count": str(len(loaded))},
             },
         )
     return loaded[0], {}
@@ -396,7 +410,11 @@ def _require_config_entry(
     """
     entry, error = _resolve_config_entry(hass, entry_id)
     if error or entry is None:
-        raise ServiceValidationError(error.get("error", _UNKNOWN_ERROR))
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key=error["translation_key"],
+            translation_placeholders=error["translation_placeholders"],
+        )
     return entry
 
 
@@ -406,7 +424,7 @@ async def _handle_alert_list(hass: HomeAssistant, call: ServiceCall) -> dict[str
         hass, call.data.get(SERVICE_ALERT_CONFIG_ENTRY)
     )
     if error or entry is None:
-        return {"alerts": [], **error}
+        return {"alerts": [], "error": error["error"]}
 
     alerts = await entry.runtime_data.api.query("alert.list")
     if not isinstance(alerts, list):
@@ -429,7 +447,11 @@ async def _handle_alert_dismiss(hass: HomeAssistant, call: ServiceCall) -> None:
     if uuid := call.data.get(SERVICE_ALERT_UUID):
         await alert_action(entry.runtime_data, uuid, "dismiss")
     else:
-        raise ServiceValidationError("Alert UUID is required for dismiss action")
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="missing_alert_uuid",
+            translation_placeholders={"action": "dismiss"},
+        )
 
 
 async def _handle_alert_restore(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -439,7 +461,11 @@ async def _handle_alert_restore(hass: HomeAssistant, call: ServiceCall) -> None:
     if uuid := call.data.get(SERVICE_ALERT_UUID):
         await alert_action(entry.runtime_data, uuid, "restore")
     else:
-        raise ServiceValidationError("Alert UUID is required for restore action")
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="missing_alert_uuid",
+            translation_placeholders={"action": "restore"},
+        )
 
 
 async def _handle_passphrase_remove(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -448,12 +474,16 @@ async def _handle_passphrase_remove(hass: HomeAssistant, call: ServiceCall) -> N
 
     dataset_path = call.data.get(SERVICE_PASSPHRASE_DATASET_PATH, "").strip()
     if not dataset_path:
-        raise ServiceValidationError("dataset_path is required")
+        raise ServiceValidationError(
+            translation_domain=DOMAIN, translation_key="missing_dataset_path"
+        )
 
     existing = entry.data.get(CONF_DATASET_PASSPHRASES, {})
     if not isinstance(existing, dict) or dataset_path not in existing:
         raise ServiceValidationError(
-            f"No stored passphrase found for dataset '{dataset_path}'"
+            translation_domain=DOMAIN,
+            translation_key="passphrase_not_found",
+            translation_placeholders={"dataset": dataset_path},
         )
     updated = {k: v for k, v in existing.items() if k != dataset_path}
     hass.config_entries.async_update_entry(
@@ -468,7 +498,7 @@ async def _handle_passphrase_list(
     """Return the dataset names that have a stored passphrase (no values)."""
     entry, error = _resolve_config_entry(hass, call.data.get(SERVICE_CONFIG_ENTRY))
     if error or entry is None:
-        return {"datasets": [], **error}
+        return {"datasets": [], "error": error["error"]}
 
     stored = entry.data.get(CONF_DATASET_PASSPHRASES, {})
     datasets = sorted(stored.keys()) if isinstance(stored, dict) else []

--- a/custom_components/truenas_ce/button.py
+++ b/custom_components/truenas_ce/button.py
@@ -126,9 +126,13 @@ class TrueNASPoolScrubButton(TrueNASButton):
         )
         if result is None:
             raise HomeAssistantError(
-                f"TrueNAS scrub failed for pool {pool_name!r} on "
-                f"{self.coordinator.host}: "
-                f"{self.coordinator.api.error or 'unknown error'}"
+                translation_domain=DOMAIN,
+                translation_key="scrub_failed",
+                translation_placeholders={
+                    "pool": pool_name,
+                    "host": self.coordinator.host,
+                    "error": str(self.coordinator.api.error or "unknown error"),
+                },
             )
         self.coordinator.set_optimistic_running(
             self.entity_description.data_path or "", task_id

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -535,7 +535,12 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self.api.query(method, [object_id])
         if self.api.error:
             raise HomeAssistantError(
-                f"TrueNAS action failed on {self.host}: {self.api.error}"
+                translation_domain=DOMAIN,
+                translation_key="run_task_failed",
+                translation_placeholders={
+                    "host": self.host,
+                    "error": str(self.api.error),
+                },
             )
         self.set_optimistic_running(data_path, object_id)
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -582,8 +582,12 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         of an "Unknown error" from a bare NotImplementedError.
         """
         raise ServiceValidationError(
-            f"The '{action}' action is not supported by this TrueNAS entity "
-            f"({self.entity_id})"
+            translation_domain=DOMAIN,
+            translation_key="unsupported_action",
+            translation_placeholders={
+                "action": action,
+                "entity_id": self.entity_id,
+            },
         )
 
     def _raise_if_api_error(self, action: str) -> None:
@@ -597,8 +601,13 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         """
         if self.coordinator.api.error:
             raise HomeAssistantError(
-                f"TrueNAS action '{action}' failed on {self.coordinator.host}: "
-                f"{self.coordinator.api.error}"
+                translation_domain=DOMAIN,
+                translation_key="action_failed",
+                translation_placeholders={
+                    "action": action,
+                    "host": self.coordinator.host,
+                    "error": str(self.coordinator.api.error),
+                },
             )
 
     async def start(self) -> None:

--- a/custom_components/truenas_ce/helper.py
+++ b/custom_components/truenas_ce/helper.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from homeassistant.const import UnitOfInformation
 from homeassistant.exceptions import HomeAssistantError
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from .coordinator import TrueNASCoordinator
 
@@ -77,7 +79,13 @@ async def alert_action(coordinator: TrueNASCoordinator, uuid: str, action: str) 
     await coordinator.api.query(f"alert.{action}", [uuid])
     if coordinator.api.error:
         raise HomeAssistantError(
-            f"Failed to {action} alert {uuid} on {coordinator.host}: "
-            f"{coordinator.api.error}"
+            translation_domain=DOMAIN,
+            translation_key="alert_action_failed",
+            translation_placeholders={
+                "action": action,
+                "uuid": uuid,
+                "host": coordinator.host,
+                "error": str(coordinator.api.error),
+            },
         )
     await coordinator.async_refresh()

--- a/custom_components/truenas_ce/quality_scale.yaml
+++ b/custom_components/truenas_ce/quality_scale.yaml
@@ -141,10 +141,22 @@ rules:
       text (name="" or name=None -- the "unnamed" main feature of a device)
       are unaffected since there is nothing to translate.
   exception-translations:
-    status: todo
+    status: done
     comment: |
-      ServiceValidationError/HomeAssistantError are raised with literal
-      English messages instead of translation_domain/translation_key.
+      Every ServiceValidationError/HomeAssistantError raised for a user-facing
+      action failure now sets translation_domain=DOMAIN and a translation_key
+      instead of a literal message, with translation_placeholders carrying the
+      dynamic parts (action, dataset, host, error, ...). The English message
+      templates live in strings.json's exceptions.<key>.message (mirrored in
+      translations/en.json). Dataset actions share a single
+      TrueNASDatasetSensor._raise_dataset_action_failed helper (translation_key
+      dataset_action_failed) since job-failed/not-found/timeout/invalid-job-id/
+      unlock-failure/snapshot-failure all report the same shape. The domain
+      service handlers' shared _resolve_config_entry now returns a
+      translation_key/translation_placeholders pair alongside its existing
+      plain-text "error" (still used, unchanged, by the list-type service
+      responses), so _require_config_entry can raise a translated exception
+      without touching those non-exception response paths.
   icon-translations:
     status: todo
     comment: Icons are set via the entity descriptions; no icons.json yet.

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
 from logging import getLogger
-from typing import Any
+from typing import Any, NoReturn
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -28,6 +28,7 @@ from .const import (
     CONF_DATA_UNIT,
     CONF_DATASET_PASSPHRASES,
     DEFAULT_DATA_UNIT,
+    DOMAIN,
     SIGNAL_UPDATE_SENSORS,
 )
 from .coordinator import TrueNASCoordinator, get_truenas_coordinator
@@ -451,14 +452,18 @@ class TrueNASAlertSensor(TrueNASSensor):
         if uuid := kwargs.get("uuid"):
             await alert_action(self.coordinator, uuid, "dismiss")
         else:
-            raise ServiceValidationError("Missing required parameter: uuid")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN, translation_key="missing_uuid"
+            )
 
     async def restore(self, **kwargs: Any) -> None:
         """Restore (un-dismiss) a previously dismissed TrueNAS alert by UUID."""
         if uuid := kwargs.get("uuid"):
             await alert_action(self.coordinator, uuid, "restore")
         else:
-            raise ServiceValidationError("Missing required parameter: uuid")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN, translation_key="missing_uuid"
+            )
 
 
 # ---------------------------
@@ -467,12 +472,17 @@ class TrueNASAlertSensor(TrueNASSensor):
 class TrueNASDatasetSensor(TrueNASSensor):
     """Define an TrueNAS Dataset sensor."""
 
-    def _action_error(self, action: str, reason: str) -> str:
-        """Build a uniform error message for a dataset action."""
-        dataset_name = self._data.get("name", _UNKNOWN_DATASET)
-        return (
-            f"Failed to {action} dataset {dataset_name} "
-            f"on {self.coordinator.host}: {reason}"
+    def _raise_dataset_action_failed(self, action: str, reason: str) -> NoReturn:
+        """Raise a uniform, translated error for a failed dataset action."""
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="dataset_action_failed",
+            translation_placeholders={
+                "action": action,
+                "dataset": self._data.get("name", _UNKNOWN_DATASET),
+                "host": self.coordinator.host,
+                "reason": str(reason),
+            },
         )
 
     async def _poll_job(self, job_id: int) -> dict[str, Any] | None:
@@ -491,7 +501,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
             return True
         if state in JOB_STATES_FAILED:
             reason = job.get("error") or job.get("exception") or "unknown error"
-            raise HomeAssistantError(self._action_error(action, reason))
+            self._raise_dataset_action_failed(action, reason)
         return False
 
     async def _wait_for_job(self, job_id: int, action: str) -> dict[str, Any]:
@@ -506,8 +516,8 @@ class TrueNASDatasetSensor(TrueNASSensor):
                     if job is None:
                         missing += 1
                         if missing >= JOB_MAX_MISSING_POLLS:
-                            raise HomeAssistantError(
-                                self._action_error(action, f"job {job_id} not found")
+                            self._raise_dataset_action_failed(
+                                action, f"job {job_id} not found"
                             )
                     elif self._job_finished(job, action):
                         return job
@@ -516,7 +526,14 @@ class TrueNASDatasetSensor(TrueNASSensor):
                     await asyncio.sleep(JOB_POLL_INTERVAL)
         except TimeoutError as err:
             raise HomeAssistantError(
-                self._action_error(action, "timed out waiting for completion")
+                translation_domain=DOMAIN,
+                translation_key="dataset_action_failed",
+                translation_placeholders={
+                    "action": action,
+                    "dataset": self._data.get("name", _UNKNOWN_DATASET),
+                    "host": self.coordinator.host,
+                    "reason": "timed out waiting for completion",
+                },
             ) from err
 
     async def _run_dataset_job(
@@ -525,7 +542,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
         """Start a dataset middleware job, wait for it, and return its result."""
         job_id = await self.coordinator.api.query(method, payload)
         if not isinstance(job_id, int):
-            raise HomeAssistantError(self._action_error(action, "invalid job id"))
+            self._raise_dataset_action_failed(action, "invalid job id")
         job = await self._wait_for_job(job_id, action)
         return job.get("result")
 
@@ -547,7 +564,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
             else str(name)
             for name, info in failed.items()
         )
-        raise HomeAssistantError(self._action_error(action, reasons))
+        self._raise_dataset_action_failed(action, reasons)
 
     async def snapshot(self) -> None:
         """Create dataset snapshot."""
@@ -557,8 +574,8 @@ class TrueNASDatasetSensor(TrueNASSensor):
         if result is None:
             result = await self.coordinator.api.query("zfs.snapshot.create", payload)
         if result is None and self.coordinator.api.error:
-            raise HomeAssistantError(
-                self._action_error("snapshot", self.coordinator.api.error)
+            self._raise_dataset_action_failed(
+                "snapshot", str(self.coordinator.api.error)
             )
 
     def _raise_if_not_encrypted(self, action: str) -> None:
@@ -568,9 +585,13 @@ class TrueNASDatasetSensor(TrueNASSensor):
         be locked/unlocked, so a non-encrypted target is a user error.
         """
         if not self._data.get("encrypted"):
-            name = self._data.get("name", _UNKNOWN_DATASET)
             raise ServiceValidationError(
-                f"Dataset {name} is not encrypted and cannot be {action}ed"
+                translation_domain=DOMAIN,
+                translation_key="dataset_not_encrypted",
+                translation_placeholders={
+                    "dataset": self._data.get("name", _UNKNOWN_DATASET),
+                    "action": action,
+                },
             )
 
     def _log_already(self, state: str) -> None:
@@ -628,10 +649,12 @@ class TrueNASDatasetSensor(TrueNASSensor):
             passphrase if passphrase is not None else self._stored_passphrase()
         )
         if not effective_passphrase:
-            dataset_name = self._data.get("name", _UNKNOWN_DATASET)
             raise ServiceValidationError(
-                f"No passphrase provided or stored for dataset {dataset_name}. "
-                "Call passphrase_set first or supply the passphrase in the action call."
+                translation_domain=DOMAIN,
+                translation_key="missing_passphrase",
+                translation_placeholders={
+                    "dataset": self._data.get("name", _UNKNOWN_DATASET),
+                },
             )
 
         # See lock(): async_refresh forces fresh data before the idempotency check.
@@ -665,7 +688,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
         dataset_name = self._data.get("name")
         if not dataset_name:
             raise ServiceValidationError(
-                "Cannot store passphrase: dataset name is unknown"
+                translation_domain=DOMAIN, translation_key="unknown_dataset_name"
             )
         existing = self.coordinator.config_entry.data.get(CONF_DATASET_PASSPHRASES, {})
         updated = (

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -524,17 +524,10 @@ class TrueNASDatasetSensor(TrueNASSensor):
                     else:
                         missing = 0
                     await asyncio.sleep(JOB_POLL_INTERVAL)
-        except TimeoutError as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="dataset_action_failed",
-                translation_placeholders={
-                    "action": action,
-                    "dataset": self._data.get("name", _UNKNOWN_DATASET),
-                    "host": self.coordinator.host,
-                    "reason": "timed out waiting for completion",
-                },
-            ) from err
+        except TimeoutError:
+            self._raise_dataset_action_failed(
+                action, "timed out waiting for completion"
+            )
 
     async def _run_dataset_job(
         self, method: str, payload: list[Any], action: str

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -472,7 +472,9 @@ class TrueNASAlertSensor(TrueNASSensor):
 class TrueNASDatasetSensor(TrueNASSensor):
     """Define an TrueNAS Dataset sensor."""
 
-    def _raise_dataset_action_failed(self, action: str, reason: str) -> NoReturn:
+    def _raise_dataset_action_failed(
+        self, action: str, reason: str, *, cause: BaseException | None = None
+    ) -> NoReturn:
         """Raise a uniform, translated error for a failed dataset action."""
         raise HomeAssistantError(
             translation_domain=DOMAIN,
@@ -483,7 +485,7 @@ class TrueNASDatasetSensor(TrueNASSensor):
                 "host": self.coordinator.host,
                 "reason": str(reason),
             },
-        )
+        ) from cause
 
     async def _poll_job(self, job_id: int) -> dict[str, Any] | None:
         """Fetch a single middleware job by id."""
@@ -524,9 +526,9 @@ class TrueNASDatasetSensor(TrueNASSensor):
                     else:
                         missing = 0
                     await asyncio.sleep(JOB_POLL_INTERVAL)
-        except TimeoutError:
+        except TimeoutError as err:
             self._raise_dataset_action_failed(
-                action, "timed out waiting for completion"
+                action, "timed out waiting for completion", cause=err
             )
 
     async def _run_dataset_job(

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -131,6 +131,65 @@
             }
         }
     },
+    "exceptions": {
+        "unsupported_action": {
+            "message": "The '{action}' action is not supported by this TrueNAS entity ({entity_id})"
+        },
+        "action_failed": {
+            "message": "TrueNAS action '{action}' failed on {host}: {error}"
+        },
+        "run_task_failed": {
+            "message": "TrueNAS action failed on {host}: {error}"
+        },
+        "scrub_failed": {
+            "message": "TrueNAS scrub failed for pool {pool} on {host}: {error}"
+        },
+        "alert_action_failed": {
+            "message": "Failed to {action} alert {uuid} on {host}: {error}"
+        },
+        "system_update_failed": {
+            "message": "Failed to start TrueNAS system update on {host}: {error}"
+        },
+        "app_update_failed": {
+            "message": "Failed to start TrueNAS app update for {app} on {host}: {error}"
+        },
+        "missing_uuid": {
+            "message": "Missing required parameter: uuid"
+        },
+        "dataset_action_failed": {
+            "message": "Failed to {action} dataset {dataset} on {host}: {reason}"
+        },
+        "dataset_not_encrypted": {
+            "message": "Dataset {dataset} is not encrypted and cannot be {action}ed"
+        },
+        "missing_passphrase": {
+            "message": "No passphrase provided or stored for dataset {dataset}. Call passphrase_set first or supply the passphrase in the action call."
+        },
+        "unknown_dataset_name": {
+            "message": "Cannot store passphrase: dataset name is unknown"
+        },
+        "config_entry_not_loaded": {
+            "message": "TrueNAS instance {entry_id} is not loaded (state: {state})"
+        },
+        "config_entry_not_found": {
+            "message": "TrueNAS instance {entry_id} not found"
+        },
+        "no_config_entries": {
+            "message": "No TrueNAS instances configured"
+        },
+        "multiple_config_entries": {
+            "message": "Multiple TrueNAS instances ({count}); please specify config_entry"
+        },
+        "missing_alert_uuid": {
+            "message": "Alert UUID is required for the {action} action"
+        },
+        "missing_dataset_path": {
+            "message": "dataset_path is required"
+        },
+        "passphrase_not_found": {
+            "message": "No stored passphrase found for dataset '{dataset}'"
+        }
+    },
     "entity": {
         "button": {
             "statistics_cleanup": {

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -133,10 +133,10 @@
     },
     "exceptions": {
         "unsupported_action": {
-            "message": "The '{action}' action is not supported by this TrueNAS entity ({entity_id})"
+            "message": "The {action} action is not supported by this TrueNAS entity ({entity_id})"
         },
         "action_failed": {
-            "message": "TrueNAS action '{action}' failed on {host}: {error}"
+            "message": "TrueNAS action {action} failed on {host}: {error}"
         },
         "run_task_failed": {
             "message": "TrueNAS action failed on {host}: {error}"
@@ -187,7 +187,7 @@
             "message": "dataset_path is required"
         },
         "passphrase_not_found": {
-            "message": "No stored passphrase found for dataset '{dataset}'"
+            "message": "No stored passphrase found for dataset {dataset}"
         }
     },
     "entity": {

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -133,10 +133,10 @@
     },
     "exceptions": {
         "unsupported_action": {
-            "message": "Die Aktion '{action}' wird von dieser TrueNAS-Entität nicht unterstützt ({entity_id})"
+            "message": "Die Aktion {action} wird von dieser TrueNAS-Entität nicht unterstützt ({entity_id})"
         },
         "action_failed": {
-            "message": "TrueNAS-Aktion '{action}' ist auf {host} fehlgeschlagen: {error}"
+            "message": "TrueNAS-Aktion {action} ist auf {host} fehlgeschlagen: {error}"
         },
         "run_task_failed": {
             "message": "TrueNAS-Aktion ist auf {host} fehlgeschlagen: {error}"
@@ -145,7 +145,7 @@
             "message": "TrueNAS-Scrub für Pool {pool} ist auf {host} fehlgeschlagen: {error}"
         },
         "alert_action_failed": {
-            "message": "Aktion '{action}' für Alert {uuid} ist auf {host} fehlgeschlagen: {error}"
+            "message": "Aktion {action} für Alert {uuid} ist auf {host} fehlgeschlagen: {error}"
         },
         "system_update_failed": {
             "message": "Start des TrueNAS-System-Updates auf {host} fehlgeschlagen: {error}"
@@ -157,10 +157,10 @@
             "message": "Fehlender Pflichtparameter: uuid"
         },
         "dataset_action_failed": {
-            "message": "Aktion '{action}' für Dataset {dataset} auf {host} fehlgeschlagen: {reason}"
+            "message": "Aktion {action} für Dataset {dataset} auf {host} fehlgeschlagen: {reason}"
         },
         "dataset_not_encrypted": {
-            "message": "Dataset {dataset} ist nicht verschlüsselt; Aktion '{action}' nicht möglich"
+            "message": "Dataset {dataset} ist nicht verschlüsselt; Aktion {action} nicht möglich"
         },
         "missing_passphrase": {
             "message": "Keine Passphrase für Dataset {dataset} angegeben oder gespeichert. Rufen Sie zuerst passphrase_set auf oder geben Sie die Passphrase im Aktionsaufruf an."
@@ -181,13 +181,13 @@
             "message": "Mehrere TrueNAS-Instanzen ({count}); bitte config_entry angeben"
         },
         "missing_alert_uuid": {
-            "message": "Für die Aktion '{action}' ist eine Alert-UUID erforderlich"
+            "message": "Für die Aktion {action} ist eine Alert-UUID erforderlich"
         },
         "missing_dataset_path": {
             "message": "dataset_path ist erforderlich"
         },
         "passphrase_not_found": {
-            "message": "Keine gespeicherte Passphrase für Dataset '{dataset}' gefunden"
+            "message": "Keine gespeicherte Passphrase für Dataset {dataset} gefunden"
         }
     },
     "entity": {

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -131,6 +131,65 @@
             }
         }
     },
+    "exceptions": {
+        "unsupported_action": {
+            "message": "Die Aktion '{action}' wird von dieser TrueNAS-Entität nicht unterstützt ({entity_id})"
+        },
+        "action_failed": {
+            "message": "TrueNAS-Aktion '{action}' ist auf {host} fehlgeschlagen: {error}"
+        },
+        "run_task_failed": {
+            "message": "TrueNAS-Aktion ist auf {host} fehlgeschlagen: {error}"
+        },
+        "scrub_failed": {
+            "message": "TrueNAS-Scrub für Pool {pool} ist auf {host} fehlgeschlagen: {error}"
+        },
+        "alert_action_failed": {
+            "message": "Aktion '{action}' für Alert {uuid} ist auf {host} fehlgeschlagen: {error}"
+        },
+        "system_update_failed": {
+            "message": "Start des TrueNAS-System-Updates auf {host} fehlgeschlagen: {error}"
+        },
+        "app_update_failed": {
+            "message": "Start des TrueNAS-App-Updates für {app} auf {host} fehlgeschlagen: {error}"
+        },
+        "missing_uuid": {
+            "message": "Fehlender Pflichtparameter: uuid"
+        },
+        "dataset_action_failed": {
+            "message": "Aktion '{action}' für Dataset {dataset} auf {host} fehlgeschlagen: {reason}"
+        },
+        "dataset_not_encrypted": {
+            "message": "Dataset {dataset} ist nicht verschlüsselt; Aktion '{action}' nicht möglich"
+        },
+        "missing_passphrase": {
+            "message": "Keine Passphrase für Dataset {dataset} angegeben oder gespeichert. Rufen Sie zuerst passphrase_set auf oder geben Sie die Passphrase im Aktionsaufruf an."
+        },
+        "unknown_dataset_name": {
+            "message": "Passphrase kann nicht gespeichert werden: Dataset-Name unbekannt"
+        },
+        "config_entry_not_loaded": {
+            "message": "TrueNAS-Instanz {entry_id} ist nicht geladen (Status: {state})"
+        },
+        "config_entry_not_found": {
+            "message": "TrueNAS-Instanz {entry_id} nicht gefunden"
+        },
+        "no_config_entries": {
+            "message": "Keine TrueNAS-Instanzen konfiguriert"
+        },
+        "multiple_config_entries": {
+            "message": "Mehrere TrueNAS-Instanzen ({count}); bitte config_entry angeben"
+        },
+        "missing_alert_uuid": {
+            "message": "Für die Aktion '{action}' ist eine Alert-UUID erforderlich"
+        },
+        "missing_dataset_path": {
+            "message": "dataset_path ist erforderlich"
+        },
+        "passphrase_not_found": {
+            "message": "Keine gespeicherte Passphrase für Dataset '{dataset}' gefunden"
+        }
+    },
     "entity": {
         "button": {
             "statistics_cleanup": {

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -131,6 +131,65 @@
             }
         }
     },
+    "exceptions": {
+        "unsupported_action": {
+            "message": "The '{action}' action is not supported by this TrueNAS entity ({entity_id})"
+        },
+        "action_failed": {
+            "message": "TrueNAS action '{action}' failed on {host}: {error}"
+        },
+        "run_task_failed": {
+            "message": "TrueNAS action failed on {host}: {error}"
+        },
+        "scrub_failed": {
+            "message": "TrueNAS scrub failed for pool {pool} on {host}: {error}"
+        },
+        "alert_action_failed": {
+            "message": "Failed to {action} alert {uuid} on {host}: {error}"
+        },
+        "system_update_failed": {
+            "message": "Failed to start TrueNAS system update on {host}: {error}"
+        },
+        "app_update_failed": {
+            "message": "Failed to start TrueNAS app update for {app} on {host}: {error}"
+        },
+        "missing_uuid": {
+            "message": "Missing required parameter: uuid"
+        },
+        "dataset_action_failed": {
+            "message": "Failed to {action} dataset {dataset} on {host}: {reason}"
+        },
+        "dataset_not_encrypted": {
+            "message": "Dataset {dataset} is not encrypted and cannot be {action}ed"
+        },
+        "missing_passphrase": {
+            "message": "No passphrase provided or stored for dataset {dataset}. Call passphrase_set first or supply the passphrase in the action call."
+        },
+        "unknown_dataset_name": {
+            "message": "Cannot store passphrase: dataset name is unknown"
+        },
+        "config_entry_not_loaded": {
+            "message": "TrueNAS instance {entry_id} is not loaded (state: {state})"
+        },
+        "config_entry_not_found": {
+            "message": "TrueNAS instance {entry_id} not found"
+        },
+        "no_config_entries": {
+            "message": "No TrueNAS instances configured"
+        },
+        "multiple_config_entries": {
+            "message": "Multiple TrueNAS instances ({count}); please specify config_entry"
+        },
+        "missing_alert_uuid": {
+            "message": "Alert UUID is required for the {action} action"
+        },
+        "missing_dataset_path": {
+            "message": "dataset_path is required"
+        },
+        "passphrase_not_found": {
+            "message": "No stored passphrase found for dataset '{dataset}'"
+        }
+    },
     "entity": {
         "button": {
             "statistics_cleanup": {

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -133,10 +133,10 @@
     },
     "exceptions": {
         "unsupported_action": {
-            "message": "The '{action}' action is not supported by this TrueNAS entity ({entity_id})"
+            "message": "The {action} action is not supported by this TrueNAS entity ({entity_id})"
         },
         "action_failed": {
-            "message": "TrueNAS action '{action}' failed on {host}: {error}"
+            "message": "TrueNAS action {action} failed on {host}: {error}"
         },
         "run_task_failed": {
             "message": "TrueNAS action failed on {host}: {error}"
@@ -187,7 +187,7 @@
             "message": "dataset_path is required"
         },
         "passphrase_not_found": {
-            "message": "No stored passphrase found for dataset '{dataset}'"
+            "message": "No stored passphrase found for dataset {dataset}"
         }
     },
     "entity": {

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -133,10 +133,10 @@
     },
     "exceptions": {
         "unsupported_action": {
-            "message": "La acción '{action}' no es compatible con esta entidad de TrueNAS ({entity_id})"
+            "message": "La acción {action} no es compatible con esta entidad de TrueNAS ({entity_id})"
         },
         "action_failed": {
-            "message": "La acción de TrueNAS '{action}' falló en {host}: {error}"
+            "message": "La acción de TrueNAS {action} falló en {host}: {error}"
         },
         "run_task_failed": {
             "message": "La acción de TrueNAS falló en {host}: {error}"
@@ -145,7 +145,7 @@
             "message": "El scrub de TrueNAS falló para el pool {pool} en {host}: {error}"
         },
         "alert_action_failed": {
-            "message": "La acción '{action}' de la alerta {uuid} falló en {host}: {error}"
+            "message": "La acción {action} de la alerta {uuid} falló en {host}: {error}"
         },
         "system_update_failed": {
             "message": "No se pudo iniciar la actualización del sistema TrueNAS en {host}: {error}"
@@ -157,10 +157,10 @@
             "message": "Falta el parámetro obligatorio: uuid"
         },
         "dataset_action_failed": {
-            "message": "La acción '{action}' del dataset {dataset} falló en {host}: {reason}"
+            "message": "La acción {action} del dataset {dataset} falló en {host}: {reason}"
         },
         "dataset_not_encrypted": {
-            "message": "El dataset {dataset} no está cifrado; la acción '{action}' no es posible"
+            "message": "El dataset {dataset} no está cifrado; la acción {action} no es posible"
         },
         "missing_passphrase": {
             "message": "No se proporcionó ni hay almacenada una frase de contraseña para el dataset {dataset}. Llame primero a passphrase_set o proporcione la frase de contraseña en la llamada de la acción."
@@ -181,13 +181,13 @@
             "message": "Hay varias instancias de TrueNAS ({count}); especifique config_entry"
         },
         "missing_alert_uuid": {
-            "message": "Se requiere un UUID de alerta para la acción '{action}'"
+            "message": "Se requiere un UUID de alerta para la acción {action}"
         },
         "missing_dataset_path": {
             "message": "Se requiere dataset_path"
         },
         "passphrase_not_found": {
-            "message": "No se encontró ninguna frase de contraseña almacenada para el dataset '{dataset}'"
+            "message": "No se encontró ninguna frase de contraseña almacenada para el dataset {dataset}"
         }
     },
     "entity": {

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -131,6 +131,65 @@
             }
         }
     },
+    "exceptions": {
+        "unsupported_action": {
+            "message": "La acción '{action}' no es compatible con esta entidad de TrueNAS ({entity_id})"
+        },
+        "action_failed": {
+            "message": "La acción de TrueNAS '{action}' falló en {host}: {error}"
+        },
+        "run_task_failed": {
+            "message": "La acción de TrueNAS falló en {host}: {error}"
+        },
+        "scrub_failed": {
+            "message": "El scrub de TrueNAS falló para el pool {pool} en {host}: {error}"
+        },
+        "alert_action_failed": {
+            "message": "La acción '{action}' de la alerta {uuid} falló en {host}: {error}"
+        },
+        "system_update_failed": {
+            "message": "No se pudo iniciar la actualización del sistema TrueNAS en {host}: {error}"
+        },
+        "app_update_failed": {
+            "message": "No se pudo iniciar la actualización de la app TrueNAS {app} en {host}: {error}"
+        },
+        "missing_uuid": {
+            "message": "Falta el parámetro obligatorio: uuid"
+        },
+        "dataset_action_failed": {
+            "message": "La acción '{action}' del dataset {dataset} falló en {host}: {reason}"
+        },
+        "dataset_not_encrypted": {
+            "message": "El dataset {dataset} no está cifrado; la acción '{action}' no es posible"
+        },
+        "missing_passphrase": {
+            "message": "No se proporcionó ni hay almacenada una frase de contraseña para el dataset {dataset}. Llame primero a passphrase_set o proporcione la frase de contraseña en la llamada de la acción."
+        },
+        "unknown_dataset_name": {
+            "message": "No se puede guardar la frase de contraseña: el nombre del dataset es desconocido"
+        },
+        "config_entry_not_loaded": {
+            "message": "La instancia de TrueNAS {entry_id} no está cargada (estado: {state})"
+        },
+        "config_entry_not_found": {
+            "message": "No se encontró la instancia de TrueNAS {entry_id}"
+        },
+        "no_config_entries": {
+            "message": "No hay instancias de TrueNAS configuradas"
+        },
+        "multiple_config_entries": {
+            "message": "Hay varias instancias de TrueNAS ({count}); especifique config_entry"
+        },
+        "missing_alert_uuid": {
+            "message": "Se requiere un UUID de alerta para la acción '{action}'"
+        },
+        "missing_dataset_path": {
+            "message": "Se requiere dataset_path"
+        },
+        "passphrase_not_found": {
+            "message": "No se encontró ninguna frase de contraseña almacenada para el dataset '{dataset}'"
+        }
+    },
     "entity": {
         "button": {
             "statistics_cleanup": {

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -131,6 +131,65 @@
             }
         }
     },
+    "exceptions": {
+        "unsupported_action": {
+            "message": "A ação '{action}' não é suportada por esta entidade TrueNAS ({entity_id})"
+        },
+        "action_failed": {
+            "message": "A ação TrueNAS '{action}' falhou em {host}: {error}"
+        },
+        "run_task_failed": {
+            "message": "A ação TrueNAS falhou em {host}: {error}"
+        },
+        "scrub_failed": {
+            "message": "O scrub do TrueNAS falhou para o pool {pool} em {host}: {error}"
+        },
+        "alert_action_failed": {
+            "message": "A ação '{action}' do alerta {uuid} falhou em {host}: {error}"
+        },
+        "system_update_failed": {
+            "message": "Falha ao iniciar a atualização do sistema TrueNAS em {host}: {error}"
+        },
+        "app_update_failed": {
+            "message": "Falha ao iniciar a atualização do app TrueNAS {app} em {host}: {error}"
+        },
+        "missing_uuid": {
+            "message": "Parâmetro obrigatório ausente: uuid"
+        },
+        "dataset_action_failed": {
+            "message": "A ação '{action}' do dataset {dataset} falhou em {host}: {reason}"
+        },
+        "dataset_not_encrypted": {
+            "message": "O dataset {dataset} não está criptografado; a ação '{action}' não é possível"
+        },
+        "missing_passphrase": {
+            "message": "Nenhuma frase secreta foi fornecida ou armazenada para o dataset {dataset}. Chame passphrase_set primeiro ou informe a frase secreta na chamada da ação."
+        },
+        "unknown_dataset_name": {
+            "message": "Não é possível salvar a frase secreta: o nome do dataset é desconhecido"
+        },
+        "config_entry_not_loaded": {
+            "message": "A instância TrueNAS {entry_id} não está carregada (estado: {state})"
+        },
+        "config_entry_not_found": {
+            "message": "Instância TrueNAS {entry_id} não encontrada"
+        },
+        "no_config_entries": {
+            "message": "Nenhuma instância TrueNAS configurada"
+        },
+        "multiple_config_entries": {
+            "message": "Várias instâncias TrueNAS ({count}); especifique config_entry"
+        },
+        "missing_alert_uuid": {
+            "message": "É necessário um UUID de alerta para a ação '{action}'"
+        },
+        "missing_dataset_path": {
+            "message": "dataset_path é obrigatório"
+        },
+        "passphrase_not_found": {
+            "message": "Nenhuma frase secreta armazenada encontrada para o dataset '{dataset}'"
+        }
+    },
     "entity": {
         "button": {
             "statistics_cleanup": {

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -133,10 +133,10 @@
     },
     "exceptions": {
         "unsupported_action": {
-            "message": "A ação '{action}' não é suportada por esta entidade TrueNAS ({entity_id})"
+            "message": "A ação {action} não é suportada por esta entidade TrueNAS ({entity_id})"
         },
         "action_failed": {
-            "message": "A ação TrueNAS '{action}' falhou em {host}: {error}"
+            "message": "A ação TrueNAS {action} falhou em {host}: {error}"
         },
         "run_task_failed": {
             "message": "A ação TrueNAS falhou em {host}: {error}"
@@ -145,7 +145,7 @@
             "message": "O scrub do TrueNAS falhou para o pool {pool} em {host}: {error}"
         },
         "alert_action_failed": {
-            "message": "A ação '{action}' do alerta {uuid} falhou em {host}: {error}"
+            "message": "A ação {action} do alerta {uuid} falhou em {host}: {error}"
         },
         "system_update_failed": {
             "message": "Falha ao iniciar a atualização do sistema TrueNAS em {host}: {error}"
@@ -157,10 +157,10 @@
             "message": "Parâmetro obrigatório ausente: uuid"
         },
         "dataset_action_failed": {
-            "message": "A ação '{action}' do dataset {dataset} falhou em {host}: {reason}"
+            "message": "A ação {action} do dataset {dataset} falhou em {host}: {reason}"
         },
         "dataset_not_encrypted": {
-            "message": "O dataset {dataset} não está criptografado; a ação '{action}' não é possível"
+            "message": "O dataset {dataset} não está criptografado; a ação {action} não é possível"
         },
         "missing_passphrase": {
             "message": "Nenhuma frase secreta foi fornecida ou armazenada para o dataset {dataset}. Chame passphrase_set primeiro ou informe a frase secreta na chamada da ação."
@@ -181,13 +181,13 @@
             "message": "Várias instâncias TrueNAS ({count}); especifique config_entry"
         },
         "missing_alert_uuid": {
-            "message": "É necessário um UUID de alerta para a ação '{action}'"
+            "message": "É necessário um UUID de alerta para a ação {action}"
         },
         "missing_dataset_path": {
             "message": "dataset_path é obrigatório"
         },
         "passphrase_not_found": {
-            "message": "Nenhuma frase secreta armazenada encontrada para o dataset '{dataset}'"
+            "message": "Nenhuma frase secreta armazenada encontrada para o dataset {dataset}"
         }
     },
     "entity": {

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -131,6 +131,65 @@
             }
         }
     },
+    "exceptions": {
+        "unsupported_action": {
+            "message": "Действие '{action}' не поддерживается этой сущностью TrueNAS ({entity_id})"
+        },
+        "action_failed": {
+            "message": "Действие TrueNAS '{action}' завершилось ошибкой на {host}: {error}"
+        },
+        "run_task_failed": {
+            "message": "Действие TrueNAS завершилось ошибкой на {host}: {error}"
+        },
+        "scrub_failed": {
+            "message": "Проверка (scrub) пула {pool} TrueNAS завершилась ошибкой на {host}: {error}"
+        },
+        "alert_action_failed": {
+            "message": "Действие '{action}' для оповещения {uuid} завершилось ошибкой на {host}: {error}"
+        },
+        "system_update_failed": {
+            "message": "Не удалось запустить обновление системы TrueNAS на {host}: {error}"
+        },
+        "app_update_failed": {
+            "message": "Не удалось запустить обновление приложения {app} TrueNAS на {host}: {error}"
+        },
+        "missing_uuid": {
+            "message": "Отсутствует обязательный параметр: uuid"
+        },
+        "dataset_action_failed": {
+            "message": "Действие '{action}' для датасета {dataset} завершилось ошибкой на {host}: {reason}"
+        },
+        "dataset_not_encrypted": {
+            "message": "Датасет {dataset} не зашифрован; действие '{action}' невозможно"
+        },
+        "missing_passphrase": {
+            "message": "Для датасета {dataset} не указана и не сохранена парольная фраза. Сначала вызовите passphrase_set или укажите парольную фразу при вызове действия."
+        },
+        "unknown_dataset_name": {
+            "message": "Невозможно сохранить парольную фразу: имя датасета неизвестно"
+        },
+        "config_entry_not_loaded": {
+            "message": "Экземпляр TrueNAS {entry_id} не загружен (состояние: {state})"
+        },
+        "config_entry_not_found": {
+            "message": "Экземпляр TrueNAS {entry_id} не найден"
+        },
+        "no_config_entries": {
+            "message": "Не настроено ни одного экземпляра TrueNAS"
+        },
+        "multiple_config_entries": {
+            "message": "Найдено несколько экземпляров TrueNAS ({count}); укажите config_entry"
+        },
+        "missing_alert_uuid": {
+            "message": "Для действия '{action}' требуется UUID оповещения"
+        },
+        "missing_dataset_path": {
+            "message": "Требуется dataset_path"
+        },
+        "passphrase_not_found": {
+            "message": "Сохранённая парольная фраза для датасета '{dataset}' не найдена"
+        }
+    },
     "entity": {
         "button": {
             "statistics_cleanup": {

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -133,10 +133,10 @@
     },
     "exceptions": {
         "unsupported_action": {
-            "message": "Действие '{action}' не поддерживается этой сущностью TrueNAS ({entity_id})"
+            "message": "Действие {action} не поддерживается этой сущностью TrueNAS ({entity_id})"
         },
         "action_failed": {
-            "message": "Действие TrueNAS '{action}' завершилось ошибкой на {host}: {error}"
+            "message": "Действие TrueNAS {action} завершилось ошибкой на {host}: {error}"
         },
         "run_task_failed": {
             "message": "Действие TrueNAS завершилось ошибкой на {host}: {error}"
@@ -145,7 +145,7 @@
             "message": "Проверка (scrub) пула {pool} TrueNAS завершилась ошибкой на {host}: {error}"
         },
         "alert_action_failed": {
-            "message": "Действие '{action}' для оповещения {uuid} завершилось ошибкой на {host}: {error}"
+            "message": "Действие {action} для оповещения {uuid} завершилось ошибкой на {host}: {error}"
         },
         "system_update_failed": {
             "message": "Не удалось запустить обновление системы TrueNAS на {host}: {error}"
@@ -157,10 +157,10 @@
             "message": "Отсутствует обязательный параметр: uuid"
         },
         "dataset_action_failed": {
-            "message": "Действие '{action}' для датасета {dataset} завершилось ошибкой на {host}: {reason}"
+            "message": "Действие {action} для датасета {dataset} завершилось ошибкой на {host}: {reason}"
         },
         "dataset_not_encrypted": {
-            "message": "Датасет {dataset} не зашифрован; действие '{action}' невозможно"
+            "message": "Датасет {dataset} не зашифрован; действие {action} невозможно"
         },
         "missing_passphrase": {
             "message": "Для датасета {dataset} не указана и не сохранена парольная фраза. Сначала вызовите passphrase_set или укажите парольную фразу при вызове действия."
@@ -181,13 +181,13 @@
             "message": "Найдено несколько экземпляров TrueNAS ({count}); укажите config_entry"
         },
         "missing_alert_uuid": {
-            "message": "Для действия '{action}' требуется UUID оповещения"
+            "message": "Для действия {action} требуется UUID оповещения"
         },
         "missing_dataset_path": {
             "message": "Требуется dataset_path"
         },
         "passphrase_not_found": {
-            "message": "Сохранённая парольная фраза для датасета '{dataset}' не найдена"
+            "message": "Сохранённая парольная фраза для датасета {dataset} не найдена"
         }
     },
     "entity": {

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -133,10 +133,10 @@
     },
     "exceptions": {
         "unsupported_action": {
-            "message": "Akcia '{action}' nie je touto entitou TrueNAS podporovaná ({entity_id})"
+            "message": "Akcia {action} nie je touto entitou TrueNAS podporovaná ({entity_id})"
         },
         "action_failed": {
-            "message": "Akcia TrueNAS '{action}' zlyhala na {host}: {error}"
+            "message": "Akcia TrueNAS {action} zlyhala na {host}: {error}"
         },
         "run_task_failed": {
             "message": "Akcia TrueNAS zlyhala na {host}: {error}"
@@ -145,7 +145,7 @@
             "message": "Scrub TrueNAS pre pool {pool} zlyhal na {host}: {error}"
         },
         "alert_action_failed": {
-            "message": "Akcia '{action}' pre upozornenie {uuid} zlyhala na {host}: {error}"
+            "message": "Akcia {action} pre upozornenie {uuid} zlyhala na {host}: {error}"
         },
         "system_update_failed": {
             "message": "Nepodarilo sa spustiť aktualizáciu systému TrueNAS na {host}: {error}"
@@ -157,10 +157,10 @@
             "message": "Chýba povinný parameter: uuid"
         },
         "dataset_action_failed": {
-            "message": "Akcia '{action}' pre dataset {dataset} zlyhala na {host}: {reason}"
+            "message": "Akcia {action} pre dataset {dataset} zlyhala na {host}: {reason}"
         },
         "dataset_not_encrypted": {
-            "message": "Dataset {dataset} nie je zašifrovaný; akcia '{action}' nie je možná"
+            "message": "Dataset {dataset} nie je zašifrovaný; akcia {action} nie je možná"
         },
         "missing_passphrase": {
             "message": "Pre dataset {dataset} nebola zadaná ani uložená prístupová fráza. Najprv zavolajte passphrase_set alebo zadajte prístupovú frázu priamo pri volaní akcie."
@@ -181,13 +181,13 @@
             "message": "Je nakonfigurovaných viacero inštancií TrueNAS ({count}); zadajte config_entry"
         },
         "missing_alert_uuid": {
-            "message": "Pre akciu '{action}' je potrebné UUID upozornenia"
+            "message": "Pre akciu {action} je potrebné UUID upozornenia"
         },
         "missing_dataset_path": {
             "message": "Je vyžadovaný dataset_path"
         },
         "passphrase_not_found": {
-            "message": "Pre dataset '{dataset}' nebola nájdená žiadna uložená prístupová fráza"
+            "message": "Pre dataset {dataset} nebola nájdená žiadna uložená prístupová fráza"
         }
     },
     "entity": {

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -131,6 +131,65 @@
             }
         }
     },
+    "exceptions": {
+        "unsupported_action": {
+            "message": "Akcia '{action}' nie je touto entitou TrueNAS podporovaná ({entity_id})"
+        },
+        "action_failed": {
+            "message": "Akcia TrueNAS '{action}' zlyhala na {host}: {error}"
+        },
+        "run_task_failed": {
+            "message": "Akcia TrueNAS zlyhala na {host}: {error}"
+        },
+        "scrub_failed": {
+            "message": "Scrub TrueNAS pre pool {pool} zlyhal na {host}: {error}"
+        },
+        "alert_action_failed": {
+            "message": "Akcia '{action}' pre upozornenie {uuid} zlyhala na {host}: {error}"
+        },
+        "system_update_failed": {
+            "message": "Nepodarilo sa spustiť aktualizáciu systému TrueNAS na {host}: {error}"
+        },
+        "app_update_failed": {
+            "message": "Nepodarilo sa spustiť aktualizáciu aplikácie {app} TrueNAS na {host}: {error}"
+        },
+        "missing_uuid": {
+            "message": "Chýba povinný parameter: uuid"
+        },
+        "dataset_action_failed": {
+            "message": "Akcia '{action}' pre dataset {dataset} zlyhala na {host}: {reason}"
+        },
+        "dataset_not_encrypted": {
+            "message": "Dataset {dataset} nie je zašifrovaný; akcia '{action}' nie je možná"
+        },
+        "missing_passphrase": {
+            "message": "Pre dataset {dataset} nebola zadaná ani uložená prístupová fráza. Najprv zavolajte passphrase_set alebo zadajte prístupovú frázu priamo pri volaní akcie."
+        },
+        "unknown_dataset_name": {
+            "message": "Prístupovú frázu nie je možné uložiť: názov datasetu je neznámy"
+        },
+        "config_entry_not_loaded": {
+            "message": "Inštancia TrueNAS {entry_id} nie je načítaná (stav: {state})"
+        },
+        "config_entry_not_found": {
+            "message": "Inštancia TrueNAS {entry_id} nebola nájdená"
+        },
+        "no_config_entries": {
+            "message": "Nie je nakonfigurovaná žiadna inštancia TrueNAS"
+        },
+        "multiple_config_entries": {
+            "message": "Je nakonfigurovaných viacero inštancií TrueNAS ({count}); zadajte config_entry"
+        },
+        "missing_alert_uuid": {
+            "message": "Pre akciu '{action}' je potrebné UUID upozornenia"
+        },
+        "missing_dataset_path": {
+            "message": "Je vyžadovaný dataset_path"
+        },
+        "passphrase_not_found": {
+            "message": "Pre dataset '{dataset}' nebola nájdená žiadna uložená prístupová fráza"
+        }
+    },
     "entity": {
         "button": {
             "statistics_cleanup": {

--- a/custom_components/truenas_ce/update.py
+++ b/custom_components/truenas_ce/update.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import TrueNASCoordinator
 from .entity import TrueNASEntity, async_add_entities
 from .update_types import (  # noqa: F401
@@ -93,8 +94,12 @@ class TrueNASUpdate(TrueNASEntity, UpdateEntity):
         job_id = await self.coordinator.api.query("update.update", {"reboot": True})
         if job_id is None:
             raise HomeAssistantError(
-                f"Failed to start TrueNAS system update on {self.coordinator.host}: "
-                f"{self.coordinator.api.error or 'unknown error'}"
+                translation_domain=DOMAIN,
+                translation_key="system_update_failed",
+                translation_placeholders={
+                    "host": self.coordinator.host,
+                    "error": str(self.coordinator.api.error or "unknown error"),
+                },
             )
 
         self._data["update_jobid"] = job_id
@@ -171,9 +176,13 @@ class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
         job_id = await self.coordinator.api.query("app.upgrade", [self._data["id"]])
         if job_id is None:
             raise HomeAssistantError(
-                f"Failed to start TrueNAS app update for {self._data['id']} on "
-                f"{self.coordinator.host}: "
-                f"{self.coordinator.api.error or 'unknown error'}"
+                translation_domain=DOMAIN,
+                translation_key="app_update_failed",
+                translation_placeholders={
+                    "app": self._data["id"],
+                    "host": self.coordinator.host,
+                    "error": str(self.coordinator.api.error or "unknown error"),
+                },
             )
 
         self._data["update_jobid"] = job_id

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -83,8 +83,14 @@ async def test_scrub_button_failure_raises() -> None:
     button = _make_scrub_button(data={"pool_name": "tank", "id": 5, "enabled": True})
     button.coordinator.api.query.return_value = None
     button.coordinator.api.error = "middleware down"
-    with pytest.raises(HomeAssistantError, match="middleware down"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await button.async_press()
+    assert exc_info.value.translation_key == "scrub_failed"
+    assert exc_info.value.translation_placeholders == {
+        "pool": "tank",
+        "host": button.coordinator.host,
+        "error": "middleware down",
+    }
 
 
 def test_statistics_cleanup_button_init_and_available() -> None:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -14,7 +14,7 @@ from custom_components.truenas_ce.button import (
     TrueNASStatisticsCleanupButton,
 )
 from custom_components.truenas_ce.button_types import TrueNASButtonEntityDescription
-from custom_components.truenas_ce.const import MIGRATION_LEGACY_ENTRY_ID
+from custom_components.truenas_ce.const import DOMAIN, MIGRATION_LEGACY_ENTRY_ID
 
 _RUN_DESC = TrueNASButtonEntityDescription(
     key="rsynctask_run", name="Run", data_path="rsynctask", api_method="rsynctask.run"
@@ -85,6 +85,7 @@ async def test_scrub_button_failure_raises() -> None:
     button.coordinator.api.error = "middleware down"
     with pytest.raises(HomeAssistantError) as exc_info:
         await button.async_press()
+    assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == "scrub_failed"
     assert exc_info.value.translation_placeholders == {
         "pool": "tank",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -315,8 +315,13 @@ async def test_async_run_task_raises_and_skips_optimistic_state_on_failure() -> 
     coord.api.query = AsyncMock(return_value=None)
     coord.api.error = "ERR_LOST_QUERY"
     coord.async_update_listeners = MagicMock()
-    with pytest.raises(HomeAssistantError, match="ERR_LOST_QUERY"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await coord.async_run_task("rsynctask.run", "1", "rsynctask")
+    assert exc_info.value.translation_key == "run_task_failed"
+    assert exc_info.value.translation_placeholders == {
+        "host": "truenas.local",
+        "error": "ERR_LOST_QUERY",
+    }
     assert coord.ds["rsynctask"]["1"]["state"] == "STOPPED"
     coord.async_update_listeners.assert_not_called()
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -30,6 +30,7 @@ from custom_components.truenas_ce.const import (
     CONF_STATISTICS_CLEANUP_IGNORED,
     DEFAULT_DEVICE_NAME,
     DEFAULT_POLL_INTERVAL,
+    DOMAIN,
     LEGACY_DOMAIN,
     MIGRATION_LEGACY_ENTRY_ID,
     MIGRATION_RECORDS,
@@ -317,6 +318,7 @@ async def test_async_run_task_raises_and_skips_optimistic_state_on_failure() -> 
     coord.async_update_listeners = MagicMock()
     with pytest.raises(HomeAssistantError) as exc_info:
         await coord.async_run_task("rsynctask.run", "1", "rsynctask")
+    assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == "run_task_failed"
     assert exc_info.value.translation_placeholders == {
         "host": "truenas.local",

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -471,8 +471,13 @@ def test_extra_state_attributes_includes_attribution_and_listed_fields() -> None
 
 def test_raise_unsupported_raises_service_validation_error() -> None:
     entity = _make_entity()
-    with pytest.raises(ServiceValidationError, match="not supported"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         entity._raise_unsupported("start")
+    assert exc_info.value.translation_key == "unsupported_action"
+    assert exc_info.value.translation_placeholders == {
+        "action": "start",
+        "entity_id": entity.entity_id,
+    }
 
 
 def test_raise_if_api_error_no_error_is_noop() -> None:
@@ -483,8 +488,14 @@ def test_raise_if_api_error_no_error_is_noop() -> None:
 def test_raise_if_api_error_raises_when_error_set() -> None:
     coordinator = make_coordinator(api_error="boom")
     entity = _make_entity(coordinator=coordinator)
-    with pytest.raises(HomeAssistantError, match="boom"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         entity._raise_if_api_error("start")
+    assert exc_info.value.translation_key == "action_failed"
+    assert exc_info.value.translation_placeholders == {
+        "action": "start",
+        "host": coordinator.host,
+        "error": "boom",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -10,6 +10,7 @@ from _fakes import make_coordinator
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from custom_components.truenas_ce.const import DOMAIN
 from custom_components.truenas_ce.entity import (
     TrueNASEntity,
     TrueNASEntityDescription,
@@ -473,6 +474,7 @@ def test_raise_unsupported_raises_service_validation_error() -> None:
     entity = _make_entity()
     with pytest.raises(ServiceValidationError) as exc_info:
         entity._raise_unsupported("start")
+    assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == "unsupported_action"
     assert exc_info.value.translation_placeholders == {
         "action": "start",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -664,8 +664,10 @@ async def test_handle_alert_dismiss_requires_uuid() -> None:
     hass.config_entries.async_entries.return_value = [entry]
     call = SimpleNamespace(data={})
 
-    with pytest.raises(ServiceValidationError, match="UUID is required"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await _handle_alert_dismiss(hass, call)
+    assert exc_info.value.translation_key == "missing_alert_uuid"
+    assert exc_info.value.translation_placeholders == {"action": "dismiss"}
 
 
 async def test_handle_alert_dismiss_calls_alert_action() -> None:
@@ -701,8 +703,10 @@ async def test_handle_alert_restore_requires_uuid() -> None:
     hass.config_entries.async_entries.return_value = [entry]
     call = SimpleNamespace(data={})
 
-    with pytest.raises(ServiceValidationError, match="UUID is required"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await _handle_alert_restore(hass, call)
+    assert exc_info.value.translation_key == "missing_alert_uuid"
+    assert exc_info.value.translation_placeholders == {"action": "restore"}
 
 
 async def test_handle_passphrase_remove_requires_path() -> None:
@@ -711,8 +715,9 @@ async def test_handle_passphrase_remove_requires_path() -> None:
     hass.config_entries.async_entries.return_value = [entry]
     call = SimpleNamespace(data={SERVICE_PASSPHRASE_DATASET_PATH: "  "})
 
-    with pytest.raises(ServiceValidationError, match="dataset_path is required"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await _handle_passphrase_remove(hass, call)
+    assert exc_info.value.translation_key == "missing_dataset_path"
 
 
 async def test_handle_passphrase_remove_requires_existing_entry() -> None:
@@ -721,8 +726,10 @@ async def test_handle_passphrase_remove_requires_existing_entry() -> None:
     hass.config_entries.async_entries.return_value = [entry]
     call = SimpleNamespace(data={SERVICE_PASSPHRASE_DATASET_PATH: "tank/data"})
 
-    with pytest.raises(ServiceValidationError, match="No stored passphrase"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await _handle_passphrase_remove(hass, call)
+    assert exc_info.value.translation_key == "passphrase_not_found"
+    assert exc_info.value.translation_placeholders == {"dataset": "tank/data"}
 
 
 async def test_handle_passphrase_remove_deletes_entry() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -686,6 +686,26 @@ async def test_dataset_wait_for_job_missing_job_exhausts_retries() -> None:
     }
 
 
+async def test_dataset_wait_for_job_timeout_raises() -> None:
+    sensor = _make_dataset({"encrypted": True, "locked": True})
+    sensor.coordinator.api.query.side_effect = [42, {"state": "RUNNING"}]
+    with (
+        patch(
+            "custom_components.truenas_ce.sensor.asyncio.sleep",
+            new=AsyncMock(side_effect=TimeoutError),
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await sensor.unlock(passphrase="secret")
+    assert exc_info.value.translation_key == "dataset_action_failed"
+    assert exc_info.value.translation_placeholders == {
+        "action": "unlock",
+        "dataset": "tank/data",
+        "host": sensor.coordinator.host,
+        "reason": "timed out waiting for completion",
+    }
+
+
 async def test_dataset_passphrase_set_stores_in_config_entry() -> None:
     sensor = _make_dataset()
     sensor.hass = sensor.coordinator.hass

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -384,8 +384,9 @@ async def test_uptime_refresh_calls_coordinator_refresh() -> None:
 # ---------------------------
 async def test_alert_dismiss_without_uuid_raises() -> None:
     sensor = _make_sensor(TrueNASAlertSensor, {})
-    with pytest.raises(ServiceValidationError, match="uuid"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await sensor.dismiss()
+    assert exc_info.value.translation_key == "missing_uuid"
 
 
 async def test_alert_dismiss_with_uuid_calls_query_and_refreshes() -> None:
@@ -397,8 +398,9 @@ async def test_alert_dismiss_with_uuid_calls_query_and_refreshes() -> None:
 
 async def test_alert_restore_without_uuid_raises() -> None:
     sensor = _make_sensor(TrueNASAlertSensor, {})
-    with pytest.raises(ServiceValidationError, match="uuid"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await sensor.restore()
+    assert exc_info.value.translation_key == "missing_uuid"
 
 
 async def test_alert_restore_with_uuid_calls_query_and_refreshes() -> None:
@@ -539,14 +541,26 @@ async def test_dataset_snapshot_both_fail_raises() -> None:
     sensor = _make_dataset()
     sensor.coordinator.api.query.side_effect = [None, None]
     sensor.coordinator.api.error = "no permission"
-    with pytest.raises(HomeAssistantError, match="no permission"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await sensor.snapshot()
+    assert exc_info.value.translation_key == "dataset_action_failed"
+    assert exc_info.value.translation_placeholders == {
+        "action": "snapshot",
+        "dataset": "tank/data",
+        "host": sensor.coordinator.host,
+        "reason": "no permission",
+    }
 
 
 async def test_dataset_lock_rejects_unencrypted() -> None:
     sensor = _make_dataset({"encrypted": False})
-    with pytest.raises(ServiceValidationError, match="not encrypted"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await sensor.lock()
+    assert exc_info.value.translation_key == "dataset_not_encrypted"
+    assert exc_info.value.translation_placeholders == {
+        "dataset": "tank/data",
+        "action": "lock",
+    }
 
 
 async def test_dataset_lock_already_locked_returns_early() -> None:
@@ -568,15 +582,22 @@ async def test_dataset_lock_runs_job_to_success() -> None:
 
 async def test_dataset_unlock_rejects_unencrypted() -> None:
     sensor = _make_dataset({"encrypted": False})
-    with pytest.raises(ServiceValidationError, match="not encrypted"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await sensor.unlock(passphrase="secret")
+    assert exc_info.value.translation_key == "dataset_not_encrypted"
+    assert exc_info.value.translation_placeholders == {
+        "dataset": "tank/data",
+        "action": "unlock",
+    }
 
 
 async def test_dataset_unlock_no_passphrase_raises() -> None:
     sensor = _make_dataset({"encrypted": True})
     sensor.coordinator.config_entry.data.pop("dataset_passphrases", None)
-    with pytest.raises(ServiceValidationError, match="No passphrase"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await sensor.unlock()
+    assert exc_info.value.translation_key == "missing_passphrase"
+    assert exc_info.value.translation_placeholders == {"dataset": "tank/data"}
 
 
 async def test_dataset_unlock_already_unlocked_returns_early() -> None:
@@ -606,8 +627,15 @@ async def test_dataset_unlock_job_success_with_failed_entries_raises() -> None:
             "result": {"failed": {"tank/data": {"error": "bad passphrase"}}},
         },
     ]
-    with pytest.raises(HomeAssistantError, match="bad passphrase"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await sensor.unlock(passphrase="wrong")
+    assert exc_info.value.translation_key == "dataset_action_failed"
+    assert exc_info.value.translation_placeholders == {
+        "action": "unlock",
+        "dataset": "tank/data",
+        "host": sensor.coordinator.host,
+        "reason": "tank/data: bad passphrase",
+    }
 
 
 async def test_dataset_unlock_job_failed_state_raises() -> None:
@@ -616,15 +644,29 @@ async def test_dataset_unlock_job_failed_state_raises() -> None:
         42,
         {"state": "FAILED", "error": "disk error"},
     ]
-    with pytest.raises(HomeAssistantError, match="disk error"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await sensor.unlock(passphrase="secret")
+    assert exc_info.value.translation_key == "dataset_action_failed"
+    assert exc_info.value.translation_placeholders == {
+        "action": "unlock",
+        "dataset": "tank/data",
+        "host": sensor.coordinator.host,
+        "reason": "disk error",
+    }
 
 
 async def test_dataset_run_job_invalid_job_id_raises() -> None:
     sensor = _make_dataset({"encrypted": True, "locked": True})
     sensor.coordinator.api.query.return_value = None
-    with pytest.raises(HomeAssistantError, match="invalid job id"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await sensor.unlock(passphrase="secret")
+    assert exc_info.value.translation_key == "dataset_action_failed"
+    assert exc_info.value.translation_placeholders == {
+        "action": "unlock",
+        "dataset": "tank/data",
+        "host": sensor.coordinator.host,
+        "reason": "invalid job id",
+    }
 
 
 async def test_dataset_wait_for_job_missing_job_exhausts_retries() -> None:
@@ -632,9 +674,16 @@ async def test_dataset_wait_for_job_missing_job_exhausts_retries() -> None:
     sensor.coordinator.api.query.side_effect = [42, None, None, None, None, None]
     with (
         patch("custom_components.truenas_ce.sensor.asyncio.sleep", new=AsyncMock()),
-        pytest.raises(HomeAssistantError, match="not found"),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await sensor.unlock(passphrase="secret")
+    assert exc_info.value.translation_key == "dataset_action_failed"
+    assert exc_info.value.translation_placeholders == {
+        "action": "unlock",
+        "dataset": "tank/data",
+        "host": sensor.coordinator.host,
+        "reason": "job 42 not found",
+    }
 
 
 async def test_dataset_passphrase_set_stores_in_config_entry() -> None:
@@ -647,8 +696,9 @@ async def test_dataset_passphrase_set_stores_in_config_entry() -> None:
 async def test_dataset_passphrase_set_no_name_raises() -> None:
     sensor = _make_dataset({"name": None})
     sensor._data["name"] = None
-    with pytest.raises(ServiceValidationError, match="unknown"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await sensor.passphrase_set("secret")
+    assert exc_info.value.translation_key == "unknown_dataset_name"
 
 
 # ---------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -704,6 +704,7 @@ async def test_dataset_wait_for_job_timeout_raises() -> None:
         "host": sensor.coordinator.host,
         "reason": "timed out waiting for completion",
     }
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
 
 
 async def test_dataset_passphrase_set_stores_in_config_entry() -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -58,8 +58,13 @@ async def test_system_update_async_install_failure_raises() -> None:
     update = _make_system_update({})
     update.coordinator.api.query.return_value = None
     update.coordinator.api.error = "job rejected"
-    with pytest.raises(HomeAssistantError, match="job rejected"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await update.async_install(version=None, backup=False)
+    assert exc_info.value.translation_key == "system_update_failed"
+    assert exc_info.value.translation_placeholders == {
+        "host": update.coordinator.host,
+        "error": "job rejected",
+    }
 
 
 async def test_system_update_options_updated_is_noop() -> None:
@@ -131,5 +136,11 @@ async def test_app_update_async_install_failure_raises() -> None:
     update.coordinator.data["app"] = {"a1": {"state": "RUNNING"}}
     update.coordinator.api.query.return_value = None
     update.coordinator.api.error = "upgrade failed"
-    with pytest.raises(HomeAssistantError, match="upgrade failed"):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await update.async_install(version=None, backup=False)
+    assert exc_info.value.translation_key == "app_update_failed"
+    assert exc_info.value.translation_placeholders == {
+        "app": "a1",
+        "host": update.coordinator.host,
+        "error": "upgrade failed",
+    }


### PR DESCRIPTION
## Proposed change

Every `ServiceValidationError`/`HomeAssistantError` raised for a user-facing action failure now sets `translation_domain=DOMAIN` and a `translation_key` instead of a literal English message, with `translation_placeholders` carrying the dynamic parts (action, dataset, host, error, ...).

The English message templates live under a new top-level `exceptions` key in `strings.json` (mirrored in `translations/en.json`), with matching translated entries added to all other locale files (`de`, `es`, `pt_BR`, `ru`, `sk`) to keep translation parity.

Dataset actions (job failed/not-found/timeout/invalid-job-id/unlock-failure/snapshot-failure) share a single `TrueNASDatasetSensor._raise_dataset_action_failed` helper since they all report the same shape. The shared `_resolve_config_entry` in `__init__.py` now returns a `translation_key`/`translation_placeholders` pair alongside its existing plain-text `"error"` string (still used unchanged by the list-type service responses), so `_require_config_entry` can raise a translated exception without touching those non-exception response paths.

This implements the Gold quality-scale `exception-translations` rule (`quality_scale.yaml` updated to `status: done`). The remaining Gold rule is `icon-translations`; `manifest.json`'s `quality_scale` field stays `silver` until that is also complete.

## Type of change

- [ ] Bugfix
- [x] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Unit tests constructing entities directly (without a running `hass`) can't call `str()` on a `translation_key`-based exception (it needs `async_get_hass()`), so the affected tests now assert on `exc_info.value.translation_key` / `.translation_placeholders` directly instead of matching the stringified message.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce translated, domain-scoped error handling for user-facing TrueNAS CE exceptions and align tests and quality scale metadata accordingly.

New Features:
- Add translation-aware ServiceValidationError and HomeAssistantError raises with translation_key and translation_placeholders for user-facing failures across the TrueNAS CE integration.
- Define new localized exception message templates in strings.json and locale translation files for common failure scenarios (dataset actions, alerts, updates, configuration resolution).

Enhancements:
- Centralize dataset action error reporting via a shared TrueNASDatasetSensor helper that raises a uniform translated HomeAssistantError for job-related failures.
- Extend config entry resolution helpers to return both plain-text and translation metadata so services can raise translated exceptions while preserving existing list responses.
- Update entity, button, helper, coordinator, and update logic to use structured, translated errors instead of interpolated English strings.
- Mark the exception-translations quality-scale rule as completed in quality_scale.yaml.

Tests:
- Adjust existing tests to assert on exception translation_key and translation_placeholders instead of matching literal error strings, and add coverage for new translated error paths.