### PR TITLE
feat(container): support the container.* API on TrueNAS 26+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
   and reports a `FAILED`/`ABORTED` job as an error instead of silently finishing. The
   coordinator poll keeps tracking (and clearing) jobs as a safety net, e.g. after an HA restart.
 
+### Fixed
+- **TrueNAS 26.0+ containers:** TrueNAS 26 removed the Incus-based `virt.*` API, so every poll
+  logged `API error: Method does not exist` and the Containers group stayed empty. Containers are
+  now read from `container.query` on 26.0+ (LXC / libvirt) with `container.start` /
+  `container.stop` for the actions (restart = stop job + start); TrueNAS 25.x keeps using
+  `virt.instance.*`. The 26.x entries carry no memory, image or IP information, so those
+  attributes read `0` / description / `unknown` there.
+
 ## [2.6.2] — TrueNAS 25.10+ update fix & device-registry hardening
 
 ### Fixed

--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -310,8 +310,15 @@ class TrueNASAPI:
         self,
         service: str,
         params: dict[str, Any] | list[Any] | None = None,
+        *,
+        job: bool = False,
     ) -> Any:
-        """Retrieve data from TrueNAS."""
+        """Retrieve data from TrueNAS.
+
+        With ``job=True`` the call is treated as a job: the client waits for
+        the job to finish and returns its result (or ``None`` on failure)
+        instead of the bare job id.
+        """
         if not self.connected() and not await self.connect():
             return None
 
@@ -319,7 +326,10 @@ class TrueNASAPI:
         _LOGGER.debug("TrueNAS %s query: %s, %s", self._host, service, params)
 
         try:
-            data = await self._client.call(service, params)
+            if job:
+                data = await self._client.call(service, params, job=True)
+            else:
+                data = await self._client.call(service, params)
         except TrueNASCallError as exc:
             self._error = exc.reason or str(exc) or ERR_UNKNOWN
             _log_call_error(self._host, exc)

--- a/custom_components/truenas_ce/binary_sensor.py
+++ b/custom_components/truenas_ce/binary_sensor.py
@@ -15,7 +15,10 @@ from .binary_sensor_types import (  # noqa: F401
     SENSOR_TYPES,
     TrueNASBinarySensorEntityDescription,
 )
-from .const import VIRT_INSTANCE_STOP_OPTIONS
+from .const import (
+    CONTAINER_STOP_OPTIONS,
+    VIRT_INSTANCE_STOP_OPTIONS,
+)
 from .entity import TrueNASEntity, async_add_entities
 
 _LOGGER = getLogger(__name__)
@@ -129,19 +132,25 @@ class TrueNASVMBinarySensor(TrueNASBinarySensor):
 #   TrueNASContainerBinarySensor
 # ---------------------------
 class TrueNASContainerBinarySensor(TrueNASBinarySensor):
-    """Define a TrueNAS Container (virt instance) Binary Sensor."""
+    """Define a TrueNAS Container Binary Sensor.
+
+    Containers are Incus ``virt.instance.*`` objects up to TrueNAS 25.x and
+    LXC ``container.*`` objects from 26.0 on; the coordinator's
+    ``supports_container_api`` picks the namespace.
+    """
 
     async def _current_status(self) -> str | None:
         """Return the container's live status, or None if it can't be determined.
 
         The cached coordinator status is stale right after a stop/start (until the
-        next poll), so the start/stop guards query the current state via
-        ``virt.instance.query`` (the response shape is known: top-level ``status``).
+        next poll), so the start/stop guards query the current state directly.
         A transient query failure returns None so the caller proceeds (fail-safe).
         """
+        v26 = self.coordinator.supports_container_api()
+        method = "container.query" if v26 else "virt.instance.query"
         try:
             instances = await self.coordinator.api.query(
-                "virt.instance.query", [[["id", "=", self._data["id"]]]]
+                method, [[["id", "=", self._data["id"]]]]
             )
         except Exception:
             _LOGGER.exception(
@@ -149,39 +158,64 @@ class TrueNASContainerBinarySensor(TrueNASBinarySensor):
             )
             return None
         instance = instances[0] if isinstance(instances, list) and instances else None
