### PR TITLE
chore: bump version to 2.6.2, add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.6.2] — TrueNAS 25.10+ update fix & device-registry hardening
+
+### Fixed
+- **"Unable to start TrueNAS update" on TrueNAS 25.10+ (#72):** TrueNAS 25.10 split the legacy
+  `update.update` API method in two — it's now settings-only, and the actual update installer
+  moved to a new `update.run` method. Calling the old method still worked for checking updates, but
+  clicking **Install** on the system Update entity now failed server-side with
+  `[EINVAL] data.reboot: Extra inputs are not permitted`. The integration now detects the running
+  TrueNAS version and calls `update.run` on 25.10+, while still using `update.update` on 25.04–25.09
+  installs. Thanks to @Regnator for reporting and confirming the fix.
+
+### Changed
+- **Device-registry & coordinator internals hardened against upcoming Home Assistant Core
+  deprecations:** `DataUpdateCoordinator` now receives `config_entry` explicitly instead of relying
+  on its deprecated `ContextVar` fallback, and device linking prefers the newer `via_device_id` over
+  `via_device` where the running Home Assistant Core version supports it (with automatic runtime
+  feature-detection, so installs on older Core versions are unaffected). No user-facing behavior
+  change on any currently-supported Home Assistant version.
+
 ## [2.6.1] — Certificate orphaned-statistics & app-stats name fix
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ target:
 
 
 Minimum requirements:
-* TrueNAS 25.04 or later (tested with 25.10.4)
+* TrueNAS 25.04 or later (tested with 25.10.5)
 * Home Assistant 2025.8.0
 
 ## Using TrueNAS development branch
@@ -399,7 +399,7 @@ After setup you can fine-tune the integration via **Settings → Devices & Servi
   [Remote access, reverse proxies & Cloudflare](#remote-access-reverse-proxies--cloudflare) for
   supported alternatives (local IP/VPN, or a plain TLS-terminating reverse proxy).
 * **TrueNAS development/nightly builds are not officially supported.** The integration is tested
-  against stable TrueNAS releases (currently 25.04–25.10.4); features may break without notice on a
+  against stable TrueNAS releases (currently 25.04–25.10.5); features may break without notice on a
   development branch.
 * **Run buttons don't show a "running" spinner state.** The Cron Job, Pool Scrub and Snapshot Task
   **Run** buttons trigger their action immediately, but a Home Assistant `ButtonEntity` has no

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,7 +15,7 @@
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"
     ],
-    "version": "2.6.1",
+    "version": "2.6.2",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change
Prepare the stable v2.6.2 release: bump `manifest.json` version and add the CHANGELOG entry summarizing the fixes shipped since v2.6.1 (#72/#73 TrueNAS 25.10+ update.run fix, #71 device-registry/coordinator deprecation hardening). Also bumped the two "tested with"/supported-range TrueNAS version mentions in the README from 25.10.4 to 25.10.5, matching the version the reporter confirmed the fix against.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information
No functional code changes — version/changelog/README only. Reporter @Regnator confirmed the update.run fix resolves #72.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 2.6.2 stable release by updating metadata and documentation to reflect recent fixes and supported versions.

Build:
- Bump the integration manifest version from 2.6.1 to 2.6.2.

Documentation:
- Add a 2.6.2 changelog entry describing the TrueNAS 25.10+ update.run fix and device-registry/coordinator hardening against upcoming Home Assistant deprecations.
- Update README TrueNAS "tested with" and supported-range version references from 25.10.4 to 25.10.5.