### PR TITLE
fix: derive snapshot task name suffix from schedule as a fallback (#55)

### DIFF
--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -51,7 +51,7 @@ _LOGGER = getLogger(__name__)
 # Maximum number of characters of an API payload to include in debug logs.
 # Full payloads can be huge (e.g. pool.query with topology or app.query), so
 # they are summarized and truncated to keep debug logs readable.
-_LOG_PAYLOAD_LIMIT = 500
+_LOG_PAYLOAD_LIMIT = 5000
 
 # Set for the duration of a quiet connect() so the filter below can drop
 # aiotruenas's own "verify_ssl=False" warning for that call only. A plain

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -2324,6 +2324,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 {"name": "naming_schema", "default": "unknown"},
                 {"name": "allow_empty", "type": "bool", "default": False},
                 {"name": "vmware_sync", "type": "bool", "default": False},
+                {"name": "schedule", "default": {}},
                 {"name": "state", "source": "state/state", "default": "unknown"},
                 {
                     "name": "datetime",

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -766,8 +766,15 @@ def _is_pinned_schedule_field(value: Any) -> bool:
     """Return True if a cron schedule field is a single fixed number.
 
     TrueNAS's simple Hourly/Daily/Weekly/Monthly presets only ever pin a
-    field to one plain number.
+    field to one plain number. The API is expected to send these as
+    digit-only strings, but plain ints are accepted too in case a future
+    or unexpected response shape uses them (bools are excluded since
+    `isinstance(True, int)` is True in Python).
     """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
     return isinstance(value, str) and value.isdigit()
 
 
@@ -812,25 +819,31 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
 
         Derived from the task's cron `schedule` dict (minute/hour/dom/month/
         dow) using TrueNAS's known periodic-snapshot-task presets, which pin
-        exactly one of dom/dow/hour to a single fixed number, leave `month`
-        at "*", and leave the rest at "*" too. If any field is neither
-        wildcarded nor a single fixed number -- a step ("*/2"), range
-        ("1-5") or list ("1,15") -- or if `month` is pinned (which never
-        occurs in any of the four presets), the schedule doesn't match a
-        known preset at all, so it's left unclassified rather than guessed
-        at from whichever field happens to still look pinned. Otherwise the
-        presets are checked in dom -> dow -> hour order, so a schedule that
-        (contrary to any known preset) has both dom and dow pinned is
-        labeled Monthly. Tasks matching no preset keep the plain
-        dataset-only name rather than risk a misleading guess.
+        exactly one of dom/dow/hour to a single fixed number, pin `minute`
+        to a single fixed number too (the run time within that hour/day),
+        and leave `month` plus the remaining fields at "*". If any field is
+        neither wildcarded nor a single fixed number -- a step ("*/2" on
+        `minute` or `hour`), range ("1-5") or list ("1,15") -- or if `month`
+        is pinned (which never occurs in any of the four presets), the
+        schedule doesn't match a known preset at all, so it's left
+        unclassified rather than guessed at from whichever field happens to
+        still look pinned. `minute` itself never distinguishes between
+        presets (every preset pins it), so it's only used for this shape
+        check, not for the dom -> dow -> hour classification below, which
+        means a schedule that (contrary to any known preset) has both dom
+        and dow pinned is labeled Monthly. An empty `schedule` dict (no
+        fields at all) is rejected up front rather than falling through to
+        "every field is missing, so every field is wildcard" -> Hourly.
+        Tasks matching no preset keep the plain dataset-only name rather
+        than risk a misleading guess.
         """
         schedule = self._data.get("schedule") if self._data else None
-        if not isinstance(schedule, dict):
+        if not isinstance(schedule, dict) or not schedule:
             return None
-        dom, dow, hour, month = (
-            schedule.get(field) for field in ("dom", "dow", "hour", "month")
+        minute, dom, dow, hour, month = (
+            schedule.get(field) for field in ("minute", "dom", "dow", "hour", "month")
         )
-        fields = (dom, dow, hour, month)
+        fields = (minute, dom, dow, hour, month)
         if any(
             not (_is_pinned_schedule_field(f) or _is_wildcard_schedule_field(f))
             for f in fields
@@ -844,7 +857,7 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
             return _SCHEDULE_LABEL_WEEKLY
         if _is_pinned_schedule_field(hour):
             return _SCHEDULE_LABEL_DAILY
-        if hour == "*":
+        if _is_wildcard_schedule_field(hour):
             return _SCHEDULE_LABEL_HOURLY
         return None
 

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -762,6 +762,15 @@ _SCHEDULE_LABEL_WEEKLY = "Weekly"
 _SCHEDULE_LABEL_MONTHLY = "Monthly"
 
 
+def _is_pinned_schedule_field(value: Any) -> bool:
+    """Return True if a cron schedule field is a fixed, non-wildcard value.
+
+    "*" means "every unit" and "*/2" etc. means "every Nth unit" -- neither
+    pins the field to a specific value, so both are treated as unset.
+    """
+    return isinstance(value, str) and "*" not in value
+
+
 class TrueNASSnapshotTaskSensor(TrueNASSensor):
     """Define a TrueNAS periodic snapshot task sensor."""
 
@@ -797,17 +806,24 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
         """Return a best-effort Hourly/Daily/Weekly/Monthly label.
 
         Derived from the task's cron `schedule` dict (minute/hour/dom/month/
-        dow) using TrueNAS's known periodic-snapshot-task presets.
+        dow) using TrueNAS's known periodic-snapshot-task presets, which pin
+        exactly one of dom/dow/hour to a fixed value and leave the rest at
+        "*". The presets are checked in dom -> dow -> hour order, so a
+        schedule that (contrary to any known preset) has both dom and dow
+        pinned is labeled Monthly. A schedule matching no preset at all --
+        e.g. a custom "every 2 hours" (`hour: "*/2"`) schedule, which is
+        wildcarded but not the literal "*" -- yields no label, leaving the
+        plain dataset-only name rather than a misleading guess.
         """
         schedule = self._data.get("schedule") if self._data else None
         if not isinstance(schedule, dict):
             return None
         dom, dow, hour = (schedule.get(field) for field in ("dom", "dow", "hour"))
-        if dom not in ("*", None):
+        if _is_pinned_schedule_field(dom):
             return _SCHEDULE_LABEL_MONTHLY
-        if dow not in ("*", None):
+        if _is_pinned_schedule_field(dow):
             return _SCHEDULE_LABEL_WEEKLY
-        if hour not in ("*", None):
+        if _is_pinned_schedule_field(hour):
             return _SCHEDULE_LABEL_DAILY
         if hour == "*":
             return _SCHEDULE_LABEL_HOURLY

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -761,6 +761,11 @@ _SCHEDULE_LABEL_DAILY = "Daily"
 _SCHEDULE_LABEL_WEEKLY = "Weekly"
 _SCHEDULE_LABEL_MONTHLY = "Monthly"
 
+# The cron fields read off a snapshot task's `schedule` dict, centralised
+# here so the field names are typed once rather than repeated at each call
+# site that inspects the dict.
+_SCHEDULE_FIELDS = ("minute", "dom", "dow", "hour", "month")
+
 
 def _is_pinned_schedule_field(value: Any) -> bool:
     """Return True if a cron schedule field is a single fixed number.
