### PR TITLE
chore: bump version to 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,14 +325,11 @@ target:
 [![Open your Home Assistant instance and open this repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=kayl-codes&repository=homeassistant-truenas&category=integration)
 
 1. Click the **My Home Assistant** button above — it opens HACS on your own instance directly on this
-   repository. (Manual alternative: open **HACS → 3-dot menu → Custom repositories**, add
-   `https://github.com/kayl-codes/homeassistant-truenas` with **Category: Integration**.)
+   repository. (TrueNAS CE is part of the official HACS default store, so you can also just open
+   **HACS → search for "TrueNAS CE"** instead.)
 2. Click **Download** to install the integration.
 3. Restart Home Assistant (full restart, not quick reload).
 4. Navigate to **Settings → Devices & services → Add Integration** and search for **TrueNAS CE**.
-
-> Once the integration is accepted into the HACS default store you can also just search for
-> **TrueNAS CE** directly in HACS — until then, use the button or the custom-repository steps above.
 
 
 Minimum requirements:

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,7 +15,7 @@
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"
     ],
-    "version": "2.5.2",
+    "version": "2.6.0",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change
Version bump to 2.6.0 and README update documenting HACS default-store availability, packaging up the changes accumulated since v2.5.2 (Gold quality scale, snapshot-task naming fix for #55) for a stable release.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information
No functional code changes in this PR itself — bundles a version bump (`manifest.json`) with a README documentation update now that TrueNAS CE is listed in the official HACS default store.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Prepare the 2.6.0 release by updating the integration version and refreshing README installation guidance for its inclusion in the HACS default store.

Enhancements:
- Bump the integration version metadata from 2.5.2 to 2.6.0 for a new stable release.

Documentation:
- Update README installation instructions to reflect TrueNAS CE’s availability in the official HACS default store and remove outdated custom-repository guidance.