### PR TITLE
fix: address round-2 Copilot findings on PR #179103

### DIFF
--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -536,7 +536,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         # An empty submission keeps a previously known key (from a taken-over
         # legacy entry) rather than blanking it out -- the field is never
         # pre-filled (see _base_schema), so a blank resubmit means "unchanged".
-        if not user_input.get(CONF_API_KEY) and truenas_config.get(CONF_API_KEY):
+        if user_input.get(CONF_API_KEY, "") == "" and truenas_config.get(CONF_API_KEY):
             user_input.pop(CONF_API_KEY, None)
         truenas_config |= user_input
 
@@ -858,7 +858,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if CONF_HOST in user_input:
                 user_input[CONF_HOST] = _sanitize_host(user_input[CONF_HOST])
-            if not user_input.get(CONF_API_KEY):
+            if user_input.get(CONF_API_KEY, "") == "":
                 user_input.pop(CONF_API_KEY, None)
             if CONF_DATASET_PASSPHRASES in user_input:
                 self._apply_passphrase_input(

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -85,7 +85,17 @@ _API_KEY_SELECTOR = selector.TextSelector(
 
 
 def _base_schema(truenas_config: Mapping[str, Any]) -> vol.Schema:
-    """Generate base schema."""
+    """Generate base schema.
+
+    The API key default is intentionally never pre-filled from
+    ``truenas_config`` (e.g. a taken-over legacy entry), even though every
+    other field is: a secret's value would otherwise be embedded in the
+    frontend's form state and re-submitted in cleartext -- the same reason
+    ``_reconfigure_schema`` below only ever declares ``CONF_API_KEY`` as
+    ``vol.Optional`` with no default. Leaving it blank is safe because
+    ``_async_apply_user_input`` keeps the previously known key when the
+    field comes back empty.
+    """
     base_schema = {
         vol.Required(
             CONF_NAME, default=truenas_config.get(CONF_NAME, DEFAULT_DEVICE_NAME)
@@ -93,9 +103,7 @@ def _base_schema(truenas_config: Mapping[str, Any]) -> vol.Schema:
         vol.Required(
             CONF_HOST, default=truenas_config.get(CONF_HOST, DEFAULT_HOST)
         ): str,
-        vol.Required(
-            CONF_API_KEY, default=truenas_config.get(CONF_API_KEY, "")
-        ): _API_KEY_SELECTOR,
+        vol.Required(CONF_API_KEY, default=""): _API_KEY_SELECTOR,
         vol.Required(
             CONF_VERIFY_SSL,
             default=truenas_config.get(CONF_VERIFY_SSL, DEFAULT_SSL_VERIFY),
@@ -525,6 +533,11 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         if CONF_HOST in user_input:
             user_input[CONF_HOST] = _sanitize_host(user_input[CONF_HOST])
+        # An empty submission keeps a previously known key (from a taken-over
+        # legacy entry) rather than blanking it out -- the field is never
+        # pre-filled (see _base_schema), so a blank resubmit means "unchanged".
+        if not user_input.get(CONF_API_KEY) and truenas_config.get(CONF_API_KEY):
+            user_input.pop(CONF_API_KEY, None)
         truenas_config |= user_input
 
         # The same device must not be configurable twice: abort when another
@@ -641,9 +654,10 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                     "failed to connect while checking for a rediscovery match",
                 ):
                     continue
-                # A failed identity lookup must not abort rediscovery either;
-                # fall back to the same best-effort match used for entries
-                # that predate this check (see docstring).
+                # A failed identity lookup must not abort rediscovery for the
+                # other entries; system_id stays None, which the stored_id
+                # check below treats as a mismatch (not a best-effort match)
+                # for any entry that has a stored id (see docstring).
                 system_id = await _async_get_system_id(api, host)
             finally:
                 await _async_safe_disconnect(api)

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -284,6 +284,23 @@ _SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 _HOST_TAIL_RE = re.compile(r"[/?#]")
 
 
+def _pop_blank_api_key(user_input: dict[str, Any], keep_existing: bool) -> None:
+    """Drop a blank ``CONF_API_KEY`` from ``user_input`` meaning "unchanged".
+
+    The API key field is never pre-filled (see ``_base_schema``), so a blank
+    resubmission means "keep the current key" -- but only when
+    ``keep_existing`` says there actually is one to fall back to; a brand
+    new setup with no stored key yet still gets a validation error instead
+    of silently continuing with an empty key. Shared by
+    ``_async_apply_user_input`` (``keep_existing`` reflects whether the
+    in-progress config already has a key, e.g. from a taken-over legacy
+    entry) and ``async_step_reconfigure`` (always ``True``, since the entry
+    being edited already has one).
+    """
+    if user_input.get(CONF_API_KEY, "") == "" and keep_existing:
+        user_input.pop(CONF_API_KEY, None)
+
+
 def _sanitize_host(host: str) -> str:
     """Normalize user input to the bare hostname/IP[:port] the API expects.
 
@@ -533,11 +550,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         if CONF_HOST in user_input:
             user_input[CONF_HOST] = _sanitize_host(user_input[CONF_HOST])
-        # An empty submission keeps a previously known key (from a taken-over
-        # legacy entry) rather than blanking it out -- the field is never
-        # pre-filled (see _base_schema), so a blank resubmit means "unchanged".
-        if user_input.get(CONF_API_KEY, "") == "" and truenas_config.get(CONF_API_KEY):
-            user_input.pop(CONF_API_KEY, None)
+        _pop_blank_api_key(user_input, bool(truenas_config.get(CONF_API_KEY)))
         truenas_config |= user_input
 
         # The same device must not be configurable twice: abort when another
@@ -858,8 +871,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if CONF_HOST in user_input:
                 user_input[CONF_HOST] = _sanitize_host(user_input[CONF_HOST])
-            if user_input.get(CONF_API_KEY, "") == "":
-                user_input.pop(CONF_API_KEY, None)
+            _pop_blank_api_key(user_input, keep_existing=True)
             if CONF_DATASET_PASSPHRASES in user_input:
                 self._apply_passphrase_input(
                     user_input,

--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -282,12 +282,15 @@ def _sanitize_host(host: str) -> str:
     Users frequently paste a full URL (for example
     ``https://nas.example.com/ui?tab=1``). The API layer requires a bare host,
     so strip any scheme as well as a trailing path, query or fragment here
-    instead of erroring out, so the value just works.
+    instead of erroring out, so the value just works. Hostnames (and DNS in
+    general) are case-insensitive, so the result is also lowercased — this
+    keeps ``NAS.local`` and ``nas.local`` from being treated as two different
+    hosts by the exact-string duplicate/rediscovery matching elsewhere.
     """
     host = host.strip()
     host = _SCHEME_RE.sub("", host)  # drop a leading scheme
     host = _HOST_TAIL_RE.split(host, maxsplit=1)[0]  # drop path/query/fragment
-    return host.strip()
+    return host.strip().lower()
 
 
 # ---------------------------

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -20,7 +20,7 @@ DOMAIN = "truenas_ce"
 # old "truenas" integration. See migration.py.
 LEGACY_DOMAIN = "truenas"
 DEFAULT_NAME = "root"
-ATTRIBUTION = "Data provided by TrueNAS integration"
+ATTRIBUTION = "Data provided by TrueNAS CE integration"
 
 # Dispatcher signal used to (re)discover entities on each coordinator refresh.
 SIGNAL_UPDATE_SENSORS = "update_sensors"

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -14,7 +14,7 @@
                 "data_description": {
                     "name": "A friendly name to tell this TrueNAS instance apart from others, if you set up more than one.",
                     "host": "The hostname or IP address of your TrueNAS instance, without \"https://\", path or trailing slash.",
-                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys.",
+                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys. Leave blank to keep a previously configured key when taking over an existing configuration.",
                     "verify_ssl": "Verify the TrueNAS instance's SSL certificate. Disable only if you use a self-signed certificate you cannot otherwise validate.",
                     "cronjob_skip_disabled": "Skip cron jobs that are disabled in TrueNAS when running the manual run action.",
                     "data_unit": "Choose whether data sizes are displayed using decimal (GB) or binary (GiB) units."
@@ -32,7 +32,7 @@
                 },
                 "data_description": {
                     "host": "The hostname or IP address of your TrueNAS instance, without \"https://\", path or trailing slash.",
-                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys.",
+                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys. Leave blank to keep the current key unchanged.",
                     "verify_ssl": "Verify the TrueNAS instance's SSL certificate. Disable only if you use a self-signed certificate you cannot otherwise validate.",
                     "cronjob_skip_disabled": "Skip cron jobs that are disabled in TrueNAS when running the manual run action.",
                     "data_unit": "Choose whether data sizes are displayed using decimal (GB) or binary (GiB) units.",

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -14,7 +14,7 @@
                 "data_description": {
                     "name": "A friendly name to tell this TrueNAS instance apart from others, if you set up more than one.",
                     "host": "The hostname or IP address of your TrueNAS instance, without \"https://\", path or trailing slash.",
-                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys.",
+                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys. Leave blank to keep a previously configured key when taking over an existing configuration.",
                     "verify_ssl": "Verify the TrueNAS instance's SSL certificate. Disable only if you use a self-signed certificate you cannot otherwise validate.",
                     "cronjob_skip_disabled": "Skip cron jobs that are disabled in TrueNAS when running the manual run action.",
                     "data_unit": "Choose whether data sizes are displayed using decimal (GB) or binary (GiB) units."
@@ -32,7 +32,7 @@
                 },
                 "data_description": {
                     "host": "The hostname or IP address of your TrueNAS instance, without \"https://\", path or trailing slash.",
-                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys.",
+                    "api_key": "An API key generated in TrueNAS under Credentials > API Keys. Leave blank to keep the current key unchanged.",
                     "verify_ssl": "Verify the TrueNAS instance's SSL certificate. Disable only if you use a self-signed certificate you cannot otherwise validate.",
                     "cronjob_skip_disabled": "Skip cron jobs that are disabled in TrueNAS when running the manual run action.",
                     "data_unit": "Choose whether data sizes are displayed using decimal (GB) or binary (GiB) units.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -52,6 +52,8 @@ from custom_components.truenas_ce.const import (
         ("", ""),
         ("   ", ""),
         ("https://nas.example.com:8443/", "nas.example.com:8443"),
+        ("NAS.Local", "nas.local"),
+        ("HTTPS://NAS.Example.COM:8443/UI", "nas.example.com:8443"),
     ],
 )
 def test_sanitize_host(raw: str, expected: str) -> None:

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -433,6 +433,13 @@ async def test_migrate_import_prefills_and_creates_entry(hass: HomeAssistant) ->
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
+    # Non-secret fields are prefilled; the API key is deliberately left blank
+    # (never pre-filled into the form -- see _base_schema) even though the
+    # legacy entry's key is known internally.
+    defaults = result["data_schema"]({})
+    assert defaults[CONF_HOST] == "legacy.example.com"
+    assert defaults[CONF_API_KEY] == ""
+
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -447,6 +454,35 @@ async def test_migrate_import_prefills_and_creates_entry(hass: HomeAssistant) ->
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == "legacy.example.com"
     assert result["options"] == {CONF_POLL_INTERVAL: "30"}
+
+
+@pytest.mark.usefixtures("_mock_connection_ok")
+async def test_migrate_import_blank_api_key_keeps_legacy_key(
+    hass: HomeAssistant,
+) -> None:
+    """Resubmitting the (blank) API key field keeps the taken-over legacy key."""
+    _legacy_entry().add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "migrate_import"}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "TrueNAS",
+            CONF_HOST: "legacy.example.com",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+            CONF_CRONJOB_SKIP_DISABLED: False,
+            CONF_DATA_UNIT: "GB",
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_API_KEY] == "old-key"
 
 
 async def test_migrate_manual_skips_takeover(hass: HomeAssistant) -> None:

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -40,7 +40,12 @@ async def test_create_fix_flow_routes_statistics_issue() -> None:
         SimpleNamespace(), "statistics_orphaned_entry1", None
     )
     assert isinstance(flow, StatisticsCleanupRepairFlow)
-    assert flow._entry_id == "entry1"
+
+    # Confirm the entry id was parsed out correctly by observing which entry
+    # the flow acts on, rather than reading the private ``_entry_id`` field.
+    flow.hass = _make_hass(None)
+    await flow.async_step_init()
+    flow.hass.config_entries.async_get_entry.assert_called_once_with("entry1")
 
 
 async def test_create_fix_flow_routes_migration_rollback_issue() -> None:
@@ -48,7 +53,10 @@ async def test_create_fix_flow_routes_migration_rollback_issue() -> None:
         SimpleNamespace(), "migration_rollback_available_entry2", None
     )
     assert isinstance(flow, MigrationRollbackRepairFlow)