-        return instance.get("status") if isinstance(instance, dict) else None
+        if not isinstance(instance, dict):
+            return None
+        status = instance.get("status")
+        if v26:
+            # container.* nests the state: {"state": "RUNNING", ...}
+            return status.get("state") if isinstance(status, dict) else None
+        return status if isinstance(status, str) else None
 
     async def start(self) -> None:
-        """Start a container."""  # virt.instance.start
+        """Start a container."""
         # Only skip when positively running; if the status is unknown, proceed.
         if await self._current_status() == "RUNNING":
             _LOGGER.warning("Container %s is already running", self._data.get("name"))
             return
 
-        await self.coordinator.api.query("virt.instance.start", [self._data["id"]])
+        method = (
+            "container.start"
+            if self.coordinator.supports_container_api()
+            else "virt.instance.start"
+        )
+        await self.coordinator.api.query(method, [self._data["id"]])
         self._raise_if_api_error("start")
         await self.coordinator.async_request_refresh()
 
     async def stop(self) -> None:
-        """Stop a container."""  # virt.instance.stop
+        """Stop a container."""
         # Only skip when positively not running; if unknown, proceed.
         status = await self._current_status()
         if status is not None and status != "RUNNING":
             _LOGGER.warning("Container %s is not running", self._data.get("name"))
             return
 
-        await self.coordinator.api.query(
-            "virt.instance.stop", [self._data["id"], VIRT_INSTANCE_STOP_OPTIONS]
-        )
+        if self.coordinator.supports_container_api():
+            await self.coordinator.api.query(
+                "container.stop", [self._data["id"], CONTAINER_STOP_OPTIONS]
+            )
+        else:
+            await self.coordinator.api.query(
+                "virt.instance.stop", [self._data["id"], VIRT_INSTANCE_STOP_OPTIONS]
+            )
         self._raise_if_api_error("stop")
         await self.coordinator.async_request_refresh()
 
     async def restart(self) -> None:
-        """Restart a container."""  # virt.instance.restart
+        """Restart a container."""
         # A restart always applies (no state guard): it stops and starts again.
-        await self.coordinator.api.query(
-            "virt.instance.restart", [self._data["id"], VIRT_INSTANCE_STOP_OPTIONS]
-        )
+        if self.coordinator.supports_container_api():
+            # container.* has no restart method: wait for the stop job, then start.
+            await self.coordinator.api.query(
+                "container.stop", [self._data["id"], CONTAINER_STOP_OPTIONS], job=True
+            )
+            self._raise_if_api_error("restart")
+            await self.coordinator.api.query("container.start", [self._data["id"]])
+        else:
+            await self.coordinator.api.query(
+                "virt.instance.restart",
+                [self._data["id"], VIRT_INSTANCE_STOP_OPTIONS],
+            )
         self._raise_if_api_error("restart")
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/truenas_ce/binary_sensor.py
+++ b/custom_components/truenas_ce/binary_sensor.py
@@ -154,7 +154,9 @@ class TrueNASContainerBinarySensor(TrueNASBinarySensor):
             )
         except Exception:
             _LOGGER.exception(
-                "Failed to query status for container %s", self._data.get("name")
+                "Failed to query status for container %s via %s",
+                self._data.get("name"),
+                method,
             )
             return None
         instance = instances[0] if isinstance(instances, list) and instances else None

--- a/custom_components/truenas_ce/binary_sensor.py
+++ b/custom_components/truenas_ce/binary_sensor.py
@@ -209,6 +209,8 @@ class TrueNASContainerBinarySensor(TrueNASBinarySensor):
             await self.coordinator.api.query(
                 "container.stop", [self._data["id"], CONTAINER_STOP_OPTIONS], job=True
             )
+            # Abort before starting if the stop failed; the trailing check
+            # below then covers the start call.
             self._raise_if_api_error("restart")
             await self.coordinator.api.query("container.start", [self._data["id"]])
         else:

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -328,6 +328,9 @@ SCHEMA_SERVICE_CONTAINER_RESTART: VolDictType = {}
 # stop (force=True) with no graceful-shutdown wait (timeout=-1). Kept here so the
 # TrueNAS stop semantics are easy to adjust in one place.
 VIRT_INSTANCE_STOP_OPTIONS = {"force": True, "timeout": -1}
