### PR TITLE
fix: disambiguate snapshot task sensor names via naming_schema suffix

### DIFF
--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
@@ -746,8 +747,37 @@ class TrueNASReplicationSensor(TrueNASSensor):
 # ---------------------------
 #   TrueNASSnapshotTaskSensor
 # ---------------------------
+_SNAPSHOT_SCHEMA_TOKEN_RE = re.compile(r"%[A-Za-z]")
+
+
 class TrueNASSnapshotTaskSensor(TrueNASSensor):
     """Define a TrueNAS periodic snapshot task sensor."""
+
+    @property
+    def name(self) -> str | None:
+        """Disambiguate same-dataset tasks using naming_schema's suffix.
+
+        Several snapshot tasks (hourly/daily/weekly, ...) commonly share one
+        dataset, so the dataset-only name collides and HA appends
+        non-deterministic _2/_3 to the generated entity id (issue #55). When
+        naming_schema carries literal text after its last strftime token
+        (e.g. "auto-%Y-%m-%d_%H-%M_daily" -> "daily"), append it. Tasks left
+        at the plain default schema keep today's dataset-only name, so
+        single-task-per-dataset setups aren't force-renamed.
+        """
+        base_name = super().name
+        suffix = self._naming_schema_suffix()
+        return f"{base_name} {suffix}" if base_name and suffix else base_name
+
+    def _naming_schema_suffix(self) -> str | None:
+        """Return the literal text trailing naming_schema's last %-token."""
+        schema = self._data.get("naming_schema") if self._data else None
+        if not isinstance(schema, str):
+            return None
+        matches = list(_SNAPSHOT_SCHEMA_TOKEN_RE.finditer(schema))
+        if not matches:
+            return None
+        return schema[matches[-1].end() :].strip("-_ ") or None
 
     async def start(self) -> None:
         """Run a periodic snapshot task on demand."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -455,6 +455,36 @@ async def test_snapshottask_start_runs_task() -> None:
     )
 
 
+_SNAPSHOTTASK_DESC = TrueNASSensorEntityDescription(
+    key="snapshottask",
+    name="",
+    data_path="snapshottask",
+    data_attribute="state",
+    data_name="dataset",
+)
+
+
+@pytest.mark.parametrize(
+    ("naming_schema", "expected_name"),
+    [
+        ("auto-%Y-%m-%d_%H-%M_daily", "tank/data daily"),
+        ("auto-%Y-%m-%d_%H-%M-weekly", "tank/data weekly"),
+        ("auto-%Y-%m-%d_%H-%M", "tank/data"),
+        ("unknown", "tank/data"),
+    ],
+)
+def test_snapshottask_name_uses_naming_schema_suffix(
+    naming_schema: str, expected_name: str
+) -> None:
+    sensor = _make_sensor(
+        TrueNASSnapshotTaskSensor,
+        {"id": 3, "dataset": "tank/data", "naming_schema": naming_schema},
+        path="snapshottask",
+        desc=_SNAPSHOTTASK_DESC,
+    )
+    assert sensor.name == expected_name
+
+
 # ---------------------------
 #   TrueNASCloudsyncSensor
 # ---------------------------


### PR DESCRIPTION
## Proposed change

Multiple periodic snapshot tasks configured on the same dataset (e.g. hourly/daily/weekly) previously all produced the same dataset-only sensor name, since `TrueNASSnapshotTaskSensor` only ever names itself after the dataset. Home Assistant then appended non-deterministic `_2`/`_3` suffixes to the generated entity id, so which physical task landed on which entity id could change across restarts.

`TrueNASSnapshotTaskSensor.name` now appends the literal text trailing `naming_schema`'s last strftime token when one is present (e.g. `auto-%Y-%m-%d_%H-%M_daily` -> `tank/data daily`), so same-dataset tasks get distinct, stable names. Tasks left at the plain default schema (no trailing literal) keep today's unchanged dataset-only name, so single-task-per-dataset setups are unaffected.

`unique_id` is derived from TrueNAS's task id and is untouched by this change — only the display name changes.

Fixes #55

Thanks @janusn for reporting and confirming the naming behaviour this fix relies on!

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Adds parametrized unit tests in `tests/test_sensor.py` covering suffix extraction (daily/weekly-style schemas) and the no-suffix default-schema case.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Disambiguate TrueNAS periodic snapshot task sensor names by incorporating naming schema suffixes for stable, distinct Home Assistant entities.

Bug Fixes:
- Ensure multiple snapshot tasks on the same dataset receive distinct, stable sensor names instead of colliding and getting non-deterministic suffixes in Home Assistant.

Tests:
- Add parametrized tests verifying snapshot task sensor names correctly include naming_schema suffixes and preserve the default name when no suffix is present.