@@ -833,7 +838,11 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
         means a schedule that (contrary to any known preset) has both dom
         and dow pinned is labeled Monthly. An empty `schedule` dict (no
         fields at all) is rejected up front rather than falling through to
-        "every field is missing, so every field is wildcard" -> Hourly.
+        "every field is missing, so every field is wildcard" -> Hourly, and
+        a fully wildcard schedule (minute included) is likewise left
+        unclassified rather than labeled Hourly, since a genuine Hourly
+        preset always pins `minute` to the run time within the hour --
+        minute *also* being "*" would mean "every minute", not hourly.
         Tasks matching no preset keep the plain dataset-only name rather
         than risk a misleading guess.
         """
@@ -841,7 +850,7 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
         if not isinstance(schedule, dict) or not schedule:
             return None
         minute, dom, dow, hour, month = (
-            schedule.get(field) for field in ("minute", "dom", "dow", "hour", "month")
+            schedule.get(field) for field in _SCHEDULE_FIELDS
         )
         fields = (minute, dom, dow, hour, month)
         if any(
@@ -857,7 +866,12 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
             return _SCHEDULE_LABEL_WEEKLY
         if _is_pinned_schedule_field(hour):
             return _SCHEDULE_LABEL_DAILY
-        if _is_wildcard_schedule_field(hour):
+        # The `any(...)` guard above guarantees every field is pinned or
+        # wildcard, and hour didn't match the pinned branch above, so hour
+        # is wildcard here -- no need to re-check it. Hourly still requires
+        # `minute` to be pinned; see the docstring note on fully wildcard
+        # schedules above.
+        if _is_pinned_schedule_field(minute):
             return _SCHEDULE_LABEL_HOURLY
         return None
 

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -749,24 +749,38 @@ class TrueNASReplicationSensor(TrueNASSensor):
 # ---------------------------
 _SNAPSHOT_SCHEMA_TOKEN_RE = re.compile(r"%[A-Za-z]")
 
+# Best-effort cadence labels guessed from TrueNAS's cron `schedule` field,
+# matching its known periodic-snapshot-task presets (dom set -> monthly, dow
+# set -> weekly, hour set -> daily, else hourly). This is unverified against
+# real daily/weekly/monthly schedules (issue #55) -- HA debug logs of
+# pool.snapshottask.query were truncated when this was written, so only an
+# hourly example was available. Only used as a fallback when naming_schema
+# carries no literal suffix of its own.
+_SCHEDULE_LABEL_HOURLY = "Hourly"
+_SCHEDULE_LABEL_DAILY = "Daily"
+_SCHEDULE_LABEL_WEEKLY = "Weekly"
+_SCHEDULE_LABEL_MONTHLY = "Monthly"
+
 
 class TrueNASSnapshotTaskSensor(TrueNASSensor):
     """Define a TrueNAS periodic snapshot task sensor."""
 
     @property
     def name(self) -> str | None:
-        """Disambiguate same-dataset tasks using naming_schema's suffix.
+        """Disambiguate same-dataset tasks via naming_schema or schedule.
 
         Several snapshot tasks (hourly/daily/weekly, ...) commonly share one
         dataset, so the dataset-only name collides and HA appends
         non-deterministic _2/_3 to the generated entity id (issue #55). When
         naming_schema carries literal text after its last strftime token
-        (e.g. "auto-%Y-%m-%d_%H-%M_daily" -> "daily"), append it. Tasks left
-        at the plain default schema keep today's dataset-only name, so
-        single-task-per-dataset setups aren't force-renamed.
+        (e.g. "auto-%Y-%m-%d_%H-%M_daily" -> "daily"), append it. Otherwise
+        fall back to a cadence label guessed from the task's cron `schedule`
+        (see _schedule_suffix). Tasks matching neither keep today's
+        dataset-only name, so single-task-per-dataset setups aren't
+        force-renamed.
         """
         base_name = super().name
