### PR TITLE
fix: scope orphaned-statistics detection to each entry's device slug (#61)

### DIFF
--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -337,9 +337,10 @@ def _is_truenas_sensor_id(statistic_id: str, device_slug: str) -> bool:
     every *other* entry's orphaned statistics too, since all of them contain
     the same "truenas" substring -- producing one duplicate Repairs issue per
     config entry for the same global orphan list on multi-entry installs
-    (#61).
+    (#61). An empty ``device_slug`` (e.g. a blank device name) is rejected
+    outright, since an empty string would otherwise match every id.
     """
-    if not statistic_id.startswith("sensor."):
+    if not device_slug or not statistic_id.startswith("sensor."):
         return False
     return device_slug in statistic_id[len("sensor.") :]
 
@@ -412,6 +413,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self.name = config_entry.data[CONF_NAME]
         self.host = config_entry.data[CONF_HOST]
+        # Computed once: a config-entry rename goes through a full entry
+        # reload (new coordinator instance), so this never goes stale.
+        self._device_slug = slugify(self.name)
 
         self.ds: dict[str, dict[str, Any]] = {
             "interface": {},
@@ -670,7 +674,6 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         ent_reg = er.async_get(self.hass)
         previous = self.orphaned_statistics
-        device_slug = slugify(self.config_entry.data[CONF_NAME])
         # Sorted once here so log output, the repair dialog and the change check
         # below all share one order: ``list_statistic_ids`` makes no ordering
         # promise, so an unsorted list could "change" without any orphan doing so.
@@ -680,7 +683,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if isinstance(meta, dict)
             and meta.get("source") == "recorder"
             and isinstance(meta.get("statistic_id"), str)
-            and _is_truenas_sensor_id(meta["statistic_id"], device_slug)
+            and _is_truenas_sensor_id(meta["statistic_id"], self._device_slug)
             and ent_reg.async_get(meta["statistic_id"]) is None
         )
         # Logged only on change: detection runs every poll, and the full id list

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -37,7 +37,6 @@ from .const import (
     CONF_MONITORED_GROUPS,
     CONF_POLL_INTERVAL,
     CONF_STATISTICS_CLEANUP_IGNORED,
-    DEFAULT_DEVICE_NAME,
     DEFAULT_MONITORED_GROUPS,
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
@@ -320,34 +319,29 @@ def _first_ipv4(aliases: Any) -> str:
     return "unknown"
 
 
-# Computed once at import time: _is_truenas_sensor_id runs for every recorder
-# statistic id during each statistics-cleanup pass.
-_DEVICE_NAME_SLUG = slugify(DEFAULT_DEVICE_NAME)
-
-
-def _is_truenas_sensor_id(statistic_id: str) -> bool:
-    """Return True if a recorder statistic_id looks like a TrueNAS sensor.
+def _is_truenas_sensor_id(statistic_id: str, device_slug: str) -> bool:
+    """Return True if a recorder statistic_id looks like *this entry's* sensor.
 
     Entity ids vary across versions and instance names (``sensor.truenas_...``,
     ``sensor.system_truenas_...`` and custom names whose slug merges the domain
     into a longer token, e.g. ``sensor.truenasviacfnoauth_...``). Match the
-    device-name slug as a substring of any underscore-separated token rather
-    than as an exact token or fixed prefix, so every orphaned variant is caught.
+    per-entry device-name slug as a substring of the id's remainder after
+    ``sensor.`` rather than as an exact token or fixed prefix, so every
+    orphaned variant is caught.
 
-    Deliberately matches against ``slugify(DEFAULT_DEVICE_NAME)`` ("truenas"),
-    not ``DOMAIN`` ("truenas_ce"): entity ids are slugged from the device name,
-    never from the integration domain, and ``DOMAIN`` itself contains an
-    underscore so it can never appear whole inside an underscore-split token
-    (this silently broke orphan detection from the 2.0.0 CE rename until found
-    while adding this module's test suite). Tying the match to the device name
-    instead of ``LEGACY_DOMAIN`` means this keeps working unchanged even if the
-    legacy-migration code/domain is ever removed (e.g. a future HA Core
-    submission dropping the "_ce" suffix).
+    ``device_slug`` must be ``slugify(config_entry.data[CONF_NAME])`` for the
+    entry doing the detection, not a fixed constant: entity ids are slugged
+    from the *device* name, which is user-chosen per entry (e.g. "TrueNAS
+    nuc13" vs "TrueNAS x11dpu" to tell multiple instances apart). Matching a
+    single global slug instead used to make every entry's coordinator flag
+    every *other* entry's orphaned statistics too, since all of them contain
+    the same "truenas" substring -- producing one duplicate Repairs issue per
+    config entry for the same global orphan list on multi-entry installs
+    (#61).
     """
     if not statistic_id.startswith("sensor."):
         return False
-    tokens = statistic_id[len("sensor.") :].split("_")
-    return any(_DEVICE_NAME_SLUG in token for token in tokens)
+    return device_slug in statistic_id[len("sensor.") :]
 
 
 def _count_statistics_with_data(hass: HomeAssistant, statistic_ids: list[str]) -> int:
@@ -646,12 +640,16 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return f"{ISSUE_STATISTICS_ORPHANED}_{self.config_entry.entry_id}"
 
     async def async_detect_orphaned_statistics(self) -> None:
-        """Find recorder statistic_ids of this integration with no live entity.
+        """Find recorder statistic_ids of this config entry with no live entity.
 
         After an entity-id rename the recorder can leave the old long-term
         statistics behind when the target name already exists. We list the
-        recorder-sourced statistics with this integration's prefix and keep those
-        whose entity is no longer in the registry.
+        recorder-sourced statistics matching this entry's device-name slug and
+        keep those whose entity is no longer in the registry. Scoping by this
+        entry's own slug (not a fixed integration-wide one) matters on
+        multi-entry installs: without it, every entry's coordinator would flag
+        every other entry's orphans too, each raising its own duplicate
+        Repairs issue for the same statistics (#61).
 
         Older leftovers are often *metadata-only* (their data points were purged
         long ago), which is why they can be reported here without being visible
@@ -672,6 +670,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         ent_reg = er.async_get(self.hass)
         previous = self.orphaned_statistics
+        device_slug = slugify(self.config_entry.data[CONF_NAME])
         # Sorted once here so log output, the repair dialog and the change check
         # below all share one order: ``list_statistic_ids`` makes no ordering
         # promise, so an unsorted list could "change" without any orphan doing so.
@@ -681,7 +680,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if isinstance(meta, dict)
             and meta.get("source") == "recorder"
             and isinstance(meta.get("statistic_id"), str)
-            and _is_truenas_sensor_id(meta["statistic_id"])
+            and _is_truenas_sensor_id(meta["statistic_id"], device_slug)
             and ent_reg.async_get(meta["statistic_id"]) is None
         )
         # Logged only on change: detection runs every poll, and the full id list

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,7 +18,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.const import CONF_NAME
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import slugify
 
@@ -269,6 +268,11 @@ def test_is_truenas_sensor_id_scoped_to_this_entrys_device_slug() -> None:
         _is_truenas_sensor_id("sensor.truenas_x11dpu_cpu_usage", "truenas_nuc13")
         is False
     )
+
+
+def test_is_truenas_sensor_id_rejects_empty_device_slug() -> None:
+    """An empty slug (e.g. a blank device name) must never match every id."""
+    assert _is_truenas_sensor_id("sensor.truenas_nuc13_cpu_usage", "") is False
 
 
 # ---------------------------
@@ -1660,8 +1664,8 @@ async def test_async_detect_orphaned_statistics_filters_matching_ids() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.entry_id = "entry1"
     coord.config_entry.options = {}
-    coord.config_entry.data = {CONF_NAME: DEFAULT_DEVICE_NAME}
     slug = slugify(DEFAULT_DEVICE_NAME)
+    coord._device_slug = slug
     stat_ids = [
         {"statistic_id": f"sensor.{slug}_cpu_usage", "source": "recorder"},
         {"statistic_id": f"sensor.{slug}_arc_size", "source": "recorder"},
@@ -1703,7 +1707,7 @@ async def test_async_detect_orphaned_statistics_ignores_other_entrys_device() ->
     coord.config_entry = MagicMock()
     coord.config_entry.entry_id = "entry1"
     coord.config_entry.options = {}
-    coord.config_entry.data = {CONF_NAME: "TrueNAS nuc13"}
+    coord._device_slug = slugify("TrueNAS nuc13")
     stat_ids = [
         {
             "statistic_id": "sensor.truenas_nuc13_certificates_cert_time_until_expiry",
@@ -1744,8 +1748,8 @@ async def test_async_detect_orphaned_statistics_logs_ids_on_change(
     coord.config_entry = MagicMock()
     coord.config_entry.entry_id = "entry1"
     coord.config_entry.options = {}
-    coord.config_entry.data = {CONF_NAME: DEFAULT_DEVICE_NAME}
     slug = slugify(DEFAULT_DEVICE_NAME)
+    coord._device_slug = slug
     stat_ids = [{"statistic_id": f"sensor.{slug}_cpu_usage", "source": "recorder"}]
     ent_reg = MagicMock()
     ent_reg.async_get.return_value = None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.const import CONF_NAME
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import slugify
 
@@ -226,18 +227,19 @@ def test_first_ipv4_returns_unknown_when_no_inet() -> None:
 # ---------------------------
 def test_is_truenas_sensor_id_matches_device_slug_token() -> None:
     slug = slugify(DEFAULT_DEVICE_NAME)
-    assert _is_truenas_sensor_id(f"sensor.{slug}_cpu_usage") is True
-    assert _is_truenas_sensor_id(f"sensor.system_{slug}_uptime") is True
-    assert _is_truenas_sensor_id(f"sensor.{slug}viacfnoauth_cpu") is True
+    assert _is_truenas_sensor_id(f"sensor.{slug}_cpu_usage", slug) is True
+    assert _is_truenas_sensor_id(f"sensor.system_{slug}_uptime", slug) is True
+    assert _is_truenas_sensor_id(f"sensor.{slug}viacfnoauth_cpu", slug) is True
 
 
 def test_is_truenas_sensor_id_rejects_other_domains() -> None:
-    assert _is_truenas_sensor_id("sensor.unrelated_integration_temp") is False
+    slug = slugify(DEFAULT_DEVICE_NAME)
+    assert _is_truenas_sensor_id("sensor.unrelated_integration_temp", slug) is False
 
 
 def test_is_truenas_sensor_id_rejects_non_sensor_entities() -> None:
     slug = slugify(DEFAULT_DEVICE_NAME)
-    assert _is_truenas_sensor_id(f"binary_sensor.{slug}_online") is False
+    assert _is_truenas_sensor_id(f"binary_sensor.{slug}_online", slug) is False
 
 
 def test_is_truenas_sensor_id_unaffected_by_domain_changes(
@@ -246,14 +248,27 @@ def test_is_truenas_sensor_id_unaffected_by_domain_changes(
     """Regression: matching used to depend on DOMAIN/LEGACY_DOMAIN, which broke
     since the 2.0.0 CE rename because DOMAIN ("truenas_ce") contains an
     underscore and can never appear whole inside an underscore-split token.
-    The fix matches ``slugify(DEFAULT_DEVICE_NAME)`` instead -- the same
-    string real entity ids are slugged from -- so behavior no longer depends
-    on DOMAIN/LEGACY_DOMAIN at all, even if both constants are ever renamed or
+    The fix matches the device-name slug instead -- the same string real
+    entity ids are slugged from -- so behavior no longer depends on
+    DOMAIN/LEGACY_DOMAIN at all, even if both constants are ever renamed or
     removed (e.g. a future HA Core submission dropping the "_ce" suffix).
     """
     monkeypatch.setattr(coordinator_module, "DOMAIN", "something_else_entirely")
     monkeypatch.setattr(coordinator_module, "LEGACY_DOMAIN", "unrelated")
-    assert _is_truenas_sensor_id("sensor.truenas_cpu_usage") is True
+    assert _is_truenas_sensor_id("sensor.truenas_cpu_usage", "truenas") is True
+
+
+def test_is_truenas_sensor_id_scoped_to_this_entrys_device_slug() -> None:
+    """Regression (#61): a global slug match flagged every entry's orphans on
+    multi-entry installs. Each entry must only match its own device slug.
+    """
+    assert (
+        _is_truenas_sensor_id("sensor.truenas_nuc13_cpu_usage", "truenas_nuc13") is True
+    )
+    assert (
+        _is_truenas_sensor_id("sensor.truenas_x11dpu_cpu_usage", "truenas_nuc13")
+        is False
+    )
 
 
 # ---------------------------
@@ -1645,6 +1660,7 @@ async def test_async_detect_orphaned_statistics_filters_matching_ids() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.entry_id = "entry1"
     coord.config_entry.options = {}
+    coord.config_entry.data = {CONF_NAME: DEFAULT_DEVICE_NAME}
     slug = slugify(DEFAULT_DEVICE_NAME)
     stat_ids = [
         {"statistic_id": f"sensor.{slug}_cpu_usage", "source": "recorder"},
@@ -1674,6 +1690,50 @@ async def test_async_detect_orphaned_statistics_filters_matching_ids() -> None:
     create_mock.assert_called_once()
 
 
+async def test_async_detect_orphaned_statistics_ignores_other_entrys_device() -> None:
+    """Regression (#61): with two TrueNAS config entries, detection used to
+    match a fixed global slug, so each entry's coordinator flagged the *other*
+    entry's orphaned statistics too and both raised their own duplicate
+    Repairs issue for the same global list. Each entry must only see
+    statistics whose id matches its own device-name slug.
+    """
+    coord = _bare_coordinator()
+    coord.hass = MagicMock()
+    coord.hass.config.components = {"recorder"}
+    coord.config_entry = MagicMock()
+    coord.config_entry.entry_id = "entry1"
+    coord.config_entry.options = {}
+    coord.config_entry.data = {CONF_NAME: "TrueNAS nuc13"}
+    stat_ids = [
+        {
+            "statistic_id": "sensor.truenas_nuc13_certificates_cert_time_until_expiry",
+            "source": "recorder",
+        },
+        {
+            "statistic_id": "sensor.truenas_x11dpu_certificates_cert_time_until_expiry",
+            "source": "recorder",
+        },
+    ]
+    ent_reg = MagicMock()
+    ent_reg.async_get.return_value = None
+    with (
+        patch.object(
+            coordinator_module,
+            "get_instance",
+            return_value=MagicMock(
+                async_add_executor_job=AsyncMock(return_value=stat_ids)
+            ),
+        ),
+        patch.object(coordinator_module.er, "async_get", return_value=ent_reg),
+        patch.object(coordinator_module.ir, "async_create_issue"),
+    ):
+        await coord.async_detect_orphaned_statistics()
+
+    assert coord.orphaned_statistics == [
+        "sensor.truenas_nuc13_certificates_cert_time_until_expiry"
+    ]
+
+
 async def test_async_detect_orphaned_statistics_logs_ids_on_change(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1684,6 +1744,7 @@ async def test_async_detect_orphaned_statistics_logs_ids_on_change(
     coord.config_entry = MagicMock()
     coord.config_entry.entry_id = "entry1"
     coord.config_entry.options = {}
+    coord.config_entry.data = {CONF_NAME: DEFAULT_DEVICE_NAME}
     slug = slugify(DEFAULT_DEVICE_NAME)
     stat_ids = [{"statistic_id": f"sensor.{slug}_cpu_usage", "source": "recorder"}]
     ent_reg = MagicMock()


### PR DESCRIPTION
## Proposed change
Follow-up to #63. @janusn's multi-entry test of v2.6.1-rc1 (see #61) showed that updating a certificate on one TrueNAS config entry produced **two** duplicate "Orphaned TrueNAS statistics" Repairs issues, even though only one device changed.

Root cause: `_is_truenas_sensor_id` matched a fixed, integration-wide slug (`slugify(DEFAULT_DEVICE_NAME)`, i.e. `"truenas"`). On a multi-entry install, every entry's coordinator scans the *entire* recorder statistics table, so every entry's device-name slug contains that same `"truenas"` substring — meaning each entry's coordinator flagged every *other* entry's orphaned statistics as well, and each entry then raised its own Repairs issue for the same global orphan list.

This PR scopes the match to each config entry's own device-name slug (`slugify(config_entry.data[CONF_NAME])`, e.g. `"truenas_nuc13"` vs `"truenas_x11dpu"`) instead of the fixed constant, so each entry only ever flags statistics that actually belonged to its own device.

This does **not** address the separate `"Handler does not support user"` error @janusn also hit when opening the repair dialog — root cause for that isn't confirmed yet, so it isn't touched here. We'll ask for confirmation whether it recurs after this fix ships.

Fixes/relates to #61.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
- New regression test `test_async_detect_orphaned_statistics_ignores_other_entrys_device` reproduces the two-entry scenario from @janusn's log.
- `_is_truenas_sensor_id` now takes `device_slug` as a required parameter instead of reading a module-level constant.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Scope orphaned statistics detection to each TrueNAS config entry’s device slug to avoid cross-entry conflicts on multi-entry installs.

Bug Fixes:
- Ensure orphaned statistics detection only matches statistics belonging to the current config entry’s device slug instead of a global slug, preventing duplicate Repairs issues across entries.

Tests:
- Add regression tests covering per-entry device-slug matching, empty-device-slug rejection, and multi-entry scenarios for orphaned statistics detection.