### PR TITLE
chore: bump quality_scale to platinum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ venv/
 # Local secrets (e.g. examples/verify_live.py credentials, .env.sonar token)
 .env
 .env.*
+
+# SonarScanner local cache / JVM crash dumps
+.scannerwork/
+hs_err_pid*.log

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -10,7 +10,7 @@
     "documentation": "https://github.com/kayl-codes/homeassistant-truenas",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
-    "quality_scale": "gold",
+    "quality_scale": "platinum",
     "requirements": [
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"


### PR DESCRIPTION
## Proposed change
`quality_scale.yaml` has had all Platinum-tier rules (`async-dependency`, `inject-websession` exempt, `strict-typing`) at `done`/`exempt` since 2026-08-02, but `manifest.json`'s `quality_scale` field was never bumped past `"gold"`. This PR closes that gap — no code/rule changes, pure metadata.

Also adds `.scannerwork/` and `hs_err_pid*.log` to `.gitignore` (local SonarScanner cache / JVM crash dump artifacts that shouldn't be tracked).

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Verified before bumping: `ruff check .` / `ruff format --check .` clean, `pipenv run mypy` clean (strict-typing rule).

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the integration’s manifest quality scale metadata to platinum and update Git ignore rules to exclude local analysis and crash dump artifacts.

Enhancements:
- Increase the integration manifest quality_scale from gold to platinum to reflect current compliance with platinum-tier rules.

Chores:
- Extend .gitignore to ignore SonarScanner cache directory and JVM crash dump log files.