-        suffix = self._naming_schema_suffix()
+        suffix = self._naming_schema_suffix() or self._schedule_suffix()
         return f"{base_name} {suffix}" if base_name and suffix else base_name
 
     def _naming_schema_suffix(self) -> str | None:
@@ -778,6 +792,26 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
         if not matches:
             return None
         return schema[matches[-1].end() :].strip("-_ ") or None
+
+    def _schedule_suffix(self) -> str | None:
+        """Return a best-effort Hourly/Daily/Weekly/Monthly label.
+
+        Derived from the task's cron `schedule` dict (minute/hour/dom/month/
+        dow) using TrueNAS's known periodic-snapshot-task presets.
+        """
+        schedule = self._data.get("schedule") if self._data else None
+        if not isinstance(schedule, dict):
+            return None
+        dom, dow, hour = (schedule.get(field) for field in ("dom", "dow", "hour"))
+        if dom not in ("*", None):
+            return _SCHEDULE_LABEL_MONTHLY
+        if dow not in ("*", None):
+            return _SCHEDULE_LABEL_WEEKLY
+        if hour not in ("*", None):
+            return _SCHEDULE_LABEL_DAILY
+        if hour == "*":
+            return _SCHEDULE_LABEL_HOURLY
+        return None
 
     async def start(self) -> None:
         """Run a periodic snapshot task on demand."""

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -763,12 +763,17 @@ _SCHEDULE_LABEL_MONTHLY = "Monthly"
 
 
 def _is_pinned_schedule_field(value: Any) -> bool:
