### PR TITLE
fix(sensor): keep app network sensors when an app stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
   and reports a `FAILED`/`ABORTED` job as an error instead of silently finishing. The
   coordinator poll keeps tracking (and clearing) jobs as a safety net, e.g. after an HA restart.
 
+### Fixed
+- **App network sensors deleted on every app stop:** a stopped app reports no interfaces in
+  `app.stats`, so its per-interface RX/TX sensors were removed from the entity registry (losing
+  history and customisations) and re-created on the next start. The last known interfaces are now
+  kept as stale entries and the sensors simply become `unavailable` while the app is stopped.
+
 ## [2.6.2] — TrueNAS 25.10+ update fix & device-registry hardening
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ### Fixed
 - **App network sensors deleted on every app stop:** a stopped app reports no interfaces in
-  `app.stats`, so its per-interface RX/TX sensors were removed from the entity registry (losing
+  `app.stats`, so its per-interface RX/TX sensors are removed from the entity registry (losing
   history and customisations) and re-created on the next start. The last known interfaces are now
   kept as stale entries and the sensors simply become `unavailable` while the app is stopped.
 

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -2716,12 +2716,12 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         networks = self._filter_app_networks(app.get("networks", []))
         if not networks:
-            networks = self._stale_app_networks(str(app_name))
+            networks = self._stale_app_networks(app_name)
 
         cpu_usage = self._coerce_float(app.get("cpu_usage"))
         memory = self._coerce_float(app.get("memory"))
 
-        self.ds["app_stats"][str(app_name)] = {
+        self.ds["app_stats"][app_name] = {
             "app_name": app_name,
             "cpu_usage": cpu_usage,
             "memory": memory,

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -2724,6 +2724,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if isinstance(net, dict) and bool(net.get("interface_name"))
             ]
 
+        if not networks:
+            networks = self._stale_app_networks(str(app_name))
+
         cpu_usage = self._coerce_float(app.get("cpu_usage"))
         memory = self._coerce_float(app.get("memory"))
 
@@ -2735,6 +2738,30 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "blkio_write": blkio_write,
             "networks": networks,
         }
+
+    def _stale_app_networks(self, app_name: str) -> list[dict[str, Any]]:
+        """Return the app's last known interfaces as stale stubs.
+
+        A stopped app reports no networks in ``app.stats``. Dropping the
+        interfaces would make the orphan cleanup delete the per-interface
+        sensors from the entity registry on every stop (and re-create them on
+        start, losing history and customisations). Instead the interfaces are
+        kept with ``None`` values and ``stale=True`` so the sensors survive and
+        merely become unavailable until the app reports live traffic again.
+        """
+        previous = self.ds["app_stats"].get(app_name, {}).get("networks")
+        if not isinstance(previous, list):
+            return []
+        return [
+            {
+                "interface_name": net["interface_name"],
+                "rx_bytes": None,
+                "tx_bytes": None,
+                "stale": True,
+            }
+            for net in previous
+            if isinstance(net, dict) and net.get("interface_name")
+        ]
 
     def _collect_current_app_names(self) -> set[str]:
         """App names currently present in the app data."""

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -2714,16 +2714,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             blkio_read = blkio_write = None
 
-        networks = app.get("networks", [])
-        if not isinstance(networks, list):
-            networks = []
-        else:
-            networks = [
-                net
-                for net in networks
-                if isinstance(net, dict) and bool(net.get("interface_name"))
-            ]
-
+        networks = self._filter_app_networks(app.get("networks", []))
         if not networks:
             networks = self._stale_app_networks(str(app_name))
 
@@ -2739,6 +2730,17 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "networks": networks,
         }
 
