### PR TITLE
chore: add Core-PR draft transform script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'custom_components/**'
       - 'tests/**'
+      - 'core_integrations/**'
       - '.github/**'
       - '**.md'
       - 'docs/**'
@@ -13,6 +14,7 @@ on:
     paths:
       - 'custom_components/**'
       - 'tests/**'
+      - 'core_integrations/**'
       - '.github/**'
       - '**.md'
       - 'docs/**'

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ __pycache__/
 /requirements_tests.txt
 /requirements_tests_only_binary_exempt.txt
 
+# Generated Core-PR draft (built on demand by core_integrations/build_core_copy.py)
+/core_integrations/homeassistant-core-draft/
+
 # Claude Code (personal/local settings — permission rules etc.)
 .claude/
 .mcp.json

--- a/core_integrations/build_core_copy.py
+++ b/core_integrations/build_core_copy.py
@@ -1,0 +1,140 @@
+"""Regenerate a Core-shaped copy of the integration from the HACS fork.
+
+Copies ``custom_components/truenas_ce`` into a
+``homeassistant/components/truenas_ce`` layout under
+``core_integrations/homeassistant-core-draft/`` and applies the divergences a
+``home-assistant/core`` submission needs (manifest fields, exact requirement
+pins, missing quality-scale rules) without touching the HACS fork itself. Run
+this again any time the fork changes to refresh the draft; it does not touch
+git, fork, or open a PR (see the AI_POLICY notes in the roadmap memory).
+
+Usage: ``python3 core_integrations/build_core_copy.py``
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+SOURCE = Path("custom_components/truenas_ce")
+DEST = Path(
+    "core_integrations/homeassistant-core-draft/homeassistant/components/truenas_ce"
+)
+
+DOCUMENTATION_URL = "https://www.home-assistant.io/integrations/truenas_ce"
+EXTRA_LOGGERS = ["aiotruenas"]
+DROPPED_MANIFEST_KEYS = ("version", "issue_tracker")
+DROPPED_REQUIREMENT_PREFIXES = ("websockets",)
+
+# anchor -> block to insert right after it, keyed by the rule name it adds.
+# Both are official Bronze quality-scale rules missing from our yaml; the
+# integration has no device_automation triggers/conditions, so both are exempt.
+_MISSING_BRONZE_RULES = {
+    "docs-conditions": (
+        "  docs-actions: done\n",
+        "  docs-conditions:\n"
+        "    status: exempt\n"
+        "    comment: This integration does not have any conditions.\n",
+    ),
+    "docs-triggers": (
+        '    comment: README has a dedicated "Removing the integration" section.\n',
+        "  docs-triggers:\n"
+        "    status: exempt\n"
+        "    comment: This integration does not have any triggers.\n",
+    ),
+}
+
+
+def _copy_tree(source: Path, dest: Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(
+        source,
+        dest,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "brand", "translations"),
+    )
+
+
+def _pin_requirement(requirement: str) -> str | None:
+    if requirement.startswith(DROPPED_REQUIREMENT_PREFIXES):
+        return None
+    match = re.match(r"^([A-Za-z0-9_.-]+)>=([\w.]+)$", requirement)
+    if not match:
+        return requirement
+    name, version = match.groups()
+    print(
+        f"  requirements: pinned {name} to =={version} -- verify this is "
+        "actually the latest released version before submitting"
+    )
+    return f"{name}=={version}"
+
+
+def _transform_manifest(dest: Path) -> None:
+    manifest_path = dest / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    for key in DROPPED_MANIFEST_KEYS:
+        manifest.pop(key, None)
+
+    manifest["documentation"] = DOCUMENTATION_URL
+    manifest.setdefault("integration_type", "device")
+    manifest.setdefault("loggers", EXTRA_LOGGERS)
+
+    pinned = (_pin_requirement(req) for req in manifest.get("requirements", []))
+    manifest["requirements"] = [req for req in pinned if req is not None]
+
+    ordered = {
+        "domain": manifest.pop("domain"),
+        "name": manifest.pop("name"),
+    } | {key: manifest[key] for key in sorted(manifest)}
+    manifest_path.write_text(json.dumps(ordered, indent=4) + "\n", encoding="utf-8")
+
+
+def _transform_quality_scale(dest: Path) -> None:
+    path = dest / "quality_scale.yaml"
+    content = path.read_text(encoding="utf-8")
+
+    for rule_name, (anchor, block) in _MISSING_BRONZE_RULES.items():
+        if f"{rule_name}:" in content:
+            continue
+        if anchor not in content:
+            print(
+                f"  quality_scale.yaml: anchor for {rule_name} not found "
+                "-- insert by hand"
+            )
+            continue
+        content = content.replace(anchor, anchor + block, 1)
+
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> None:
+    if not SOURCE.is_dir():
+        sys.exit(f"source directory not found: {SOURCE}")
+
+    print(f"Copying {SOURCE} -> {DEST}")
+    _copy_tree(SOURCE, DEST)
+
+    print("Transforming manifest.json for Core conventions")
+    _transform_manifest(DEST)
+
+    print("Adding missing Bronze quality-scale rules")
+    _transform_quality_scale(DEST)
+
+    print(
+        "\nDone. Still needs manual work before this is PR-ready:\n"
+        "  - port tests/ to Core conventions (MockConfigEntry, syrupy snapshots)\n"
+        "  - add truenas_ce to Core's .strict-typing\n"
+        "  - run `python3 -m script.hassfest` and "
+        "`python3 -m script.gen_requirements_all` inside an actual "
+        "home-assistant/core checkout\n"
+        "  - brand icons come from the separate home-assistant/brands PR "
+        "(#10948), not from this copy"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Proposed change
Adds `core_integrations/build_core_copy.py`, a one-off dev tool that regenerates a `homeassistant/components/truenas_ce`-shaped copy of the integration from the HACS fork (`custom_components/truenas_ce`) for the longer-running Home Assistant Core submission effort tracked internally.

It applies the divergences a Core submission needs without hand-maintaining two trees:
- drops `brand/` and `translations/` (Core-only takes `strings.json`; brand icons live in the separate `home-assistant/brands` PR)
- strips manifest fields Core doesn't use (`version`, `issue_tracker`), points `documentation` at the home-assistant.io URL, adds `integration_type`/`loggers`, pins `requirements` exactly instead of `>=`
- adds the two Bronze quality-scale rules (`docs-conditions`, `docs-triggers`) our `quality_scale.yaml` was missing relative to Core's actual rule set, marked `exempt`

The generated output directory is gitignored and rebuilt on demand (`python core_integrations/build_core_copy.py`) — this PR only adds the generator, not a checked-in copy.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Pure dev tooling, does not touch `custom_components/truenas_ce` at runtime. No PR against `home-assistant/core` is being opened by this — that stays a manual, human-reviewed step per the Open Home Foundation's AI policy.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a dev-only script to generate a Home Assistant Core–shaped draft copy of the truenas_ce integration from the HACS fork without affecting runtime code.

Enhancements:
- Introduce a regeneration script that copies the HACS truenas_ce integration into a Core-style layout and applies required manifest and quality scale adjustments.
- Update .gitignore to exclude the generated Core draft integration directory from version control.

Chores:
- Document remaining manual steps in the script output for preparing a Core pull request, including tests, typing, and Core tooling runs.