### PR TITLE
feat(update): track app upgrade job progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+### Added
+- **App update progress tracking:** the app update entity now supports HA's progress feature.
+  After starting an `app.upgrade`, the entity polls the TrueNAS job every 2 s, exposes its
+  percent as `update_percentage`, mirrors `update_state`/`update_description` in the app data
+  and reports a `FAILED`/`ABORTED` job as an error instead of silently finishing. The
+  coordinator poll keeps tracking (and clearing) jobs as a safety net, e.g. after an HA restart.
+
 ## [2.6.2] — TrueNAS 25.10+ update fix & device-registry hardening
 
 ### Fixed

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -42,6 +42,14 @@ UPTIME_EPOCH_TOLERANCE_SECONDS = 300
 QUERY_TIMEOUT: float = 30.0
 
 # Error constants
+# TrueNAS job states in which an app upgrade job is still active.
+APP_UPDATE_JOB_ACTIVE_STATES: frozenset[str] = frozenset({"WAITING", "RUNNING"})
+# How often the app update entity polls its upgrade job while installing (s).
+APP_UPDATE_JOB_POLL_INTERVAL = 2
+# Give up on entity-side job tracking after this long; the coordinator's
+# regular poll keeps mirroring the job state afterwards.
+APP_UPDATE_JOB_TIMEOUT = 30 * 60
+
 ERR_CERT_VERIFY_FAILED = "certificate_verify_failed"
 ERR_HTTP_USED = "http_used"
 ERR_TLS_NOT_SUPPORTED = "tlsv1_not_supported"

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -32,6 +32,7 @@ from homeassistant.util import slugify
 from .api import TrueNASAPI, _summarize_payload
 from .apiparser import ApiValueSpec, parse_api
 from .const import (
+    APP_UPDATE_JOB_ACTIVE_STATES,
     BEHAVIOR_SKIP_DISABLED_CRONJOBS,
     CONF_BEHAVIORS,
     CONF_MONITORED_GROUPS,
@@ -2412,6 +2413,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ],
             ensure_vals=[
                 {"name": "running", "type": "bool", "default": False},
+                {"name": "update_jobid", "default": 0},
+                {"name": "update_progress", "default": 0},
+                {"name": "update_state", "default": "unknown"},
+                {"name": "update_description", "default": ""},
             ],
         )
 
@@ -2429,25 +2434,79 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 and bool(vals.get("image_updates_available"))
             )
 
-        await self._clear_finished_app_updates()
+        await self._refresh_app_update_jobs()
 
-    async def _clear_finished_app_updates(self) -> None:
-        """Reset update_jobid once an app's upgrade job is no longer running.
+    async def _refresh_app_update_jobs(self) -> None:
+        """Mirror the state of every tracked app upgrade job into ``ds["app"]``.
 