-    assert flow._entry_id == "entry2"
+
+    flow.hass = _make_hass(None)
+    await flow.async_step_init()
+    flow.hass.config_entries.async_get_entry.assert_called_once_with("entry2")
 
 
 async def test_statistics_cleanup_init_lists_ids_when_data_remains() -> None:


### PR DESCRIPTION
## Proposed change

Addresses the second round of Copilot review findings on home-assistant/core#179103:

- Never pre-fill the API key secret into the config-flow form (`migrate_import` takeover path). The field now always starts blank; a blank resubmit keeps the previously known key instead of overwriting it, so the secret is no longer embedded in the frontend's form state.
- Stop asserting the private `_entry_id` attribute in `test_repairs.py`; assert observable flow behavior (which entry `async_get_entry` was called with) instead.
- Fix a comment in `_async_update_rediscovered_entry` that inaccurately described a failed identity lookup as falling back to a best-effort match, when it's actually treated as a mismatch for any entry that has a stored id.
- Correct `ATTRIBUTION` to say "TrueNAS CE" (matching the actual integration name) instead of "TrueNAS".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvement / refactoring

## Additional information

Equivalent fixes applied to the `home-assistant/core` PR #179103 mirror in the `kayl-codes/core` fork.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass (`ruff check`, `ruff format --check`; full suite green except the one test file that needs the Windows-incompatible `pytest_homeassistant_custom_component` package, verified via targeted local scripts instead).
- [x] Documentation added/updated (`strings.json` / `translations/en.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Protect API key secrets in config flows and refine TrueNAS CE matching, attribution, and repair test coverage.

Bug Fixes:
- Prevent API keys from being pre-filled in config-flow forms while preserving existing keys when a blank value is submitted.
- Normalize hostnames case-insensitively to improve duplicate and rediscovery matching.
- Correct the TrueNAS CE attribution label.

Enhancements:
- Update repair tests to verify observable flow behavior instead of private implementation details.
- Clarify rediscovery matching comments to accurately describe failed identity lookups.

Tests:
- Add coverage for blank API key handling during legacy-entry migration and case-insensitive host sanitization.