### PR TITLE
fix: guard app-network data resolution against non-dict app_stats entries

### DIFF
--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -240,8 +240,10 @@ def _resolve_app_network_data(
     base_uid, interface_name = _parse_app_network_uid(uid)
     if base_uid is None or interface_name is None:
         return None
-    main_data = app_stats.get(base_uid, {})
-    if not main_data or not isinstance(main_data.get("networks"), list):
+    main_data = app_stats.get(base_uid)
+    if not isinstance(main_data, dict) or not isinstance(
+        main_data.get("networks"), list
+    ):
         return None
     return next(
         (

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -80,6 +80,11 @@ def test_resolve_app_network_data_networks_not_list_returns_none() -> None:
     assert _resolve_app_network_data("plex::eth0", app_stats) is None
 
 
+def test_resolve_app_network_data_base_entry_not_dict_returns_none() -> None:
+    app_stats = {"plex": "not-a-dict"}
+    assert _resolve_app_network_data("plex::eth0", app_stats) is None
+
+
 def test_resolve_app_network_data_no_matching_interface_returns_none() -> None:
     app_stats = {"plex": {"networks": [{"interface_name": "eth1"}]}}
     assert _resolve_app_network_data("plex::eth0", app_stats) is None


### PR DESCRIPTION
## Proposed change

`_resolve_app_network_data` assumed `app_stats.get(base_uid, {})` always
returned a `dict`, then called `.get()` on it again without checking. A
non-dict truthy value (malformed/unexpected API response shape) would raise
`AttributeError` instead of resolving to `None` like the other malformed-data
cases already handled here. Adds an `isinstance(main_data, dict)` guard,
matching this project's existing defensive-coding convention for API
responses. Flagged by GitHub Copilot review on the ha-core mirror PR
(home-assistant/core#179103); same underlying bug also present here since
both share the app-stats sensor helper code.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Regression test added: `test_resolve_app_network_data_base_entry_not_dict_returns_none`.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Guard app network data resolution against malformed app statistics entries that are not dictionaries.

Bug Fixes:
- Prevent _resolve_app_network_data from raising AttributeError when the app_stats base entry is not a dict by validating the data structure before access.

Tests:
- Add a regression test to verify that _resolve_app_network_data returns None when the base app_stats entry is not a dict.