### PR TITLE
fix: use update.run API method on TrueNAS 25.10+ (#72)

### DIFF
--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -925,6 +925,18 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
 
     # ---------------------------
+    #   supports_update_run
+    # ---------------------------
+    def supports_update_run(self) -> bool:
+        """Return True if the "update.run" API method is available.
+
+        TrueNAS 25.10 split the legacy "update.update" method: it now only
+        writes update *settings*, while installing an update (with the
+        optional reboot) moved to the new "update.run" method.
+        """
+        return (self._version_major, self._version_minor) >= (25, 10)
+
+    # ---------------------------
     #   _detect_virtualization
     # ---------------------------
     def _detect_virtualization(self) -> None:

--- a/custom_components/truenas_ce/update.py
+++ b/custom_components/truenas_ce/update.py
@@ -89,9 +89,13 @@ class TrueNASUpdate(TrueNASEntity, UpdateEntity):
         """Install the latest available update.
 
         The version parameter is currently ignored; TrueNAS API only supports
-        installing the latest available firmware via update.update.
+        installing the latest available firmware. TrueNAS 25.10 moved this
+        from "update.update" (now settings-only) to "update.run".
         """
-        job_id = await self.coordinator.api.query("update.update", {"reboot": True})
+        method = (
+            "update.run" if self.coordinator.supports_update_run() else "update.update"
+        )
+        job_id = await self.coordinator.api.query(method, {"reboot": True})
         if job_id is None:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -81,4 +81,5 @@ def make_coordinator(
         async_clear_orphaned_statistics=AsyncMock(),
         async_count_orphans_with_data=AsyncMock(return_value=0),
         raise_migration_rollback_issue=MagicMock(),
+        supports_update_run=MagicMock(return_value=False),
     )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -45,6 +45,7 @@ def test_system_update_not_running_has_no_percentage() -> None:
 
 async def test_system_update_async_install_success() -> None:
     update = _make_system_update({})
+    update.coordinator.supports_update_run.return_value = False
     update.coordinator.api.query.return_value = 555
     await update.async_install(version=None, backup=False)
     update.coordinator.api.query.assert_awaited_once_with(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -54,6 +54,17 @@ async def test_system_update_async_install_success() -> None:
     update.coordinator.async_refresh.assert_awaited_once()
 
 
+async def test_system_update_async_install_uses_update_run_on_2510_plus() -> None:
+    update = _make_system_update({})
+    update.coordinator.supports_update_run.return_value = True
+    update.coordinator.api.query.return_value = 555
+    await update.async_install(version=None, backup=False)
+    update.coordinator.api.query.assert_awaited_once_with(
+        "update.run", {"reboot": True}
+    )
+    assert update._data["update_jobid"] == 555
+
+
 async def test_system_update_async_install_failure_raises() -> None:
     update = _make_system_update({})
     update.coordinator.api.query.return_value = None


### PR DESCRIPTION
## Proposed change

TrueNAS 25.10 split the legacy `update.update` API method into two: `update.update` is now settings-only (`autocheck`/`profile`), while the actual update installer (with the `reboot` flag) moved to a new, job-decorated `update.run` method. Calling the old method with `{"reboot": true}` on TrueNAS 25.10+ now fails server-side validation with `[EINVAL] data.reboot: Extra inputs are not permitted`, breaking the "Install" action on the system Update entity.

This adds `TrueNASCoordinator.supports_update_run()`, gated on the TrueNAS server version already tracked by the coordinator, and uses it in `TrueNASUpdate.async_install()` to pick `update.run` on 25.10+ and keep `update.update` on older versions (including the integration's declared minimum, 25.04).

Fixes #72

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Root cause confirmed by comparing the versioned API schemas in the `truenas/middleware` repo (`middlewared/api/v25_04_2` only has the old combined `update.update`; `v25_10_0` adds the settings-only override plus the new `update.run`, which is `@job(lock='update')`-decorated — consistent with our existing job-id handling).

## Checklist
- [ ] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make TrueNAS update installation compatible with API changes in version 25.10+ by selecting the appropriate update method based on server version.

Bug Fixes:
- Ensure the system update install action works on TrueNAS 25.10+ by calling the new "update.run" API method instead of the settings-only "update.update".
- Preserve correct behavior on older TrueNAS versions by continuing to use the legacy "update.update" method when "update.run" is unavailable.

Enhancements:
- Add coordinator support for detecting availability of the "update.run" API method based on the tracked TrueNAS server version.

Tests:
- Extend system update tests to cover both legacy and new update API methods and to mock coordinator support for "update.run".