-    """Return True if a cron schedule field is a fixed, non-wildcard value.
+    """Return True if a cron schedule field is a single fixed number.
 
-    "*" means "every unit" and "*/2" etc. means "every Nth unit" -- neither
-    pins the field to a specific value, so both are treated as unset.
+    TrueNAS's simple Hourly/Daily/Weekly/Monthly presets only ever pin a
+    field to one plain number.
     """
-    return isinstance(value, str) and "*" not in value
+    return isinstance(value, str) and value.isdigit()
+
+
+def _is_wildcard_schedule_field(value: Any) -> bool:
+    """Return True if a cron schedule field is unset ("*" or absent)."""
+    return value in ("*", None)
 
 
 class TrueNASSnapshotTaskSensor(TrueNASSensor):
@@ -807,18 +812,32 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
 
         Derived from the task's cron `schedule` dict (minute/hour/dom/month/
         dow) using TrueNAS's known periodic-snapshot-task presets, which pin
-        exactly one of dom/dow/hour to a fixed value and leave the rest at
-        "*". The presets are checked in dom -> dow -> hour order, so a
-        schedule that (contrary to any known preset) has both dom and dow
-        pinned is labeled Monthly. A schedule matching no preset at all --
-        e.g. a custom "every 2 hours" (`hour: "*/2"`) schedule, which is
-        wildcarded but not the literal "*" -- yields no label, leaving the
-        plain dataset-only name rather than a misleading guess.
+        exactly one of dom/dow/hour to a single fixed number, leave `month`
+        at "*", and leave the rest at "*" too. If any field is neither
+        wildcarded nor a single fixed number -- a step ("*/2"), range
+        ("1-5") or list ("1,15") -- or if `month` is pinned (which never
+        occurs in any of the four presets), the schedule doesn't match a
+        known preset at all, so it's left unclassified rather than guessed
+        at from whichever field happens to still look pinned. Otherwise the
+        presets are checked in dom -> dow -> hour order, so a schedule that
+        (contrary to any known preset) has both dom and dow pinned is
+        labeled Monthly. Tasks matching no preset keep the plain
+        dataset-only name rather than risk a misleading guess.
         """
         schedule = self._data.get("schedule") if self._data else None
         if not isinstance(schedule, dict):
             return None
-        dom, dow, hour = (schedule.get(field) for field in ("dom", "dow", "hour"))
+        dom, dow, hour, month = (
+            schedule.get(field) for field in ("dom", "dow", "hour", "month")
+        )
+        fields = (dom, dow, hour, month)
+        if any(
+            not (_is_pinned_schedule_field(f) or _is_wildcard_schedule_field(f))
+            for f in fields
+        ):
+            return None
+        if _is_pinned_schedule_field(month):
+            return None
         if _is_pinned_schedule_field(dom):
             return _SCHEDULE_LABEL_MONTHLY
         if _is_pinned_schedule_field(dow):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3050,9 +3050,13 @@ async def test_get_snapshottask_parses_when_monitored() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_SNAPSHOTS]}
     coord.api = MagicMock()
-    coord.api.query = AsyncMock(return_value=[{"id": 1, "dataset": "tank/data"}])
+    schedule = {"minute": "0", "hour": "*", "dom": "*", "month": "*", "dow": "*"}
+    coord.api.query = AsyncMock(
+        return_value=[{"id": 1, "dataset": "tank/data", "schedule": schedule}]
+    )
     await coord.get_snapshottask()
     assert 1 in coord.ds["snapshottask"]
+    assert coord.ds["snapshottask"][1]["schedule"] == schedule
 
 
 async def test_get_scrub_parses_response() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3059,6 +3059,17 @@ async def test_get_snapshottask_parses_when_monitored() -> None:
     assert coord.ds["snapshottask"][1]["schedule"] == schedule
 
 
