### PR TITLE
fix: address home-assistant/core#179103 review findings

### DIFF
--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -8,7 +8,6 @@ from logging import DEBUG, ERROR, Filter, LogRecord, getLogger
 from typing import Any
 
 from aiotruenas import TrueNASClient
-from aiotruenas.client import _SubscriptionTerminator
 from aiotruenas.exceptions import (
     TrueNASAuthenticationError,
     TrueNASCallError,
@@ -198,9 +197,11 @@ class TrueNASAPI:
         ----------
         host:
             Bare TrueNAS hostname or IP address without scheme or path
-            (for example, ``"truenas.local"`` or ``"192.168.1.10"``).
-            Values containing a URL scheme (``"://"``) or path (``"/"``)
-            are rejected to prevent malformed WebSocket URLs.
+            (for example, ``"truenas.local"`` or ``"192.168.1.10"``). This
+            class does not itself validate or strip a scheme/path -- callers
+            (``config_flow._sanitize_host``) are expected to normalize user
+            input before constructing this class, to avoid malformed
+            WebSocket URLs.
         api_key:
             API key used to authenticate with the TrueNAS API.
         verify_ssl:
@@ -359,11 +360,18 @@ class TrueNASAPI:
     # ---------------------------
     async def subscribe_events(
         self, event: str
-    ) -> (
-        tuple[str, asyncio.Queue[dict[str, Any] | _SubscriptionTerminator]]
-        | tuple[None, None]
-    ):
-        """Subscribe to an event and return (subscription_id, queue)."""
+    ) -> tuple[str, asyncio.Queue[Any]] | tuple[None, None]:
+        """Subscribe to an event and return (subscription_id, queue).
+
+        The queue yields either raw event payload dicts or aiotruenas's
+        internal subscription-terminator sentinel (an unstable, underscored
+        symbol we deliberately avoid importing); callers should just treat
+        any non-dict item as end-of-subscription. ``asyncio.Queue`` is
+        invariant, so the item type must stay structurally compatible with
+        aiotruenas's own (private) return type -- ``Any`` achieves that
+        without importing the private symbol; a plain ``object`` would not,
+        since it is a supertype rather than a structural match.
+        """
         if not self.connected() and not await self.connect():
             self._error = self._error or ERR_CONNECTION_REFUSED
             _LOGGER.warning(

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -98,7 +98,6 @@ def register_system_device(
     http_scheme = "https" if coordinator.api.scheme == "wss" else "http"
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        connections={(DOMAIN, identifier)},
         identifiers={(DOMAIN, identifier)},
         name=inst,
         model=f"{system_info['system_product']}",

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -225,10 +225,13 @@ def _parse_app_network_uid(uid: str) -> tuple[str | None, str | None]:
     return (base_uid, iface) if sep and base_uid and iface else (None, None)
 
 
-def _resolve_app_network_data(
-    uid: str, app_stats: dict[str, Any]
-) -> dict[str, Any] | None:
+def _resolve_app_network_data(uid: str, app_stats: Any) -> dict[str, Any] | None:
     """Resolve a composite app-network UID to its merged sensor data.
+
+    ``app_stats`` is typed ``Any`` rather than ``dict[str, Any]``: callers
+    pass it straight from ``coordinator.data.get("app_stats", {})``, which
+    can be a malformed non-dict payload on a broken API response, so this
+    function must runtime-check it rather than trust the static type.
 
     Uses ``_APP_STATS_NETWORK_UID_SEPARATOR`` to split the UID, then looks up
     the base app in ``app_stats`` and merges the matching network interface
@@ -239,6 +242,8 @@ def _resolve_app_network_data(
     """
     base_uid, interface_name = _parse_app_network_uid(uid)
     if base_uid is None or interface_name is None:
+        return None
+    if not isinstance(app_stats, dict):
         return None
     main_data = app_stats.get(base_uid)
     if not isinstance(main_data, dict) or not isinstance(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -75,6 +75,10 @@ def test_resolve_app_network_data_unknown_base_returns_none() -> None:
     assert _resolve_app_network_data("plex::eth0", {}) is None
 
 
+def test_resolve_app_network_data_non_dict_app_stats_returns_none() -> None:
+    assert _resolve_app_network_data("plex::eth0", "not-a-dict") is None
+
+
 def test_resolve_app_network_data_networks_not_list_returns_none() -> None:
     app_stats = {"plex": {"networks": "not-a-list"}}
     assert _resolve_app_network_data("plex::eth0", app_stats) is None


### PR DESCRIPTION
## Proposed change

Fixes surfaced by reviewers on the `home-assistant/core` submission (home-assistant/core#179103) that apply equally to this repo's identical code:

- **api.py**: dropped the private `aiotruenas.client._SubscriptionTerminator` import (API-stability risk); the `subscribe_events` queue item is now typed `Any` instead, since `asyncio.Queue` is invariant and must stay structurally compatible with aiotruenas's own (private) return type — a plain `object` breaks that compatibility.
- **api.py**: corrected the `TrueNASAPI.__init__` docstring, which claimed this class rejects hosts containing a scheme/path — that validation actually happens upstream in `config_flow._sanitize_host`, not here.
- **entity.py**: removed the non-standard `connections={(DOMAIN, identifier)}` from the system device registration (`connections` is meant for standardized types like MAC/BT/Zigbee); `identifiers` alone is correct here.
- **sensor.py**: `_resolve_app_network_data` now guards against a non-dict `app_stats` payload (a Copilot review finding — a malformed API response could otherwise raise `AttributeError` instead of degrading gracefully).

## Type of change
- [x] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

The same fixes have been mirrored into the `home-assistant/core` fork (branch `truenas_ce`, PR #179103).

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.