### PR TITLE
fix: lowercase sanitized host to avoid case-sensitive duplicate entries

### DIFF
--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -282,12 +282,15 @@ def _sanitize_host(host: str) -> str:
     Users frequently paste a full URL (for example
     ``https://nas.example.com/ui?tab=1``). The API layer requires a bare host,
     so strip any scheme as well as a trailing path, query or fragment here
-    instead of erroring out, so the value just works.
+    instead of erroring out, so the value just works. Hostnames (and DNS in
+    general) are case-insensitive, so the result is also lowercased — this
+    keeps ``NAS.local`` and ``nas.local`` from being treated as two different
+    hosts by the exact-string duplicate/rediscovery matching elsewhere.
     """
     host = host.strip()
     host = _SCHEME_RE.sub("", host)  # drop a leading scheme
     host = _HOST_TAIL_RE.split(host, maxsplit=1)[0]  # drop path/query/fragment
-    return host.strip()
+    return host.strip().lower()
 
 
 # ---------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -52,6 +52,8 @@ from custom_components.truenas_ce.const import (
         ("", ""),
         ("   ", ""),
         ("https://nas.example.com:8443/", "nas.example.com:8443"),
+        ("NAS.Local", "nas.local"),
+        ("HTTPS://NAS.Example.COM:8443/UI", "nas.example.com:8443"),
     ],
 )
 def test_sanitize_host(raw: str, expected: str) -> None:


### PR DESCRIPTION
## Proposed change

`_sanitize_host` stripped scheme/path/query from user-entered hosts but left casing untouched. Since DNS hostnames are case-insensitive, `NAS.local` and `nas.local` could end up as two separate config entries: `_async_abort_entries_match`/zeroconf rediscovery compare `CONF_HOST` with exact string equality, so a casing difference alone bypasses duplicate detection. Now lowercases the sanitized result.

Addresses a Copilot review finding raised on the `home-assistant/core#179103` mirror of this integration; mirrored here first since it's a real bug independent of that PR.

## Type of change

- [x] Bugfix

## Additional information

Also mirrored into the `ha-core` fork backing `home-assistant/core#179103` (staged locally, not yet pushed).

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Prevent case-sensitive duplicate host entries by canonicalizing sanitized hostnames.

Bug Fixes:
- Normalize sanitized hostnames to lowercase so case differences cannot create duplicate configuration entries or bypass rediscovery matching.

Tests:
- Add coverage for mixed-case hostnames and URLs during host sanitization.