+# Options passed to container.stop on TrueNAS 26+ (LXC containers under the
+# container.* namespace): shut down gracefully, kill after shutdown_timeout.
+CONTAINER_STOP_OPTIONS = {"force": False, "force_after_timeout": True}
 
 SERVICE_APP_START = "app_start"
 SCHEMA_SERVICE_APP_START: VolDictType = {}

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -309,6 +309,25 @@ def _ups_value(graph_data: Any) -> float | None:
     return _netdata_mean_value(graph_data)
 
 
+def _cpuset_size(cpuset: Any) -> int:
+    """Return the number of CPUs in a cpuset string such as ``"0-3,6"``, else 0."""
+    if not isinstance(cpuset, str) or not cpuset.strip():
+        return 0
+    count = 0
+    for part in cpuset.split(","):
+        part = part.strip()
+        try:
+            if "-" in part:
+                start, end = (int(p) for p in part.split("-", 1))
+                count += max(0, end - start + 1)
+            elif part:
+                int(part)
+                count += 1
+        except ValueError:
+            return 0
+    return count
+
+
 def _first_ipv4(aliases: Any) -> str:
     """Return the first IPv4 address from a virt instance alias list, else 'unknown'."""
     if isinstance(aliases, list):
@@ -940,6 +959,18 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         optional reboot) moved to the new "update.run" method.
         """
         return (self._version_major, self._version_minor) >= (25, 10)
+
+    # ---------------------------
+    #   supports_container_api
+    # ---------------------------
+    def supports_container_api(self) -> bool:
+        """Return True if containers live under the ``container.*`` namespace.
+
+        TrueNAS 26.0 dropped the Incus-based ``virt.*`` API; LXC containers
+        are now managed through ``container.query`` / ``container.start`` /
+        ``container.stop`` (libvirt), with a different entry shape.
+        """
+        return (self._version_major, self._version_minor) >= (26, 0)
 
     # ---------------------------
     #   _detect_virtualization
@@ -1947,6 +1978,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["container"] = {}
             return
 
+        if self.supports_container_api():
+            await self._get_container_v26()
+            return
+
         instances = await self.api.query("virt.instance.query")
         if isinstance(instances, list):
             containers = [
@@ -1993,6 +2028,53 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["container"][uid]["memory"] = round(memory / 1048576)
             self.ds["container"][uid]["running"] = vals.get("status") == "RUNNING"
             self.ds["container"][uid]["ip_address"] = _first_ipv4(vals.get("aliases"))
+
+    async def _get_container_v26(self) -> None:
+        """Get LXC containers via ``container.query`` (TrueNAS 26.0+).
+
+        The entry carries no memory, image or IP information and its status
+        is nested (``status.state``); the resulting record keeps the same keys
+        as the Incus path so entities and attributes are unchanged.
+        """
+        containers = await self.api.query("container.query")
+        if not isinstance(containers, list):
+            _LOGGER.debug(
+                "container.query returned %s (expected list); no containers",
+                type(containers).__name__,
+            )
+            containers = []
+
+        self.ds["container"] = parse_api(
+            data=self.ds["container"],
+            source=containers,
+            key="id",
+            vals=[
+                {"name": "id", "default": "unknown"},
+                {"name": "name", "default": "unknown"},
+                {"name": "cpuset", "default": None},
+                {"name": "autostart", "type": "bool", "default": False},
+                {"name": "image", "source": "description", "default": "unknown"},
+                {"name": "status", "source": "status/state", "default": "unknown"},
+            ],
+            ensure_vals=[
+                {"name": "type", "default": "CONTAINER"},
+                {"name": "cpu", "default": 0},
+                {"name": "memory", "default": 0},
+                {"name": "aliases", "default": []},
+                {"name": "running", "type": "bool", "default": False},
+                {"name": "ip_address", "default": "unknown"},
+            ],
+        )
+
+        for vals in self.ds["container"].values():
+            vals["type"] = "CONTAINER"
+            vals["cpu"] = _cpuset_size(vals.pop("cpuset", None))
+            vals["memory"] = 0
+            vals["aliases"] = []
+            vals["ip_address"] = "unknown"
+            if not vals.get("image"):
+                vals["image"] = "unknown"
+            vals["running"] = vals.get("status") == "RUNNING"
 
     # ---------------------------
     #   get_directoryservices

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -310,21 +310,27 @@ def _ups_value(graph_data: Any) -> float | None:
 
 
 def _cpuset_size(cpuset: Any) -> int:
-    """Return the number of CPUs in a cpuset string such as ``"0-3,6"``, else 0."""
+    """Return the number of CPUs in a cpuset string such as ``"0-3,6"``.
+
+    Malformed segments are skipped (logged at debug level) so a partially
+    valid cpuset still yields the count of its valid CPUs.
+    """
     if not isinstance(cpuset, str) or not cpuset.strip():
         return 0
     count = 0
     for part in cpuset.split(","):
         part = part.strip()
+        if not part:
+            continue
         try:
             if "-" in part:
                 start, end = (int(p) for p in part.split("-", 1))
                 count += max(0, end - start + 1)
-            elif part:
+            else:
                 int(part)
                 count += 1
         except ValueError:
-            return 0
+            _LOGGER.debug("Ignoring malformed cpuset segment %r in %r", part, cpuset)
     return count
 
 

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -83,4 +83,5 @@ def make_coordinator(
         async_count_orphans_with_data=AsyncMock(return_value=0),
         raise_migration_rollback_issue=MagicMock(),
         supports_update_run=MagicMock(return_value=False),
+        supports_container_api=MagicMock(return_value=False),
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -375,6 +375,13 @@ async def test_query_returns_none_when_connect_fails(closed_api: TrueNASAPI) -> 
 async def test_query_returns_data_on_success(connected_api: TrueNASAPI) -> None:
     connected_api._client.call.return_value = {"ok": True}
     assert await connected_api.query("system.info") == {"ok": True}
+    connected_api._client.call.assert_awaited_once_with("system.info", None)
+
+
+async def test_query_job_waits_for_job_result(connected_api: TrueNASAPI) -> None:
+    connected_api._client.call.return_value = None
+    assert await connected_api.query("container.stop", [1], job=True) is None
+    connected_api._client.call.assert_awaited_once_with("container.stop", [1], job=True)
 
 
 async def test_query_call_error_uses_reason(connected_api: TrueNASAPI) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -14,7 +14,10 @@ from custom_components.truenas_ce.binary_sensor import (
 from custom_components.truenas_ce.binary_sensor_types import (
     TrueNASBinarySensorEntityDescription,
 )
-from custom_components.truenas_ce.const import VIRT_INSTANCE_STOP_OPTIONS
+from custom_components.truenas_ce.const import (
+    CONTAINER_STOP_OPTIONS,
+    VIRT_INSTANCE_STOP_OPTIONS,
+)
 
 _DESC = TrueNASBinarySensorEntityDescription(
     key="k", name="N", data_path="vm", data_is_on="running"
@@ -165,6 +168,52 @@ async def test_container_restart_always_calls_and_refreshes() -> None:
     ct.coordinator.api.query.assert_awaited_once_with(
         "virt.instance.restart", ["c1", VIRT_INSTANCE_STOP_OPTIONS]
     )
+    ct.coordinator.async_request_refresh.assert_awaited_once()
+
+
+# TrueNAS 26+: LXC containers under container.* (virt.* is gone)
+def _make_container_v26(data: dict | None = None) -> TrueNASContainerBinarySensor:
+    ct = _make_container({"id": 7, **(data or {})})
+    ct.coordinator.supports_container_api.return_value = True
+    return ct
+
+
+async def test_container_v26_current_status_reads_nested_state() -> None:
+    ct = _make_container_v26()
+    ct.coordinator.api.query.return_value = [{"status": {"state": "RUNNING"}}]
+    assert await ct._current_status() == "RUNNING"
+    ct.coordinator.api.query.assert_awaited_once_with(
+        "container.query", [[["id", "=", 7]]]
+    )
+
+
+async def test_container_v26_start_success() -> None:
+    ct = _make_container_v26()
+    ct.coordinator.api.query.side_effect = [[{"status": {"state": "STOPPED"}}], None]
+    await ct.start()
+    ct.coordinator.api.query.assert_awaited_with("container.start", [7])
+    ct.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_container_v26_stop_success() -> None:
+    ct = _make_container_v26()
+    ct.coordinator.api.query.side_effect = [[{"status": {"state": "RUNNING"}}], None]
+    await ct.stop()
+    ct.coordinator.api.query.assert_awaited_with(
+        "container.stop", [7, CONTAINER_STOP_OPTIONS]
+    )
+    ct.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_container_v26_restart_stops_then_starts() -> None:
+    ct = _make_container_v26()
+    await ct.restart()
+    assert [c.args for c in ct.coordinator.api.query.await_args_list] == [
+        ("container.stop", [7, CONTAINER_STOP_OPTIONS]),
+        ("container.start", [7]),
+    ]
+    # The stop is a job; wait for it before starting again.
+    assert ct.coordinator.api.query.await_args_list[0].kwargs == {"job": True}
     ct.coordinator.async_request_refresh.assert_awaited_once()
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
 from _fakes import make_coordinator
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.truenas_ce.binary_sensor import (
     TrueNASAppBinarySensor,
@@ -215,6 +217,17 @@ async def test_container_v26_restart_stops_then_starts() -> None:
     # The stop is a job; wait for it before starting again.
     assert ct.coordinator.api.query.await_args_list[0].kwargs == {"job": True}
     ct.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_container_v26_restart_stop_error_prevents_start() -> None:
+    ct = _make_container_v26()
+    ct.coordinator.api.error = "middleware down"
+    with pytest.raises(HomeAssistantError):
+        await ct.restart()
+    ct.coordinator.api.query.assert_awaited_once_with(
+        "container.stop", [7, CONTAINER_STOP_OPTIONS], job=True
+    )
+    ct.coordinator.async_request_refresh.assert_not_awaited()
 
 
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -52,6 +52,7 @@ from custom_components.truenas_ce.coordinator import (
     _arc_value,
     _as_int,
     _count_statistics_with_data,
+    _cpuset_size,
     _first_ipv4,
     _is_truenas_sensor_id,
     _median,
@@ -2848,6 +2849,21 @@ async def test_get_container_v26_uses_container_query() -> None:
     assert ct8["running"] is False
     assert ct8["cpu"] == 0
     assert ct8["image"] == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("cpuset", "expected"),
+    [
+        ("0-3,6", 5),
+        ("2", 1),
+        ("", 0),
+        (None, 0),
+        ("0-1,x,4", 3),
+        ("3-1", 0),
+    ],
+)
+def test_cpuset_size(cpuset: str | None, expected: int) -> None:
+    assert _cpuset_size(cpuset) == expected
 
 
 def test_supports_container_api_from_26() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -69,6 +69,8 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord.orphaned_statistics = []
     coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
     coord.host = "truenas.local"
+    coord._version_major = 0
+    coord._version_minor = 0
     return coord
 
 
@@ -2798,6 +2800,62 @@ async def test_get_container_filters_container_type_and_computes_fields() -> Non
     assert coord.ds["container"]["c1"]["memory"] == 1
     assert coord.ds["container"]["c1"]["running"] is True
     assert coord.ds["container"]["c1"]["ip_address"] == "10.0.0.5"
+
+
+async def test_get_container_v26_uses_container_query() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
+    coord._version_major, coord._version_minor = 26, 0
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 7,
+                "uuid": "8c8b3d3e-0000-4000-8000-000000000000",
+                "name": "debian",
+                "description": "Debian 13",
+                "autostart": True,
+                "cpuset": "0-3,6",
+                "dataset": "tank/.containers/debian",
+                "status": {"state": "RUNNING", "pid": 1234, "domain_state": "running"},
+            },
+            {
+                "id": 8,
+                "name": "alpine",
+                "description": "",
+                "autostart": False,
+                "cpuset": None,
+                "dataset": "tank/.containers/alpine",
+                "status": {"state": "STOPPED", "pid": None, "domain_state": None},
+            },
+        ]
+    )
+    await coord.get_container()
+    coord.api.query.assert_awaited_once_with("container.query")
+    ct = coord.ds["container"][7]
+    assert ct["name"] == "debian"
+    assert ct["type"] == "CONTAINER"
+    assert ct["status"] == "RUNNING"
+    assert ct["running"] is True
+    assert ct["autostart"] is True
+    assert ct["cpu"] == 5
+    assert ct["memory"] == 0
+    assert ct["image"] == "Debian 13"
+    assert ct["ip_address"] == "unknown"
+    ct8 = coord.ds["container"][8]
+    assert ct8["running"] is False
+    assert ct8["cpu"] == 0
+    assert ct8["image"] == "unknown"
+
+
+def test_supports_container_api_from_26() -> None:
+    coord = _bare_coordinator()
+    coord._version_major, coord._version_minor = 25, 10
+    assert coord.supports_container_api() is False
+    coord._version_major, coord._version_minor = 26, 0
+    assert coord.supports_container_api() is True
 
 
 async def test_get_container_normalizes_non_numeric_memory() -> None:


### PR DESCRIPTION
## Proposed change
TrueNAS 26.0 removed the Incus-based `virt.*` namespace entirely (there is no `virt.py` model in `truenas/middleware` `api/v26_0_0`, only `container*.py`, and the `plugins/virt` package is gone). LXC containers are now managed via `container.query` / `container.start` / `container.stop` (libvirt), with a different entry shape: `id: int`, `name`, `description`, `autostart`, `cpuset`, `dataset`, `devices`, `status: {state: RUNNING|STOPPED|SUSPENDED, pid, domain_state}` — no `memory`, `image` or `aliases`.

On 26.x the integration still called `virt.instance.query`, so every poll logged `TrueNAS <host> API error: Method does not exist` and the Containers group stayed empty; start/stop/restart actions could not work either.

This PR gates on the already-parsed TrueNAS version (`supports_container_api()`, `>= 26.0`, same pattern as `supports_update_run()` for 25.10):

- `TrueNASCoordinator.get_container` reads `container.query` on 26+ and normalizes it into the existing container record (`status` ← `status.state`, `cpu` ← size of `cpuset`, `image` ← `description`, `memory`/`aliases`/`ip_address` defaulted) so entities/attributes are unchanged. 25.x keeps the `virt.instance.query` path untouched.
- `TrueNASContainerBinarySensor` uses `container.query` (nested `status.state`) for the live-status guard, `container.start [id]` / `container.stop [id, {force: false, force_after_timeout: true}]` for the actions, and stop-job-then-start for restart (there is no `container.restart`).
- `TrueNASAPI.query(..., job=True)` passes through to `aiotruenas.TrueNASClient.call(job=True)` so the stop job can be awaited before starting again.

## Type of change
- [x] Bugfix
- [x] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Shape/method names taken from `truenas/middleware` master (`api/v26_0_0/container.py`, `plugins/container/lifecycle.py`). Verified against a TrueNAS `26.0.0-MASTER` box that `virt.instance.query` is gone and `container.query` / `container.start` / `container.stop` exist; that box currently has no containers, so the entity path is covered by unit tests only — a live check with a real LXC container on 26.x would be welcome.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required. (CHANGELOG `Unreleased`)
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Support TrueNAS 26+ container.* API while preserving existing container entities and behavior.

New Features:
- Add support for managing containers via the TrueNAS 26+ container.* API, including live status, start, stop, and restart actions.
- Introduce graceful-stop options for LXC containers using the new container.stop semantics.

Bug Fixes:
- Resolve failures and empty container groups caused by calling the removed virt.instance.* API on TrueNAS 26+.
- Normalize TrueNAS 26+ container records so missing memory, image, and IP fields do not break existing entity attributes.

Enhancements:
- Add version-gated detection of the container.* namespace to switch seamlessly between Incus virt.instance.* and LXC container.* APIs.
- Derive CPU counts from cpuset strings for TrueNAS 26+ containers to keep resource metrics consistent.
- Extend the TrueNAS API wrapper to optionally treat calls as jobs and wait for completion results.

Documentation:
- Update the changelog with details of TrueNAS 26+ container API support and behavior changes.

Tests:
- Add unit tests covering cpuset parsing, container.* API support gating, 26+ container querying and normalization, and container binary sensor behavior for LXC containers.
- Add tests verifying the new job-aware query path in the TrueNAS API wrapper.