### PR TITLE
fix: correct keyless-description fallback, override truthiness checks, and strings wording/casing

### DIFF
--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -240,7 +240,7 @@ ISSUE_MIGRATION_ROLLBACK = "migration_rollback_available"
 # Community-Edition migration state, persisted on the (new) config entry's data.
 # MIGRATION_DONE is the idempotency flag; MIGRATION_RECORDS holds the reverse map
 # (unique_id -> old entity_id + registry overrides) so the adoption can be rolled
-# back; MIGRATION_LEGACY_ENTRY_ID/​_CONFIG remember the disabled legacy entry and
+# back; MIGRATION_LEGACY_ENTRY_ID/_CONFIG remember the disabled legacy entry and
 # a snapshot of its data+options for a clean rollback; MIGRATION_BACKUP_KEY is the
 # .storage key of the standalone safety snapshot. See migration.py.
 MIGRATION_DONE = "ce_migration_done"

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -232,10 +232,8 @@ def _skip_keyless_description(
     entity_description: TrueNASEntityDescription, data: dict[str, Any]
 ) -> bool:
     """Return True if a keyless description has no value to expose."""
-    attr_name: str | None = getattr(
-        entity_description,
-        "data_attribute",
-        getattr(entity_description, "data_is_on", None),
+    attr_name = getattr(entity_description, "data_attribute", None) or getattr(
+        entity_description, "data_is_on", None
     )
     return data.get(attr_name) is None if attr_name else False
 

--- a/custom_components/truenas_ce/migration.py
+++ b/custom_components/truenas_ce/migration.py
@@ -336,11 +336,11 @@ def _restore_overrides(
 ) -> None:
     """Re-apply the user's name/icon/area/disabled overrides to an adopted entity."""
     updates: dict[str, Any] = {}
-    if record.get(_R_NAME):
+    if record.get(_R_NAME) is not None:
         updates["name"] = record[_R_NAME]
-    if record.get(_R_ICON):
+    if record.get(_R_ICON) is not None:
         updates["icon"] = record[_R_ICON]
-    if record.get(_R_AREA):
+    if record.get(_R_AREA) is not None:
         updates["area_id"] = record[_R_AREA]
     if record.get(_R_DISABLED):
         updates["disabled_by"] = er.RegistryEntryDisabler.USER

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -2,7 +2,7 @@
     "config": {
         "step": {
             "user": {
-                "description": "Set up TrueNAS integration.",
+                "description": "Set up TrueNAS CE integration.",
                 "data": {
                     "name": "Name of the integration",
                     "host": "Host",
@@ -284,19 +284,19 @@
                 "name": "Memory free"
             },
             "pool_free": {
-                "name": "free"
+                "name": "Free"
             },
             "pool_size": {
-                "name": "size"
+                "name": "Size"
             },
             "pool_allocated": {
-                "name": "allocated"
+                "name": "Allocated"
             },
             "pool_errors": {
-                "name": "errors"
+                "name": "Errors"
             },
             "pool_fragmentation": {
-                "name": "fragmentation"
+                "name": "Fragmentation"
             },
             "pool_scrub_start": {
                 "name": "Scrub started"

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "step": {
             "user": {
-                "description": "Set up TrueNAS integration.",
+                "description": "Set up TrueNAS CE integration.",
                 "data": {
                     "name": "Name of the integration",
                     "host": "Host",
@@ -284,19 +284,19 @@
                 "name": "Memory free"
             },
             "pool_free": {
-                "name": "free"
+                "name": "Free"
             },
             "pool_size": {
-                "name": "size"
+                "name": "Size"
             },
             "pool_allocated": {
-                "name": "allocated"
+                "name": "Allocated"
             },
             "pool_errors": {
-                "name": "errors"
+                "name": "Errors"
             },
             "pool_fragmentation": {
-                "name": "fragmentation"
+                "name": "Fragmentation"
             },
             "pool_scrub_start": {
                 "name": "Scrub started"


### PR DESCRIPTION
## Proposed change
GitHub Copilot flagged 6 findings on the `home-assistant/core` mirror PR ([review](https://github.com/home-assistant/core/pull/179103#pullrequestreview-4964986128)). Verified each against this repo's code and found the same bugs exist here (this repo is the source the mirror was derived from), so mirroring the fixes back:

- `entity.py` — `_skip_keyless_description`'s `getattr(..., "data_attribute", fallback)` only falls back when the attribute is *missing*, not when it's present but `None`. Since `data_attribute` always exists as a dataclass field (default `None`), the fallback to `data_is_on` could never trigger. Replaced with explicit `or`-chaining.
- `migration.py` — `_restore_overrides` used truthiness checks (`record.get(...)`), which silently skip restoring a valid-but-falsy override (e.g. an intentionally empty-string name/icon/area). Changed to `is not None` checks.
- `const.py` — removed a stray zero-width space (U+200B) hidden in a comment.
- `strings.json` / `translations/en.json` — "Set up TrueNAS integration." → "Set up TrueNAS CE integration." (matches the integration's actual name), and pool sensor names (`allocated`/`errors`/`fragmentation`/`free`/`size`) capitalized to match the Sentence-Case convention used by sibling entries.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
No behavior-visible regression risk: the `_skip_keyless_description` fallback was previously dead code (no live entity description currently relies on it), and the `_restore_overrides` fix only changes handling of falsy-but-set override values.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix entity fallback and migration override handling, and standardize TrueNAS CE wording and sensor name casing.

Bug Fixes:
- Correct keyless entity description fallback handling when the primary data attribute is unset.
- Restore empty-string entity name, icon, and area overrides instead of treating them as absent.

Chores:
- Remove an invisible character from migration comments and align TrueNAS CE strings and pool sensor naming with project conventions.