-        Otherwise the update entity stays "in progress" after the first update
-        and the app cannot be updated again until Home Assistant restarts.
+        The update entity polls its own job at a much higher cadence while an
+        install is running; this per-poll pass is the safety net that keeps the
+        entity from staying "in progress" forever (e.g. after HA restarts mid
+        upgrade or if the entity's tracking loop gave up).
         """
-        for vals in self.ds["app"].values():
-            job_id = vals.get("update_jobid")
-            if not job_id:
-                continue
+        for uid, vals in list(self.ds["app"].items()):
+            if vals.get("update_jobid"):
+                await self.async_refresh_app_update_job(uid)
 
-            jobs = await self.api.query("core.get_jobs", params=[[["id", "=", job_id]]])
-            state = None
-            if isinstance(jobs, list) and jobs and isinstance(jobs[0], dict):
-                state = jobs[0].get("state")
-            if state not in ("RUNNING", "WAITING"):
-                vals["update_jobid"] = 0
+    async def async_refresh_app_update_job(self, uid: str) -> dict[str, Any] | None:
+        """Poll the upgrade job of app ``uid`` and store its progress.
+
+        Writes ``update_state``, ``update_progress`` (percent) and
+        ``update_description`` into the app's data. Once the job leaves an
+        active state (or can no longer be found) ``update_jobid`` is reset so
+        the app can be upgraded again.
+
+        Returns the raw job dict, or ``None`` when there is nothing to track or
+        the API call failed (in which case tracking state is left untouched).
+        """
+        vals = self.ds.get("app", {}).get(uid)
+        if not vals:
+            return None
+        job_id = vals.get("update_jobid")
+        if not job_id:
+            return None
+
+        jobs = await self.api.query("core.get_jobs", params=[[["id", "=", job_id]]])
+        if jobs is None:
+            # Transient API error: keep tracking, retry on the next poll.
+            return None
+        job = jobs[0] if jobs and isinstance(jobs[0], dict) else None
+        if job is None:
+            _LOGGER.warning(
+                "Upgrade job %s for app %s no longer exists on %s; stopped tracking",
+                job_id,
+                uid,
+                self.host,
+            )
+            self._reset_app_update_job(vals, state="unknown")
+            return None
+
+        state = str(job.get("state") or "unknown")
+        progress = job.get("progress") or {}
+        vals["update_state"] = state
+        vals["update_progress"] = int(progress.get("percent") or 0)
+        vals["update_description"] = str(progress.get("description") or "")
+
+        if state not in APP_UPDATE_JOB_ACTIVE_STATES:
+            if state != "SUCCESS":
+                _LOGGER.error(
+                    "Upgrade job %s for app %s on %s finished with state %s: %s",
+                    job_id,
+                    uid,
+                    self.host,
+                    state,
+                    job.get("error") or "no error message",
+                )
+            self._reset_app_update_job(vals, state=state)
+        return job
+
+    @staticmethod
+    def _reset_app_update_job(vals: dict[str, Any], *, state: str) -> None:
+        """Stop tracking an app upgrade job, leaving its final state visible."""
+        vals["update_jobid"] = 0
+        vals["update_progress"] = 0
+        vals["update_description"] = ""
+        vals["update_state"] = state
 
     # ---------------------------
     #   app stats subscription helpers

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -2444,7 +2444,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entity from staying "in progress" forever (e.g. after HA restarts mid
         upgrade or if the entity's tracking loop gave up).
         """
-        for uid, vals in list(self.ds["app"].items()):
+        for uid, vals in self.ds["app"].items():
             if vals.get("update_jobid"):
                 await self.async_refresh_app_update_job(uid)
 
@@ -2502,10 +2502,13 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @staticmethod
     def _reset_app_update_job(vals: dict[str, Any], *, state: str) -> None:
-        """Stop tracking an app upgrade job, leaving its final state visible."""
+        """Stop tracking an app upgrade job.
+
+        Only the job id is cleared; the final state, progress and description
+        stay visible in the app data for troubleshooting until the next
+        upgrade starts.
+        """
         vals["update_jobid"] = 0
-        vals["update_progress"] = 0
-        vals["update_description"] = ""
         vals["update_state"] = state
 
     # ---------------------------

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -171,6 +171,9 @@
         "app_update_failed": {
             "message": "Failed to start TrueNAS app update for {app} on {host}: {error}"
         },
+        "app_update_job_failed": {
+            "message": "TrueNAS app update for {app} on {host} did not succeed: {error}"
+        },
         "missing_uuid": {
             "message": "Missing required parameter: uuid"
         },

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -171,6 +171,9 @@
         "app_update_failed": {
             "message": "Start des TrueNAS-App-Updates für {app} auf {host} fehlgeschlagen: {error}"
         },
+        "app_update_job_failed": {
+            "message": "TrueNAS-App-Update für {app} auf {host} war nicht erfolgreich: {error}"
+        },
         "missing_uuid": {
             "message": "Fehlender Pflichtparameter: uuid"
         },

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -171,6 +171,9 @@
         "app_update_failed": {
             "message": "Failed to start TrueNAS app update for {app} on {host}: {error}"
         },
+        "app_update_job_failed": {
+            "message": "TrueNAS app update for {app} on {host} did not succeed: {error}"
+        },
         "missing_uuid": {
             "message": "Missing required parameter: uuid"
         },

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -171,6 +171,9 @@
         "app_update_failed": {
             "message": "No se pudo iniciar la actualización de la app TrueNAS {app} en {host}: {error}"
         },
+        "app_update_job_failed": {
+            "message": "La actualización de la app TrueNAS {app} en {host} no se completó correctamente: {error}"
+        },
         "missing_uuid": {
             "message": "Falta el parámetro obligatorio: uuid"
         },

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -171,6 +171,9 @@
         "app_update_failed": {
             "message": "Falha ao iniciar a atualização do app TrueNAS {app} em {host}: {error}"
         },
+        "app_update_job_failed": {
+            "message": "A atualização do app TrueNAS {app} em {host} não foi concluída com sucesso: {error}"
+        },
         "missing_uuid": {
             "message": "Parâmetro obrigatório ausente: uuid"
         },

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -171,6 +171,9 @@
         "app_update_failed": {
             "message": "Не удалось запустить обновление приложения {app} TrueNAS на {host}: {error}"
         },
+        "app_update_job_failed": {
+            "message": "Обновление приложения {app} TrueNAS на {host} завершилось неудачно: {error}"
+        },
         "missing_uuid": {
             "message": "Отсутствует обязательный параметр: uuid"
         },

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -171,6 +171,9 @@
         "app_update_failed": {
             "message": "Nepodarilo sa spustiť aktualizáciu aplikácie {app} TrueNAS na {host}: {error}"
         },
+        "app_update_job_failed": {
+            "message": "Aktualizácia aplikácie {app} TrueNAS na {host} neprebehla úspešne: {error}"
+        },
         "missing_uuid": {
             "message": "Chýba povinný parameter: uuid"
         },

--- a/custom_components/truenas_ce/update.py
+++ b/custom_components/truenas_ce/update.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from logging import getLogger
+from time import monotonic
 from typing import Any
 
 from homeassistant.components.update import (
@@ -15,7 +17,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import (
+    APP_UPDATE_JOB_ACTIVE_STATES,
+    APP_UPDATE_JOB_POLL_INTERVAL,
+    APP_UPDATE_JOB_TIMEOUT,
+    DOMAIN,
+)
 from .coordinator import TrueNASCoordinator
 from .entity import TrueNASEntity, async_add_entities
 from .update_types import (  # noqa: F401
@@ -141,7 +148,9 @@ class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
         """Set up device update entity."""
         super().__init__(coordinator, entity_description, uid)
 
-        self._attr_supported_features = UpdateEntityFeature.INSTALL
+        self._attr_supported_features = (
+            UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
+        )
 
     @property
     def installed_version(self) -> str | None:
@@ -190,12 +199,61 @@ class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
             )
 
         self._data["update_jobid"] = job_id
-        await self.coordinator.async_refresh()
+        self._data["update_state"] = "RUNNING"
+        self._data["update_progress"] = 0
+        self._data["update_description"] = ""
+        self.async_write_ha_state()
+
+        job = await self._async_track_upgrade_job()
+        # Re-sync versions/state from TrueNAS now that the job is done.
+        await self.coordinator.async_request_refresh()
+
+        if job is not None and job.get("state") != "SUCCESS":
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="app_update_job_failed",
+                translation_placeholders={
+                    "app": self._data["id"],
+                    "host": self.coordinator.host,
+                    "error": str(job.get("error") or job.get("state") or "unknown"),
+                },
+            )
+
+    async def _async_track_upgrade_job(self) -> dict[str, Any] | None:
+        """Poll the running upgrade job and push progress to HA until it ends.
+
+        Returns the final job dict, or ``None`` if the job vanished or tracking
+        timed out (the coordinator keeps mirroring the job on its own cadence).
+        """
+        deadline = monotonic() + APP_UPDATE_JOB_TIMEOUT
+        while self._data.get("update_jobid"):
+            await asyncio.sleep(APP_UPDATE_JOB_POLL_INTERVAL)
+            job = await self.coordinator.async_refresh_app_update_job(self._data["id"])
+            self.async_write_ha_state()
+            if job is not None and job.get("state") not in APP_UPDATE_JOB_ACTIVE_STATES:
+                return job
+            if monotonic() > deadline:
+                _LOGGER.warning(
+                    "Upgrade job %s for app %s is still running after %s s; "
+                    "leaving progress tracking to the regular poll",
+                    self._data.get("update_jobid"),
+                    self._data["id"],
+                    APP_UPDATE_JOB_TIMEOUT,
+                )
+                return None
+        return None
 
     @property
     def in_progress(self) -> bool:
         """Return if update is in progress."""
         return bool(self._data.get("update_jobid"))
+
+    @property
+    def update_percentage(self) -> int | None:
+        """Update installation progress percentage."""
+        if not self.in_progress:
+            return None
+        return int(self._data.get("update_progress") or 0)
 
     @property
     def title(self) -> str | None:

--- a/custom_components/truenas_ce/update.py
+++ b/custom_components/truenas_ce/update.py
@@ -232,7 +232,7 @@ class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
             self.async_write_ha_state()
             if job is not None and job.get("state") not in APP_UPDATE_JOB_ACTIVE_STATES:
                 return job
-            if monotonic() > deadline:
+            if monotonic() >= deadline:
                 _LOGGER.warning(
                     "Upgrade job %s for app %s is still running after %s s; "
                     "leaving progress tracking to the regular poll",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -68,6 +68,7 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._app_stats_sub_id = None
     coord.orphaned_statistics = []
     coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
+    coord.host = "truenas.local"
     return coord
 
 
@@ -3145,7 +3146,7 @@ async def test_get_scrub_parses_response() -> None:
 
 
 # ---------------------------
-#   get_app / _clear_finished_app_updates
+#   get_app / app update job tracking
 # ---------------------------
 async def test_get_app_catalog_update_available() -> None:
     coord = _bare_coordinator()
@@ -3163,7 +3164,7 @@ async def test_get_app_catalog_update_available() -> None:
             }
         ]
     )
