### PR TITLE
fix: address 3 more home-assistant/core#179103 review findings

### DIFF
--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -425,7 +425,6 @@ class TrueNASAPI:
                 subscription_id,
                 exc,
             )
-            _LOGGER.exception(ERROR_API_FORMAT, self._host, exc)
         except TrueNASError as exc:
             self._error = _classify_exception(exc, during_call=True)
             _LOGGER.warning(

--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -327,11 +327,11 @@ def generate_keymap(
     if not key_search:
         return None
     return {
-        data[uid][key_search]: uid
+        entry[key_search]: uid
         for uid in data
-        if isinstance(data[uid], dict)
-        and key_search in data[uid]
-        and isinstance(data[uid][key_search], Hashable)
+        if isinstance(entry := data[uid], dict)
+        and key_search in entry
+        and isinstance(entry[key_search], Hashable)
     }
 
 

--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -313,15 +313,23 @@ def get_uid(
 #   generate_keymap
 # ---------------------------
 def generate_keymap(
-    data: dict[str, dict[str, Any]], key_search: str | None
+    data: dict[str, Any], key_search: str | None
 ) -> dict[Hashable, str] | None:
-    """Generate keymap."""
+    """Generate keymap.
+
+    ``data``'s values are typed ``Any`` rather than ``dict[str, Any]``: this
+    is a general-purpose helper, and a future/unexpected caller could pass a
+    non-dict value for some uid, so the entry must be runtime-checked rather
+    than trusted from the static type.
+    """
     if not key_search:
         return None
     return {
         data[uid][key_search]: uid
         for uid in data
-        if key_search in data[uid] and isinstance(data[uid][key_search], Hashable)
+        if isinstance(data[uid], dict)
+        and key_search in data[uid]
+        and isinstance(data[uid][key_search], Hashable)
     }
 
 

--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -320,7 +320,9 @@ def generate_keymap(
     ``data``'s values are typed ``Any`` rather than ``dict[str, Any]``: this
     is a general-purpose helper, and a future/unexpected caller could pass a
     non-dict value for some uid, so the entry must be runtime-checked rather
-    than trusted from the static type.
+    than trusted from the static type. Entries whose value is not a dict, or
+    that lack ``key_search``, are silently ignored and excluded from the
+    returned keymap.
     """
     if not key_search:
         return None

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
+from .api import _summarize_payload
 from .const import (
     ATTRIBUTION,
     BEHAVIOR_REMOVE_INACTIVE_NIC,
@@ -300,10 +301,10 @@ def _collect_new_entities(
             # or _new_referenced_entities' unconditional .get() access.
             _LOGGER.debug(
                 "Skipping non-dict coordinator payload for data_path %s"
-                " (entity description key %s): %r",
+                " (entity description key %s): %s",
                 entity_description.data_path or "",
                 entity_description.key,
-                data,
+                _summarize_payload(data),
             )
             continue
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -298,6 +298,11 @@ def _collect_new_entities(
             # A malformed coordinator payload for this data_path would
             # otherwise raise AttributeError in _skip_keyless_description's
             # or _new_referenced_entities' unconditional .get() access.
+            _LOGGER.debug(
+                "Skipping non-dict coordinator payload for data_path %s: %r",
+                entity_description.data_path or "",
+                data,
+            )
             continue
 
         if entity_description.data_reference:

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -294,6 +294,11 @@ def _collect_new_entities(
         data = coordinator.data.get(entity_description.data_path or "")
         if data is None:
             continue
+        if not isinstance(data, dict):
+            # A malformed coordinator payload for this data_path would
+            # otherwise raise AttributeError in _skip_keyless_description's
+            # or _new_referenced_entities' unconditional .get() access.
+            continue
 
         if entity_description.data_reference:
             new_entities += _new_referenced_entities(

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -299,8 +299,10 @@ def _collect_new_entities(
             # otherwise raise AttributeError in _skip_keyless_description's
             # or _new_referenced_entities' unconditional .get() access.
             _LOGGER.debug(
-                "Skipping non-dict coordinator payload for data_path %s: %r",
+                "Skipping non-dict coordinator payload for data_path %s"
+                " (entity description key %s): %r",
                 entity_description.data_path or "",
+                entity_description.key,
                 data,
             )
             continue

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -159,6 +159,13 @@ def test_generate_keymap_ignores_non_dict_values(ap: ModuleType) -> None:
     assert ap.generate_keymap(data, "guid") == {"guid-2": "uid-2"}
 
 
+def test_generate_keymap_ignores_non_dict_value_containing_key_search_substring(
+    ap: ModuleType,
+) -> None:
+    data = {"uid-1": "has a guid in it", "uid-2": {"guid": "guid-2"}}
+    assert ap.generate_keymap(data, "guid") == {"guid-2": "uid-2"}
+
+
 def test_generate_keymap_skips_entries_missing_key_search(ap: ModuleType) -> None:
     data = {
         "uid-1": {"guid": "guid-1"},

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -192,6 +192,19 @@ def test_collect_new_entities_skips_missing_data_path() -> None:
     assert not result
 
 
+def test_collect_new_entities_skips_non_dict_data_path_payload() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="uptime",
+        name="Uptime",
+        data_path="system_info",
+        data_attribute="hostname",
+        func="TrueNASEntity",
+    )
+    coordinator = make_coordinator(data={"system_info": "not-a-dict"})
+    result = _collect_new_entities(coordinator, [desc], _dispatcher(), set())
+    assert not result
+
+
 def test_collect_new_entities_skips_app_stats_sensor_descriptions() -> None:
     desc = TrueNASSensorEntityDescription(
         key="k", name="N", data_path="disk", func="TrueNASAppStatsSensor"


### PR DESCRIPTION
## Proposed change
Mirrors 3 defensive-coding findings surfaced by the latest Copilot review on `home-assistant/core#179103` (our Home Assistant Core submission) that also apply to this codebase, since both share the same source:

- `apiparser.py`: `generate_keymap`'s `key_search` lookup degraded to a substring check on a non-dict value instead of a dict lookup — a coincidental substring match would raise `TypeError`. Guarded with `isinstance(data[uid], dict)`.
- `api.py`: `unsubscribe_events` logged twice on `TrueNASCallError` — a quiet debug message immediately followed by an unconditional ERROR-level traceback, defeating the point of logging quietly for an expected cleanup failure during shutdown/disconnect races. Dropped the stray exception log.
- `entity.py`: `_collect_new_entities` passed an unvalidated coordinator payload straight to `_skip_keyless_description`/`_new_referenced_entities`, which would raise `AttributeError` on a malformed non-dict `data_path` payload. Guarded with `isinstance(data, dict)`.

## Type of change
- [x] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Verified locally (worktree, isolated from the main working directory): `ruff check`/`ruff format --check` clean, `mypy` clean, `bandit` clean, `pytest -q` → 852 passed (850 + 2 new regression tests).

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden defensive handling of malformed data and reduce noisy logging during expected event-unsubscription failures.

Bug Fixes:
- Harden keymap generation and entity discovery against unexpected non-dictionary payloads.
- Prevent expected unsubscribe cleanup failures from being logged redundantly at ERROR level.

Tests:
- Add regression coverage for non-dictionary keymap values, malformed coordinator payloads, and quiet unsubscribe error logging.