+async def test_get_snapshottask_defaults_schedule_when_missing() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"snapshottask": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_SNAPSHOTS]}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": 1, "dataset": "tank/data"}])
+    await coord.get_snapshottask()
+    assert coord.ds["snapshottask"][1]["schedule"] == {}
+
+
 async def test_get_scrub_parses_response() -> None:
     coord = _bare_coordinator()
     coord.ds = {"scrub": {}}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -516,6 +516,23 @@ def test_snapshottask_name_uses_naming_schema_suffix(
             {"minute": "0", "hour": "*/2", "dom": "*", "month": "*", "dow": "*"},
             "tank/data",
         ),
+        (
+            # A weekday range isn't a single fixed value -> not treated as
+            # a pinned dow, so no suffix.
+            {"minute": "0", "hour": "0", "dom": "*", "month": "*", "dow": "1-5"},
+            "tank/data",
+        ),
+        (
+            # A day-of-month list isn't a single fixed value either.
+            {"minute": "0", "hour": "0", "dom": "1,15", "month": "*", "dow": "*"},
+            "tank/data",
+        ),
+        (
+            # A pinned month never occurs in any of the four presets, so the
+            # whole schedule is left unclassified even though dom is pinned.
+            {"minute": "0", "hour": "0", "dom": "1", "month": "1", "dow": "*"},
+            "tank/data",
+        ),
         ({}, "tank/data"),
         ("not-a-dict", "tank/data"),
     ],

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -552,6 +552,13 @@ def test_snapshottask_name_uses_naming_schema_suffix(
             {"minute": "0", "hour": None, "dom": "*", "month": "*", "dow": "*"},
             "tank/data Hourly",
         ),
+        (
+            # A fully wildcard schedule (minute included) means "every
+            # minute", not hourly -- Hourly requires minute to be pinned to
+            # the run time within the hour, so this stays unclassified.
+            {"minute": "*", "hour": "*", "dom": "*", "month": "*", "dow": "*"},
+            "tank/data",
+        ),
         ({}, "tank/data"),
         ("not-a-dict", "tank/data"),
     ],

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -485,6 +485,67 @@ def test_snapshottask_name_uses_naming_schema_suffix(
     assert sensor.name == expected_name
 
 
+@pytest.mark.parametrize(
+    ("schedule", "expected_name"),
+    [
+        (
+            {"minute": "0", "hour": "*", "dom": "*", "month": "*", "dow": "*"},
+            "tank/data Hourly",
+        ),
+        (
+            {"minute": "0", "hour": "0", "dom": "*", "month": "*", "dow": "*"},
+            "tank/data Daily",
+        ),
+        (
+            {"minute": "0", "hour": "0", "dom": "*", "month": "*", "dow": "1"},
+            "tank/data Weekly",
+        ),
+        (
+            {"minute": "0", "hour": "0", "dom": "1", "month": "*", "dow": "*"},
+            "tank/data Monthly",
+        ),
+        ({}, "tank/data"),
+        ("not-a-dict", "tank/data"),
+    ],
+)
+def test_snapshottask_name_falls_back_to_schedule(
+    schedule: dict | str, expected_name: str
+) -> None:
+    sensor = _make_sensor(
+        TrueNASSnapshotTaskSensor,
+        {
+            "id": 3,
+            "dataset": "tank/data",
+            "naming_schema": "auto-%Y-%m-%d_%H-%M",
+            "schedule": schedule,
+        },
+        path="snapshottask",
+        desc=_SNAPSHOTTASK_DESC,
+    )
+    assert sensor.name == expected_name
+
+
+def test_snapshottask_name_naming_schema_suffix_wins_over_schedule() -> None:
+    sensor = _make_sensor(
+        TrueNASSnapshotTaskSensor,
+        {
+            "id": 3,
+            "dataset": "tank/data",
+            "naming_schema": "auto-%Y-%m-%d_%H-%M_daily",
+            "schedule": {
+                "minute": "0",
+                "hour": "*",
+                "dom": "*",
+                "month": "*",
+                "dow": "*",
+            },
+        },
+        path="snapshottask",
+        desc=_SNAPSHOTTASK_DESC,
+    )
+    assert sensor.name == "tank/data daily"
+
+
 # ---------------------------
 #   TrueNASCloudsyncSensor
 # ---------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -533,6 +533,25 @@ def test_snapshottask_name_uses_naming_schema_suffix(
             {"minute": "0", "hour": "0", "dom": "1", "month": "1", "dow": "*"},
             "tank/data",
         ),