-    coord._clear_finished_app_updates = AsyncMock()
+    coord._refresh_app_update_jobs = AsyncMock()
     await coord.get_app()
     assert coord.ds["app"]["app1"]["running"] is True
     assert coord.ds["app"]["app1"]["update_available"] is True
@@ -3185,7 +3186,7 @@ async def test_get_app_custom_app_falls_back_to_image_updates() -> None:
             }
         ]
     )
-    coord._clear_finished_app_updates = AsyncMock()
+    coord._refresh_app_update_jobs = AsyncMock()
     await coord.get_app()
     assert coord.ds["app"]["app1"]["update_available"] is True
 
@@ -3206,36 +3207,92 @@ async def test_get_app_no_update_for_noncustom_without_upgrade() -> None:
             }
         ]
     )
-    coord._clear_finished_app_updates = AsyncMock()
+    coord._refresh_app_update_jobs = AsyncMock()
     await coord.get_app()
     assert coord.ds["app"]["app1"]["update_available"] is False
 
 
-async def test_clear_finished_app_updates_resets_when_not_running() -> None:
+async def test_refresh_app_update_job_mirrors_running_progress() -> None:
     coord = _bare_coordinator()
     coord.ds = {"app": {"app1": {"update_jobid": 5}}}
     coord.api = MagicMock()
