### PR TITLE
fix: key certificates by name instead of id to prevent orphaned statistics

### DIFF
--- a/custom_components/truenas_ce/binary_sensor_types.py
+++ b/custom_components/truenas_ce/binary_sensor_types.py
@@ -242,7 +242,7 @@ SENSOR_TYPES: tuple[TrueNASBinarySensorEntityDescription, ...] = (
         data_is_on="expired",
         data_name="name",
         data_uid=None,
-        data_reference="id",
+        data_reference="name",
     ),
 )
 

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -2099,12 +2099,19 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     #   get_certificates
     # ---------------------------
     async def get_certificates(self) -> None:
-        """Get TrueNAS certificates."""
+        """Get TrueNAS certificates.
+
+        Keyed by ``name`` (DB-unique in TrueNAS) rather than the raw ``id``:
+        replacing a certificate's content (e.g. a manual renewal/reissue, as
+        opposed to TrueNAS's own in-place scheduled auto-renewal) deletes the
+        old database row and creates a new one with a fresh ``id`` but the
+        same ``name``, which otherwise made the sensor look orphaned (#61).
+        """
         certificates = await self.api.query("certificate.query")
         self.ds["certificate"] = parse_api(
             data={},
             source=certificates,
-            key="id",
+            key="name",
             vals=_CERTIFICATE_VALS,
         )
         now = dt_util.utcnow()

--- a/custom_components/truenas_ce/sensor_types.py
+++ b/custom_components/truenas_ce/sensor_types.py
@@ -790,7 +790,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         data_attribute="days_until_expiry",
         data_name="name",
         data_uid=None,
-        data_reference="id",
+        data_reference="name",
         func="TrueNASCertExpirySensor",
     ),
     TrueNASSensorEntityDescription(
@@ -805,7 +805,7 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         data_attribute="until",
         data_name="name",
         data_uid=None,
-        data_reference="id",
+        data_reference="name",
     ),
     TrueNASSensorEntityDescription(
         key="arc_data_hit_percent",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2844,7 +2844,7 @@ async def test_get_certificates_computes_days_until_expiry() -> None:
         ]
     )
     await coord.get_certificates()
-    assert coord.ds["certificate"][1]["days_until_expiry"] in (9, 10)
+    assert coord.ds["certificate"]["cert1"]["days_until_expiry"] in (9, 10)
 
 
 async def test_get_certificates_none_expiry_when_until_missing() -> None:
@@ -2853,7 +2853,7 @@ async def test_get_certificates_none_expiry_when_until_missing() -> None:
     coord.api = MagicMock()
     coord.api.query = AsyncMock(return_value=[{"id": 1, "name": "cert1"}])
     await coord.get_certificates()
-    assert coord.ds["certificate"][1]["days_until_expiry"] is None
+    assert coord.ds["certificate"]["cert1"]["days_until_expiry"] is None
 
 
 # ---------------------------


### PR DESCRIPTION
## Proposed change
Fixes #61. TrueNAS's own scheduled certificate auto-renewal updates a
certificate's database row in place (same `id`), but replacing a
certificate's actual content — a manual renew/reissue, as opposed to
that passive scheduled renewal — goes through delete+create instead,
since TrueNAS's `do_update()` doesn't support content changes and
`cert_name` is DB-unique. That yields a new `id` while `name` stays
stable, which made the `certificate_expiry` / `certificate_expiration_time`
/ `certificate_expired` entities' `unique_id` churn on every such update,
so the recorder's orphaned-statistics repair flagged the old id's stats
as orphaned right after a routine cert update.

This PR keys the coordinator's certificate dict (`parse_api(key=...)`)
and the `data_reference` of all three certificate entity descriptions by
`name` instead of `id` — the same stable-identifier pattern already used
for disks (`identifier` instead of the volatile `devname`).

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Planned to ship as a prerelease (RC) first so the issue reporter can
validate against their setup before promoting to stable, mirroring the
RC workflow used for #55.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Key certificate-related data by stable certificate name instead of volatile database ID to avoid orphaned statistics after manual certificate renewals.

Bug Fixes:
- Prevent certificate expiry and expiration sensors from being treated as orphaned when TrueNAS recreates certificates with new IDs.
- Align coordinator and sensor entity references to use certificate names as the unique identifier for statistics and state tracking.

Tests:
- Update coordinator tests to assert certificate data is stored and accessed by name keys rather than numeric IDs.