+        (
+            # A step on `minute` ("every 5 minutes") isn't a single fixed
+            # value either, even though hour/dom/dow/month otherwise look
+            # like the Hourly preset -> no suffix.
+            {"minute": "*/5", "hour": "*", "dom": "*", "month": "*", "dow": "*"},
+            "tank/data",
+        ),
+        (
+            # Plain ints are accepted as pinned values too, not just
+            # digit-only strings.
+            {"minute": 0, "hour": 0, "dom": "*", "month": "*", "dow": "*"},
+            "tank/data Daily",
+        ),
+        (
+            # A missing `hour` key (None) is treated as wildcard, same as
+            # an explicit "*".
+            {"minute": "0", "hour": None, "dom": "*", "month": "*", "dow": "*"},
+            "tank/data Hourly",
+        ),
         ({}, "tank/data"),
         ("not-a-dict", "tank/data"),
     ],

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -504,6 +504,18 @@ def test_snapshottask_name_uses_naming_schema_suffix(
             {"minute": "0", "hour": "0", "dom": "1", "month": "*", "dow": "*"},
             "tank/data Monthly",
         ),
+        (
+            # Contrary to any known TrueNAS preset (both dom and dow pinned);
+            # dom is checked first, so this resolves to Monthly.
+            {"minute": "0", "hour": "0", "dom": "1", "month": "*", "dow": "1"},
+            "tank/data Monthly",
+        ),
+        (
+            # No known preset matches (custom "every 2 hours" schedule) ->
+            # no suffix, plain dataset-only name.
+            {"minute": "0", "hour": "*/2", "dom": "*", "month": "*", "dow": "*"},
+            "tank/data",
+        ),
         ({}, "tank/data"),
         ("not-a-dict", "tank/data"),
     ],


### PR DESCRIPTION
## Proposed change
Follow-up to #59 for issue #55. Users with several same-dataset snapshot tasks that all still use the plain default `naming_schema` (no literal suffix) still get colliding names, since the previous fix only disambiguates when `naming_schema` carries custom literal text.

This adds a fallback: parse the task's cron `schedule` field (now captured by `get_snapshottask`) and, when `naming_schema` gives no suffix, guess a `Hourly`/`Daily`/`Weekly`/`Monthly` label from it, matching TrueNAS's known periodic-snapshot-task schedule presets (`dom` set → Monthly, `dow` set → Weekly, `hour` set → Daily, else Hourly). `naming_schema`'s literal suffix still wins when present.

Also bumps `_LOG_PAYLOAD_LIMIT` (500 → 5000 chars) so debug-log captures of `pool.snapshottask.query` aren't truncated after the first list entry — that's what limited us to a single confirmed example (Hourly) from the reporter's data.

**Caveat:** the Daily/Weekly/Monthly branches are a best-effort guess based on TrueNAS's known presets, not yet confirmed against real non-hourly schedule data (see the reporter's debug log, which was truncated before this fix). Shipping as a prerelease for confirmation before it goes stable.

Closes #55 (pending reporter confirmation).

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Follow-up to #59 (v2.6.0-rc1). Will ship as v2.6.0-rc2 for @janusn to verify before stable v2.6.0.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve TrueNAS snapshot task sensor naming to avoid collisions by deriving a cadence suffix from either the naming schema or the task schedule, and ensure schedule data is captured and logged sufficiently for debugging.

Bug Fixes:
- Avoid entity name collisions for same-dataset snapshot tasks that use the default naming_schema by falling back to an Hourly/Daily/Weekly/Monthly suffix inferred from the task schedule.
- Ensure snapshot task schedule data is stored by the coordinator, defaulting to an empty dict when missing, so sensors can reliably derive names.

Enhancements:
- Add robust schedule classification logic that only labels tasks when their cron schedule matches known TrueNAS presets, avoiding misleading cadence guesses.
- Increase API payload debug log limit to capture more of large responses such as pool.snapshottask.query for better diagnostics.

Tests:
- Extend snapshot task sensor tests to cover schedule-based naming, precedence of naming_schema suffix over schedule, and various cron schedule edge cases.
- Update coordinator tests to verify that snapshot task schedules are parsed and defaulted correctly.