-    coord.api.query = AsyncMock(return_value=[{"state": "SUCCESS"}])
-    await coord._clear_finished_app_updates()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 5,
+                "state": "RUNNING",
+                "progress": {"percent": 42, "description": "Pulling image"},
+            }
+        ]
+    )
+    job = await coord.async_refresh_app_update_job("app1")
+    assert job is not None and job["state"] == "RUNNING"
+    coord.api.query.assert_awaited_once_with("core.get_jobs", params=[[["id", "=", 5]]])
+    app = coord.ds["app"]["app1"]
+    assert app["update_jobid"] == 5
+    assert app["update_state"] == "RUNNING"
+    assert app["update_progress"] == 42
+    assert app["update_description"] == "Pulling image"
+
+
+async def test_refresh_app_update_job_resets_when_finished() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"app1": {"update_jobid": 5, "update_progress": 90}}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"id": 5, "state": "SUCCESS", "progress": {"percent": 100}}]
+    )
+    job = await coord.async_refresh_app_update_job("app1")
+    assert job is not None and job["state"] == "SUCCESS"
+    app = coord.ds["app"]["app1"]
+    assert app["update_jobid"] == 0
+    assert app["update_progress"] == 0
+    assert app["update_state"] == "SUCCESS"
+
+
+async def test_refresh_app_update_job_resets_when_job_missing() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"app1": {"update_jobid": 5}}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[])
+    assert await coord.async_refresh_app_update_job("app1") is None
     assert coord.ds["app"]["app1"]["update_jobid"] == 0
 
 
-async def test_clear_finished_app_updates_keeps_running_job() -> None:
+async def test_refresh_app_update_job_keeps_job_on_api_error() -> None:
     coord = _bare_coordinator()
-    coord.ds = {"app": {"app1": {"update_jobid": 5}}}
+    coord.ds = {"app": {"app1": {"update_jobid": 5, "update_progress": 30}}}
     coord.api = MagicMock()
-    coord.api.query = AsyncMock(return_value=[{"state": "RUNNING"}])
-    await coord._clear_finished_app_updates()
+    coord.api.query = AsyncMock(return_value=None)
+    assert await coord.async_refresh_app_update_job("app1") is None
     assert coord.ds["app"]["app1"]["update_jobid"] == 5
