### PR TITLE
fix: log the failing method/event name on TrueNAS API call errors

### DIFF
--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -152,8 +152,13 @@ def _classify_exception(exc: TrueNASError, *, during_call: bool) -> str:
     )
 
 
-def _log_call_error(host: str, exc: TrueNASCallError) -> None:
+def _log_call_error(host: str, context: str, exc: TrueNASCallError) -> None:
     """Log a TrueNAS call error, quietly for expected permission errors.
+
+    ``context`` is the service/event/subscription identifier the error
+    occurred on, so recurring errors (e.g. a method unsupported by the
+    TrueNAS version, see #81) can be traced back to their source instead of
+    only showing the bare exception text.
 
     A read-only-scoped API key gets an ``EACCES`` response from admin-only
     methods (e.g. ``smb.status``). That is a permanent, expected condition
@@ -166,6 +171,7 @@ def _log_call_error(host: str, exc: TrueNASCallError) -> None:
         DEBUG if permission_denied else ERROR,
         ERROR_API_FORMAT,
         host,
+        context,
         exc,
         exc_info=None if permission_denied else exc,
     )
@@ -332,7 +338,7 @@ class TrueNASAPI:
                 data = await self._client.call(service, params)
         except TrueNASCallError as exc:
             self._error = exc.reason or str(exc) or ERR_UNKNOWN
-            _log_call_error(self._host, exc)
+            _log_call_error(self._host, service, exc)
             return None
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)
@@ -380,7 +386,7 @@ class TrueNASAPI:
             return await self._client.subscribe(event)
         except TrueNASCallError as exc:
             self._error = exc.reason or str(exc) or ERR_UNKNOWN
-            _log_call_error(self._host, exc)
+            _log_call_error(self._host, event, exc)
             return None, None
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)
@@ -417,7 +423,7 @@ class TrueNASAPI:
                 subscription_id,
                 exc,
             )
-            _LOGGER.exception(ERROR_API_FORMAT, self._host, exc)
+            _LOGGER.exception(ERROR_API_FORMAT, self._host, subscription_id, exc)
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)
             _LOGGER.warning(
@@ -459,7 +465,7 @@ class TrueNASAPI:
             return events
         except TrueNASCallError as exc:
             self._error = exc.reason or str(exc) or ERR_UNKNOWN
-            _log_call_error(self._host, exc)
+            _log_call_error(self._host, subscription_id, exc)
             return []
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -337,4 +337,4 @@ SCHEMA_SERVICE_APP_START: VolDictType = {}
 SERVICE_APP_STOP = "app_stop"
 SCHEMA_SERVICE_APP_STOP: VolDictType = {}
 
-ERROR_API_FORMAT = "TrueNAS %s API error: %s"
+ERROR_API_FORMAT = "TrueNAS %s API error calling %s: %s"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -550,6 +550,21 @@ async def test_unsubscribe_events_handles_call_error(connected_api: TrueNASAPI) 
     assert connected_api.error == ""
 
 
+async def test_unsubscribe_events_logs_error_with_subscription_id(
+    connected_api: TrueNASAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    exc = TrueNASCallError("boom", code=22, errname="EINVAL", reason="bad params")
+    connected_api._client.unsubscribe = AsyncMock(side_effect=exc)
+    with caplog.at_level("DEBUG", logger=api_module.__name__):
+        await connected_api.unsubscribe_events("sub-123")
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert error_records
+    assert all(record.exc_info is not None for record in error_records)
+    expected_message = ERROR_API_FORMAT % ("truenas.local", "sub-123", exc)
+    assert any(record.getMessage() == expected_message for record in error_records)
+
+
 async def test_unsubscribe_events_handles_generic_error(
     connected_api: TrueNASAPI,
 ) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -467,7 +467,9 @@ async def test_query_non_permission_call_error_still_logs_error(
     assert error_records
     assert all(record.exc_info is not None for record in error_records)
     assert any(
-        "truenas.local" in record.getMessage() and "boom" in record.getMessage()
+        "truenas.local" in record.getMessage()
+        and "system.info" in record.getMessage()
+        and "boom" in record.getMessage()
         for record in error_records
     )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,6 +41,7 @@ from custom_components.truenas_ce.const import (
     ERR_TIMEOUT,
     ERR_UNKNOWN,
     ERR_UNKNOWN_HOSTNAME,
+    ERROR_API_FORMAT,
 )
 
 
@@ -458,20 +459,15 @@ async def test_query_non_permission_call_error_still_logs_error(
     connected_api: TrueNASAPI,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    connected_api._client.call.side_effect = TrueNASCallError(
-        "boom", code=22, errname="EINVAL", reason="bad params"
-    )
+    exc = TrueNASCallError("boom", code=22, errname="EINVAL", reason="bad params")
+    connected_api._client.call.side_effect = exc
     with caplog.at_level("DEBUG", logger=api_module.__name__):
         assert await connected_api.query("system.info") is None
     error_records = [record for record in caplog.records if record.levelname == "ERROR"]
     assert error_records
     assert all(record.exc_info is not None for record in error_records)
-    assert any(
-        "truenas.local" in record.getMessage()
-        and "system.info" in record.getMessage()
-        and "boom" in record.getMessage()
-        for record in error_records
-    )
+    expected_message = ERROR_API_FORMAT % ("truenas.local", "system.info", exc)
+    assert any(record.getMessage() == expected_message for record in error_records)
 
 
 # ---------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -523,11 +523,8 @@ async def test_subscribe_events_non_permission_call_error_still_logs_error(
     connected_api: TrueNASAPI,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    connected_api._client.subscribe = AsyncMock(
-        side_effect=TrueNASCallError(
-            "boom", code=22, errname="EINVAL", reason="bad params"
-        )
-    )
+    exc = TrueNASCallError("boom", code=22, errname="EINVAL", reason="bad params")
+    connected_api._client.subscribe = AsyncMock(side_effect=exc)
     with caplog.at_level("DEBUG", logger=api_module.__name__):
         sub_id, queue = await connected_api.subscribe_events("app.stats")
     assert sub_id is None
@@ -535,6 +532,8 @@ async def test_subscribe_events_non_permission_call_error_still_logs_error(
     error_records = [record for record in caplog.records if record.levelname == "ERROR"]
     assert error_records
     assert all(record.exc_info is not None for record in error_records)
+    expected_message = ERROR_API_FORMAT % ("truenas.local", "app.stats", exc)
+    assert any(record.getMessage() == expected_message for record in error_records)
 
 
 async def test_unsubscribe_events_calls_client(connected_api: TrueNASAPI) -> None:
@@ -607,17 +606,16 @@ async def test_get_subscription_events_non_permission_call_error_still_logs_erro
     connected_api: TrueNASAPI,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    connected_api._client.get_subscription_events = AsyncMock(
-        side_effect=TrueNASCallError(
-            "boom", code=22, errname="EINVAL", reason="bad params"
-        )
-    )
+    exc = TrueNASCallError("boom", code=22, errname="EINVAL", reason="bad params")
+    connected_api._client.get_subscription_events = AsyncMock(side_effect=exc)
     with caplog.at_level("DEBUG", logger=api_module.__name__):
         result = await connected_api.get_subscription_events("sub-123")
     assert result == []
     error_records = [record for record in caplog.records if record.levelname == "ERROR"]
     assert error_records
     assert all(record.exc_info is not None for record in error_records)
+    expected_message = ERROR_API_FORMAT % ("truenas.local", "sub-123", exc)
+    assert any(record.getMessage() == expected_message for record in error_records)
 
 
 async def test_get_subscription_events_generic_error(connected_api: TrueNASAPI) -> None:


### PR DESCRIPTION
## Proposed change
`ERROR_API_FORMAT` ("TrueNAS %s API error: %s") only logged the host and the exception text, not which `query()` call actually failed. That makes recurring errors like the "Method does not exist" reports in #81 (TrueNAS SCALE 26.0.0-BETA.2) impossible to trace back to a specific API method from the log alone.

`_log_call_error` now takes a `context` parameter (the service/event/subscription identifier) and includes it in the log line, at all three call sites (`query`, `subscribe_events`, `get_subscription_events`) plus the direct usage in `unsubscribe_events`.

This doesn't fix #81 itself (the exact TrueNAS-26 API incompatibility is still unconfirmed), but it's the prerequisite to actually diagnosing it -- the next occurrence will show the method name in the log.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Related to #81.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Add call context to TrueNAS API error logs to make recurring failures actionable.

Bug Fixes:
- Include the failing service, event, or subscription identifier in TrueNAS API error logs so call failures can be traced to their source.

Tests:
- Add coverage verifying contextual error messages for query, event subscription, subscription retrieval, and unsubscribe failures.