### PR TITLE
fix: prevent UndefinedType._singleton from appearing in app stats entity names

### DIFF
--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -1009,6 +1009,7 @@ class TrueNASAppStatsSensor(TrueNASEntity, SensorEntity):
     @property
     def name(self) -> str | None:
         """Return the dynamic friendly name for the entity."""
+        desc_name = self._translated_description_name() or self.entity_description.key
         if self.entity_description.key in (
             "app_stats_network_rx",
             "app_stats_network_tx",
@@ -1021,13 +1022,13 @@ class TrueNASAppStatsSensor(TrueNASEntity, SensorEntity):
                     return (
                         f"{resolved.get('app_name', self._uid)} "
                         f"{resolved.get('interface_name')} "
-                        f"{self.entity_description.name}"
+                        f"{desc_name}"
                     )
-                return f"{base_uid} {self.entity_description.name}"
+                return f"{base_uid} {desc_name}"
             return None
 
         app_name = self._data.get("app_name", self._uid)
-        return f"{app_name} {self.entity_description.name}"
+        return f"{app_name} {desc_name}"
 
     @property
     def native_value(self) -> Any:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -888,6 +888,46 @@ def test_app_stats_standard_native_value_and_name() -> None:
     assert sensor.available is True
 
 
+def test_app_stats_name_without_literal_name_no_translations() -> None:
+    """Descriptions that only set translation_key (no literal `name`) must not
+    leak HA's UNDEFINED sentinel into the name when no translations are loaded --
+    regression test for the fix in PR #66.
+    """
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_cpu",
+        translation_key="app_stats_cpu",
+        data_path="app_stats",
+        data_attribute="cpu",
+    )
+    coordinator = make_coordinator(
+        data={"app_stats": {"plex": {"app_name": "Plex", "cpu": 12.5}}}
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex")
+    sensor.platform_data = None
+    assert sensor.name == "Plex app_stats_cpu"
+
+
+def test_app_stats_name_without_literal_name_translated() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_cpu",
+        translation_key="app_stats_cpu",
+        data_path="app_stats",
+        data_attribute="cpu",
+    )
+    coordinator = make_coordinator(
+        data={"app_stats": {"plex": {"app_name": "Plex", "cpu": 12.5}}}
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex")
+    sensor.platform_data = SimpleNamespace(
+        platform_name="truenas_ce",
+        domain="sensor",
+        platform_translations={
+            "component.truenas_ce.entity.sensor.app_stats_cpu.name": "CPU"
+        },
+    )
+    assert sensor.name == "Plex CPU"
+
+
 def test_app_stats_native_value_none_when_no_data() -> None:
     coordinator = make_coordinator(data={"app_stats": {}})
     sensor = TrueNASAppStatsSensor(coordinator, _app_stats_desc(), "plex")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
After HA 2026.8 update TrueNASAppStatsSensor.name now falls back to the description key instead of using EntityDescription.name directly, avoiding stringification of the new UNDEFINED enum default.

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Bug Fixes:
- Prevent app stats sensor entities from displaying the UndefinedType singleton in their names after Home Assistant 2026.8 changes.