+    assert coord.ds["app"]["app1"]["update_progress"] == 30
 
 
-async def test_clear_finished_app_updates_skips_without_jobid() -> None:
+async def test_refresh_app_update_job_skips_without_jobid() -> None:
     coord = _bare_coordinator()
     coord.ds = {"app": {"app1": {"update_jobid": 0}}}
     coord.api = MagicMock()
     coord.api.query = AsyncMock()
-    await coord._clear_finished_app_updates()
+    assert await coord.async_refresh_app_update_job("app1") is None
+    assert await coord.async_refresh_app_update_job("missing") is None
     coord.api.query.assert_not_awaited()
+
+
+async def test_refresh_app_update_jobs_polls_every_tracked_app() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "app": {
+            "app1": {"update_jobid": 5},
+            "app2": {"update_jobid": 0},
+            "app3": {"update_jobid": 6},
+        }
+    }
+    coord.async_refresh_app_update_job = AsyncMock()
+    await coord._refresh_app_update_jobs()
+    assert sorted(
+        c.args[0] for c in coord.async_refresh_app_update_job.await_args_list
+    ) == ["app1", "app3"]
 
 
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3226,7 +3226,8 @@ async def test_refresh_app_update_job_mirrors_running_progress() -> None:
         ]
     )
     job = await coord.async_refresh_app_update_job("app1")
-    assert job is not None and job["state"] == "RUNNING"
+    assert job is not None
+    assert job["state"] == "RUNNING"
     coord.api.query.assert_awaited_once_with("core.get_jobs", params=[[["id", "=", 5]]])
     app = coord.ds["app"]["app1"]
     assert app["update_jobid"] == 5
@@ -3243,11 +3244,60 @@ async def test_refresh_app_update_job_resets_when_finished() -> None:
         return_value=[{"id": 5, "state": "SUCCESS", "progress": {"percent": 100}}]
     )
     job = await coord.async_refresh_app_update_job("app1")
-    assert job is not None and job["state"] == "SUCCESS"
+    assert job is not None
+    assert job["state"] == "SUCCESS"
     app = coord.ds["app"]["app1"]
     assert app["update_jobid"] == 0
-    assert app["update_progress"] == 0
     assert app["update_state"] == "SUCCESS"
+    # Final progress stays visible for troubleshooting.
+    assert app["update_progress"] == 100
+
+
+async def test_refresh_app_update_job_keeps_waiting_job_active() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"app1": {"update_jobid": 7}}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 7,
+                "state": "WAITING",
+                "progress": {"percent": 0, "description": "Queued"},
+            }
+        ]
+    )
+    job = await coord.async_refresh_app_update_job("app1")
+    assert job is not None
+    assert job["state"] == "WAITING"
+    app = coord.ds["app"]["app1"]
+    assert app["update_jobid"] == 7
+    assert app["update_state"] == "WAITING"
+    assert app["update_progress"] == 0
+    assert app["update_description"] == "Queued"
+
+
+async def test_refresh_app_update_job_failed_keeps_final_progress() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {"app1": {"update_jobid": 5}}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 5,
+                "state": "FAILED",
+                "error": "pull failed",
+                "progress": {"percent": 40, "description": "Pulling image"},
+            }
+        ]
+    )
+    job = await coord.async_refresh_app_update_job("app1")
+    assert job is not None
+    assert job["state"] == "FAILED"
+    app = coord.ds["app"]["app1"]
+    assert app["update_jobid"] == 0
+    assert app["update_state"] == "FAILED"
+    assert app["update_progress"] == 40
+    assert app["update_description"] == "Pulling image"
 
 
 async def test_refresh_app_update_job_resets_when_job_missing() -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -234,6 +234,45 @@ async def test_app_update_async_install_tracks_job_until_success() -> None:
     update.coordinator.async_request_refresh.assert_awaited()
 
 