+    @staticmethod
+    def _filter_app_networks(networks: Any) -> list[dict[str, Any]]:
+        """Return only well-formed network entries (dicts with an interface_name)."""
+        if not isinstance(networks, list):
+            return []
+        return [
+            net
+            for net in networks
+            if isinstance(net, dict) and bool(net.get("interface_name"))
+        ]
+
     def _stale_app_networks(self, app_name: str) -> list[dict[str, Any]]:
         """Return the app's last known interfaces as stale stubs.
 
@@ -2749,9 +2751,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         kept with ``None`` values and ``stale=True`` so the sensors survive and
         merely become unavailable until the app reports live traffic again.
         """
-        previous = self.ds["app_stats"].get(app_name, {}).get("networks")
-        if not isinstance(previous, list):
-            return []
+        previous = self._filter_app_networks(
+            self.ds.get("app_stats", {}).get(app_name, {}).get("networks")
+        )
         return [
             {
                 "interface_name": net["interface_name"],
@@ -2760,7 +2762,6 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "stale": True,
             }
             for net in previous
-            if isinstance(net, dict) and net.get("interface_name")
         ]
 
     def _collect_current_app_names(self) -> set[str]:

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -1017,7 +1017,14 @@ class TrueNASAppStatsSensor(TrueNASEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
+        """Return True if entity is available.
+
+        Network sensors of a stopped app resolve to a stale interface stub (see
+        ``TrueNASCoordinator._stale_app_networks``); report them unavailable
+        rather than showing a stale or unknown rate.
+        """
+        if self._data.get("stale"):
+            return False
         return super().available
 
     @property

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -1023,7 +1023,7 @@ class TrueNASAppStatsSensor(TrueNASEntity, SensorEntity):
         ``TrueNASCoordinator._stale_app_networks``); report them unavailable
         rather than showing a stale or unknown rate.
         """
-        if self._data.get("stale"):
+        if isinstance(self._data, dict) and self._data.get("stale"):
             return False
         return super().available
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3540,3 +3540,63 @@ async def test_get_cronjob_falls_back_to_legacy_option_when_behaviors_absent() -
     )
     await coord.get_cronjob()
     assert coord.ds["cronjob"][3]["display_name"] == "Cronjob 3"
+
+
+# ---------------------------
+#   app.stats: stopped apps keep their network interfaces
+# ---------------------------
+def _stats_entry(name: str, networks: list[dict] | None) -> dict:
+    entry: dict = {"app_name": name, "cpu_usage": 0, "memory": 0}
+    if networks is not None:
+        entry["networks"] = networks
+    return entry
+
+
+def test_upsert_app_stats_keeps_known_interfaces_when_app_stops() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "app_stats": {
+            "plex": {
+                "app_name": "plex",
+                "networks": [
+                    {"interface_name": "eth0", "rx_bytes": 10, "tx_bytes": 20}
+                ],
+            }
+        }
+    }
+    coord._upsert_app_stats_entry(_stats_entry("plex", []))
+    assert coord.ds["app_stats"]["plex"]["networks"] == [
+        {"interface_name": "eth0", "rx_bytes": None, "tx_bytes": None, "stale": True}
+    ]
+
+
+def test_upsert_app_stats_no_interfaces_without_prior_knowledge() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app_stats": {}}
+    coord._upsert_app_stats_entry(_stats_entry("plex", []))
+    assert coord.ds["app_stats"]["plex"]["networks"] == []
+
+
+def test_upsert_app_stats_live_interfaces_replace_stale_ones() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "app_stats": {
+            "plex": {
+                "app_name": "plex",
+                "networks": [
+                    {
+                        "interface_name": "eth0",
+                        "rx_bytes": None,
+                        "tx_bytes": None,
+                        "stale": True,
+                    }
+                ],
+            }
+        }
+    }
+    coord._upsert_app_stats_entry(
+        _stats_entry("plex", [{"interface_name": "eth0", "rx_bytes": 5, "tx_bytes": 6}])
+    )
+    assert coord.ds["app_stats"]["plex"]["networks"] == [
+        {"interface_name": "eth0", "rx_bytes": 5, "tx_bytes": 6}
+    ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1040,3 +1040,59 @@ def test_app_stats_extra_state_attributes_no_data_returns_attribution_only() -> 
     sensor = TrueNASAppStatsSensor(coordinator, _app_stats_desc(), "plex")
     attrs = sensor.extra_state_attributes
     assert "app_name" not in attrs
+
+
+def test_app_stats_network_stale_interface_is_unavailable() -> None:
+    """A stopped app keeps its interfaces as stale stubs; the sensor must go
+    unavailable instead of being deleted and re-created on every stop/start."""
+    coordinator = make_coordinator(
+        data={
+            "app_stats": {
+                "plex": {
+                    "app_name": "Plex",
+                    "networks": [
+                        {
+                            "interface_name": "eth0",
+                            "rx_bytes": None,
+                            "tx_bytes": None,
+                            "stale": True,
+                        }
+                    ],
+                }
+            }
+        }
+    )
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx",
+        name="RX",
+        data_path="app_stats",
+        data_attribute="rx_bytes",
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex::eth0")
+    assert sensor.available is False
+    assert sensor.native_value is None
+    assert sensor.name == "Plex eth0 RX"
+
+
+def test_app_stats_network_live_interface_is_available() -> None:
+    coordinator = make_coordinator(
+        data={
+            "app_stats": {
+                "plex": {
+                    "app_name": "Plex",
+                    "networks": [
+                        {"interface_name": "eth0", "rx_bytes": 2048, "tx_bytes": 1}
+                    ],
+                }
+            }
+        }
+    )
+    desc = TrueNASSensorEntityDescription(
+        key="app_stats_network_rx",
+        name="RX",
+        data_path="app_stats",
+        data_attribute="rx_bytes",
+    )
+    sensor = TrueNASAppStatsSensor(coordinator, desc, "plex::eth0")
+    assert sensor.available is True
+    assert sensor.native_value == 2.0


### PR DESCRIPTION
## Proposed change
When an app is stopped, TrueNAS' `app.stats` event reports it with an empty `networks` list. The per-interface RX/TX sensors then drop out of the active unique-id set while their base is still live, so `_cleanup_orphaned_entities` deletes them from the entity registry — and re-registers them on the next start. Visible in the log as a `Registered new sensor.<host>_apps_<app>_eth0_network_rx/tx` / `Removing orphaned TrueNAS entity …` pair on every stop/start, and it loses history and any customisations (names, areas, hidden flags) each time.

This PR keeps the app's last known interfaces as stale stubs (`rx_bytes`/`tx_bytes` = `None`, `stale=True`) in `ds["app_stats"][app]["networks"]` when a stats entry arrives without networks, so the sensors survive; `TrueNASAppStatsSensor.available` returns `False` for a stale stub, so they show `unavailable` until the app reports live traffic again. Apps that are removed altogether are still pruned (`_prune_stale_app_stats`), so their sensors are still cleaned up.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Observed on TrueNAS 26.0 nightly with HA 2026.8; not specific to a version.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required. (CHANGELOG `Unreleased`)
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Preserve TrueNAS app network sensors across app stop/start cycles by retaining last-known interfaces as stale entries and marking corresponding sensors unavailable while the app is stopped.

Bug Fixes:
- Prevent per-interface app network RX/TX sensors from being deleted and re-created on every app stop by keeping stale network entries instead of dropping interfaces.

Enhancements:
- Add coordinator helpers to filter app network data and derive stale interface stubs from previous app stats when an app reports no networks.
- Update sensor availability logic so app network sensors backed by stale interface stubs report as unavailable rather than exposing stale or unknown values.

Documentation:
- Document the fix for app network sensors being deleted on every app stop in the changelog.

Tests:
- Add coordinator and sensor tests covering retention of stale app network interfaces and availability behavior for stopped versus live app network sensors.