### PR TITLE
fix: remove dead write-only attribute in TrueNASAppStatsSensor

### DIFF
--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -1007,7 +1007,6 @@ class TrueNASAppStatsSensor(TrueNASEntity, SensorEntity):
                 self._data = resolved or {}
             else:
                 self._data = {}
-            self._has_valid_interface_payload = bool(resolved)
             if not resolved:
                 _LOGGER.debug(
                     "Network sensor %s (%s) could not resolve interface data",


### PR DESCRIPTION
## Proposed change
`TrueNASAppStatsSensor._refresh_data()` set `self._has_valid_interface_payload = bool(resolved)`, but nothing in the class ever reads this attribute. It's dead, write-only state left over from an earlier implementation. This removes the assignment; the existing `if not resolved:` debug-logging branch right below it is unaffected and unchanged.

## Type of change
- [x] Code quality improvements to existing code or addition of tests

## Additional information
No behavior change — this is a pure dead-code removal, confirmed via repo-wide grep that `_has_valid_interface_payload` had no readers.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works. (n/a — no behavior change)
- [ ] Documentation added/updated if required. (n/a)
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Enhancements:
- Clean up dead assignment of an unused sensor attribute without changing runtime behavior.