### PR TITLE
chore: bump version to 2.6.1, add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.6.1] — Certificate orphaned-statistics & app-stats name fix
+
+### Fixed
+- **Orphaned statistics after a certificate update (#61):** certificate entities
+  (`certificate_expiry`, `certificate_expiration_time`, `certificate_expired`) are now keyed by
+  the certificate's stable `name` instead of TrueNAS's internal `id`, which changes on a
+  content-replacing renew/reissue (as opposed to TrueNAS's own passive scheduled auto-renewal).
+  Detection is also now scoped to each config entry's own device, so installs with multiple
+  TrueNAS instances no longer raise a duplicate Repairs issue for another entry's orphaned
+  statistics. Thanks to @janusn for reporting and verifying both release candidates.
+- **`UndefinedType._singleton` leaking into app-stats sensor names (#66):** app CPU/memory/
+  network/block-I/O sensors could briefly show a literal `UndefinedType._singleton` fragment in
+  their name before translations loaded, because a custom `name` override bypassed the safe
+  translation-lookup helper used by every other entity. Thanks to @testuser7 for the fix.
+
 ## [2.5.2] — Read-only API key log noise fix
 
 ### Fixed

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,7 +15,7 @@
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"
     ],
-    "version": "2.6.0",
+    "version": "2.6.1",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change
Prepare the stable v2.6.1 release: bump `manifest.json` version and add the CHANGELOG entry summarizing the fixes shipped since v2.6.0 (#61/#63/#64 certificate orphaned statistics, #66 app-stats name leak), both already verified via the v2.6.1-rc1/rc2 prereleases.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information
No functional code changes — version/changelog only. Reporter @janusn confirmed rc2 resolves #61; contributor @testuser7 fixed #66.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 2.6.1 stable release by updating the integration version and documenting the included fixes.

Build:
- Bump the integration manifest version from 2.6.0 to 2.6.1.

Documentation:
- Add a 2.6.1 changelog entry summarizing certificate statistics and app-stats name fixes since 2.6.0.