+async def test_app_update_async_install_keeps_polling_while_waiting() -> None:
+    update = _install_ready_update(
+        [
+            {"state": "WAITING", "progress": {"percent": 0}},
+            {"state": "RUNNING", "progress": {"percent": 50}},
+            {"state": "SUCCESS", "progress": {"percent": 100}},
+        ]
+    )
+    with patch("custom_components.truenas_ce.update.asyncio.sleep", AsyncMock()):
+        await update.async_install(version=None, backup=False)
+
+    assert update.coordinator.async_refresh_app_update_job.await_count == 3
+    assert update.in_progress is False
+
+
+async def test_app_update_async_install_gives_up_after_timeout() -> None:
+    # Job never leaves RUNNING; monotonic() jumps past the deadline on the
+    # third poll (first call sets the deadline, then one call per poll).
+    update = _install_ready_update(
+        [{"state": "RUNNING", "progress": {"percent": 10}}] * 3
+    )
+    with (
+        patch("custom_components.truenas_ce.update.asyncio.sleep", AsyncMock()),
+        patch("custom_components.truenas_ce.update.APP_UPDATE_JOB_TIMEOUT", 100),
+        patch(
+            "custom_components.truenas_ce.update.monotonic",
+            side_effect=[0, 50, 99, 100],
+        ),
+    ):
+        await update.async_install(version=None, backup=False)
+
+    assert update.coordinator.async_refresh_app_update_job.await_count == 3
+    # Job is left for the coordinator poll to track: still marked in progress.
+    assert update._data["update_jobid"] == 99
+    assert update.in_progress is True
+    assert update.async_write_ha_state.call_count == 4
+    update.coordinator.async_request_refresh.assert_awaited_once()
+
+
 async def test_app_update_async_install_raises_when_job_fails() -> None:
     update = _install_ready_update(
         [

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from _fakes import make_coordinator
 from homeassistant.exceptions import HomeAssistantError
@@ -137,10 +139,15 @@ async def test_app_update_async_install_success() -> None:
     update = _make_app_update({"id": "a1"})
     update.coordinator.data["app"] = {"a1": {"state": "RUNNING"}}
     update.coordinator.api.query.return_value = 99
+    update.async_write_ha_state = MagicMock()
+    update._async_track_upgrade_job = AsyncMock(return_value={"state": "SUCCESS"})
     await update.async_install(version=None, backup=False)
     update.coordinator.api.query.assert_awaited_once_with("app.upgrade", ["a1"])
     assert update._data["update_jobid"] == 99
-    update.coordinator.async_refresh.assert_awaited_once()
+    assert update._data["update_progress"] == 0
+    update.async_write_ha_state.assert_called_once()
+    update._async_track_upgrade_job.assert_awaited_once()
+    update.coordinator.async_request_refresh.assert_awaited_once()
 
 
 async def test_app_update_async_install_failure_raises() -> None:
@@ -156,3 +163,104 @@ async def test_app_update_async_install_failure_raises() -> None:
         "host": update.coordinator.host,
         "error": "upgrade failed",
     }
+
+
+# ---------------------------
+#   App update job progress tracking
+# ---------------------------
+def test_app_update_supports_progress_feature() -> None:
+    from homeassistant.components.update import UpdateEntityFeature
+
+    update = _make_app_update({})
+    assert update.supported_features & UpdateEntityFeature.PROGRESS
+
+
+def test_app_update_percentage_while_running() -> None:
+    update = _make_app_update({"update_jobid": 7, "update_progress": 55})
+    assert update.in_progress is True
+    assert update.update_percentage == 55
+
+
+def test_app_update_percentage_none_when_idle() -> None:
+    update = _make_app_update({"update_jobid": 0, "update_progress": 55})
+    assert update.in_progress is False
+    assert update.update_percentage is None
+
+
+def _install_ready_update(job_states: list[dict]) -> TrueNASAppUpdate:
+    """App update whose coordinator reports the given job snapshots in order."""
+    update = _make_app_update({"id": "a1"})
+    update.coordinator.data["app"] = {"a1": update._data}
+    update._data["state"] = "RUNNING"
+    update.coordinator.api.query.return_value = 99
+    update.async_write_ha_state = MagicMock()
+
+    snapshots = iter(job_states)
+
+    async def _refresh(uid: str) -> dict | None:
+        assert uid == "a1"
+        job = next(snapshots)
+        if job is None:
+            # Coordinator could not find the job any more and stopped tracking.
+            update._data["update_jobid"] = 0
+            return None
+        update._data["update_state"] = job["state"]
+        update._data["update_progress"] = job.get("progress", {}).get("percent", 0)
+        if job["state"] not in ("RUNNING", "WAITING"):
+            update._data["update_jobid"] = 0
+        return job
+
+    update.coordinator.async_refresh_app_update_job = AsyncMock(side_effect=_refresh)
+    return update
+
+
+async def test_app_update_async_install_tracks_job_until_success() -> None:
+    update = _install_ready_update(
+        [
+            {"state": "RUNNING", "progress": {"percent": 10}},
+            {"state": "RUNNING", "progress": {"percent": 80}},
+            {"state": "SUCCESS", "progress": {"percent": 100}},
+        ]
+    )
+    with patch("custom_components.truenas_ce.update.asyncio.sleep", AsyncMock()):
+        await update.async_install(version=None, backup=False)
+
+    update.coordinator.api.query.assert_awaited_once_with("app.upgrade", ["a1"])
+    assert update.coordinator.async_refresh_app_update_job.await_count == 3
+    # State is pushed after job start and after every job poll.
+    assert update.async_write_ha_state.call_count >= 4
+    assert update._data["update_jobid"] == 0
+    assert update.in_progress is False
+    update.coordinator.async_request_refresh.assert_awaited()
+
+
+async def test_app_update_async_install_raises_when_job_fails() -> None:
+    update = _install_ready_update(
+        [
+            {"state": "RUNNING", "progress": {"percent": 10}},
+            {"state": "FAILED", "error": "image pull failed"},
+        ]
+    )
+    with (
+        patch("custom_components.truenas_ce.update.asyncio.sleep", AsyncMock()),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await update.async_install(version=None, backup=False)
+
+    assert exc_info.value.translation_key == "app_update_job_failed"
+    assert exc_info.value.translation_placeholders == {
+        "app": "a1",
+        "host": update.coordinator.host,
+        "error": "image pull failed",
+    }
+    assert update._data["update_jobid"] == 0
+
+
+async def test_app_update_async_install_stops_when_job_vanishes() -> None:
+    update = _install_ready_update([{"state": "RUNNING"}, None])
+    with patch("custom_components.truenas_ce.update.asyncio.sleep", AsyncMock()):
+        await update.async_install(version=None, backup=False)
+
+    assert update.coordinator.async_refresh_app_update_job.await_count == 2
+    assert update._data["update_jobid"] == 0
+    assert update.in_progress is False


### PR DESCRIPTION
## Proposed change
App update entities currently only flip `in_progress` on/off; there is no progress and a failed `app.upgrade` job silently "finishes". This PR makes the app update entity track its TrueNAS upgrade job:

- `TrueNASAppUpdate` advertises `UpdateEntityFeature.PROGRESS` and exposes `update_percentage`.
- After starting `app.upgrade`, `async_install` polls the job every 2 s (30 min cap) via a new `coordinator.async_refresh_app_update_job(uid)`, which mirrors the job's `state`, `progress.percent` and `progress.description` into `ds["app"][uid]` (`update_state` / `update_progress` / `update_description`) and pushes state to HA on every tick.
- A job that ends in a non-`SUCCESS` state raises `app_update_job_failed` (new translatable error, all locales) instead of finishing silently.
- The coordinator poll keeps mirroring/clearing tracked jobs as a safety net (`_refresh_app_update_jobs`, replaces `_clear_finished_app_updates`), so entities never stay "in progress" after an HA restart or tracking timeout.

## Type of change
- [ ] Bugfix
- [x] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Verified live against TrueNAS 25.10 / HA 2026.8: upgrading an app from the HA update entity shows `in_progress: true`, `update_percentage` 0 → 40 → …, then `installed_version` bumps and the entity returns to `off`; the TrueNAS `app.upgrade` job reported `SUCCESS`.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required. (CHANGELOG `Unreleased`)
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Track TrueNAS app upgrade job progress in Home Assistant and surface failures instead of completing silently.

New Features:
- Expose app update installation progress via Home Assistant's update progress feature and the `update_percentage` property.
- Poll TrueNAS `app.upgrade` jobs from the app update entity and mirror job state, progress, and description into app data while installs run.
- Raise a translated `app_update_job_failed` error when the underlying TrueNAS upgrade job finishes in a non-success state.

Enhancements:
- Have the coordinator regularly refresh and clear tracked app upgrade jobs as a safety net, ensuring entities do not stay indefinitely in-progress.
- Initialize and persist app upgrade tracking fields (`update_jobid`, progress, state, description) in coordinator app data for troubleshooting.
- Extend tests to cover progress reporting, job polling behavior, timeout handling, vanished jobs, and coordinator-side job mirroring.

Documentation:
- Document app update progress tracking behavior and error handling in the Unreleased section of the changelog.