### PR TITLE
fix: guard app-stats sensor discovery against cross-entry signal identity

### DIFF
--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -83,6 +83,9 @@ async def async_setup_entry(
         # instance's entities and try to add them here, causing "Platform truenas
         # does not generate unique IDs … already exists" spam (#33).
         if updated_coordinator is not None and updated_coordinator is not coordinator:
+            _LOGGER.debug(
+                "Ignoring app-stats refresh from other config entry's coordinator"
+            )
             return
         _discover_app_stats(platform, coordinator, _async_add_entities)
 

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -127,6 +127,10 @@ def _discover_app_stats(
     """
     app_stats_data = coord.data.get("app_stats", {})
     if not isinstance(app_stats_data, dict):
+        _LOGGER.warning(
+            "TrueNAS app stats returned malformed data: %s",
+            app_stats_data,
+        )
         app_stats_data = {}
     app_stats_entities: list[TrueNASAppStatsSensor] = []
 

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -75,16 +75,16 @@ async def async_setup_entry(
     def _discover_app_stats_sensors(
         updated_coordinator: TrueNASCoordinator | None = None,
     ) -> None:
-        # SIGNAL_UPDATE_SENSORS is a global dispatcher signal that __init__ always
-        # fires with the *same* coordinator instance object (one per config entry),
-        # so the identity check below is safe. With more than one TrueNAS config
-        # entry every platform receives every entry's refresh, so ignore refreshes
-        # from other entries — otherwise this platform would build the *other*
-        # instance's entities and try to add them here, causing "Platform truenas
-        # does not generate unique IDs … already exists" spam (#33).
+        # SIGNAL_UPDATE_SENSORS fires for every config entry on every platform,
+        # so with multiple TrueNAS entries this platform would otherwise build
+        # the *other* entry's entities too, causing "already exists" spam (#33).
+        # __init__ always passes the same coordinator instance per entry, so an
+        # identity check reliably tells them apart.
         if updated_coordinator is not None and updated_coordinator is not coordinator:
             _LOGGER.debug(
-                "Ignoring app-stats refresh from other config entry's coordinator"
+                "Ignoring app-stats refresh for %s (this platform belongs to %s)",
+                updated_coordinator.name,
+                coordinator.name,
             )
             return
         _discover_app_stats(platform, coordinator, _async_add_entities)

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -75,9 +75,16 @@ async def async_setup_entry(
     def _discover_app_stats_sensors(
         updated_coordinator: TrueNASCoordinator | None = None,
     ) -> None:
-        _discover_app_stats(
-            platform, updated_coordinator or coordinator, _async_add_entities
-        )
+        # SIGNAL_UPDATE_SENSORS is a global dispatcher signal that __init__ always
+        # fires with the *same* coordinator instance object (one per config entry),
+        # so the identity check below is safe. With more than one TrueNAS config
+        # entry every platform receives every entry's refresh, so ignore refreshes
+        # from other entries — otherwise this platform would build the *other*
+        # instance's entities and try to add them here, causing "Platform truenas
+        # does not generate unique IDs … already exists" spam (#33).
+        if updated_coordinator is not None and updated_coordinator is not coordinator:
+            return
+        _discover_app_stats(platform, coordinator, _async_add_entities)
 
     _discover_app_stats_sensors()
     config_entry.async_on_unload(
@@ -116,6 +123,8 @@ def _discover_app_stats(
         ``app_name::interface_name`` so apps sharing an NIC name remain unique
     """
     app_stats_data = coord.data.get("app_stats", {})
+    if not isinstance(app_stats_data, dict):
+        app_stats_data = {}
     app_stats_entities: list[TrueNASAppStatsSensor] = []
 
     loaded = {

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -82,9 +82,12 @@ async def async_setup_entry(
         # identity check reliably tells them apart.
         if updated_coordinator is not None and updated_coordinator is not coordinator:
             _LOGGER.debug(
-                "Ignoring app-stats refresh for %s (this platform belongs to %s)",
+                "Ignoring app-stats refresh for %s (%s); this platform belongs to "
+                "%s (%s)",
                 updated_coordinator.name,
+                updated_coordinator.config_entry.entry_id,
                 coordinator.name,
+                coordinator.config_entry.entry_id,
             )
             return
         _discover_app_stats(platform, coordinator, _async_add_entities)


### PR DESCRIPTION
## Proposed change

`SIGNAL_UPDATE_SENSORS` is a global dispatcher signal that `__init__` fires for every config entry on every platform. With more than one TrueNAS config entry, each platform's app-stats discovery callback also runs for refreshes belonging to *other* config entries, building entities that belong to the other coordinator instance and causing `Platform truenas does not generate unique IDs ... already exists` errors (#33).

This adds an identity check so the app-stats discovery callback ignores refreshes whose coordinator instance doesn't match the platform's own coordinator.

Also adds a defensive `isinstance(dict)` check when reading `app_stats_data` from the coordinator, so malformed/unexpected data can't reach the discovery loop below (matches the codebase's existing defensive style around API responses).

Fixes #33.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Verified locally: `ruff check`, `ruff format --check`, `mypy`, `bandit` all clean; `pytest tests/test_sensor.py -q` (105 passed). Also live-tested on a real Home Assistant instance via a full restart — no TrueNAS-related errors in the logs and specifically zero "unique IDs ... already exists" errors after the fix, with all app-stats sensors populated correctly.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Guard TrueNAS app-stats sensor discovery against cross-entry coordinator signals to prevent duplicate entity creation errors.

Bug Fixes:
- Ensure app-stats sensors only react to updates from their own coordinator to avoid cross-entry entity collisions and duplicate unique ID errors.
- Handle malformed or non-dict app stats data defensively so invalid responses do not enter the sensor discovery loop.