### PR TITLE
fix: namespace update_sensors signal and log rollback task errors

### DIFF
--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -23,7 +23,9 @@ DEFAULT_NAME = "root"
 ATTRIBUTION = "Data provided by TrueNAS CE integration"
 
 # Dispatcher signal used to (re)discover entities on each coordinator refresh.
-SIGNAL_UPDATE_SENSORS = "update_sensors"
+# Namespaced to avoid colliding with another integration's dispatcher signal
+# (dispatcher signals share a single hass-wide namespace).
+SIGNAL_UPDATE_SENSORS = f"{DOMAIN}_update_sensors"
 
 # TrueNAS interface link states (from interface.query -> state/link_state).
 LINK_STATE_UP = "LINK_STATE_UP"

--- a/custom_components/truenas_ce/repairs.py
+++ b/custom_components/truenas_ce/repairs.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any
 
 from homeassistant.components.repairs import RepairsFlow
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import issue_registry as ir
@@ -18,6 +20,8 @@ from .const import (
 )
 from .coordinator import get_truenas_coordinator
 from .migration import async_rollback_to_legacy
+
+_LOGGER = getLogger(__name__)
 
 # Upper bound on ids rendered into the repair dialog. A chain of renames can
 # leave dozens behind; the remainder is summarised so the dialog stays readable
@@ -98,6 +102,25 @@ class StatisticsCleanupRepairFlow(RepairsFlow):
         return self.async_create_entry(title="", data={})
 
 
+async def _async_rollback_and_log_errors(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Run the legacy rollback, logging (not raising) any failure.
+
+    Scheduled via ``async_create_task`` because the rollback removes this very
+    config entry, which would tear down the repair flow mid-step if awaited
+    inline. An unhandled exception in an untracked task would otherwise only
+    surface as a generic asyncio "Task exception was never retrieved" log
+    entry with no integration context.
+    """
+    try:
+        await async_rollback_to_legacy(hass, entry)
+    except Exception:
+        _LOGGER.exception(
+            "TrueNAS CE migration rollback failed for entry %s", entry.entry_id
+        )
+
+
 class MigrationRollbackRepairFlow(RepairsFlow):
     """Confirm-gated rollback of the Community-Edition migration.
 
@@ -128,9 +151,9 @@ class MigrationRollbackRepairFlow(RepairsFlow):
         """Hand the adopted entities (and history) back to the legacy entry."""
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is not None:
-            # Scheduled as a task because the rollback removes this very config
-            # entry; doing it inline would tear down the flow mid-step.
-            self.hass.async_create_task(async_rollback_to_legacy(self.hass, entry))
+            self.hass.async_create_task(
+                _async_rollback_and_log_errors(self.hass, entry)
+            )
         ir.async_delete_issue(
             self.hass, DOMAIN, f"{ISSUE_MIGRATION_ROLLBACK}_{self._entry_id}"
         )

--- a/custom_components/truenas_ce/repairs.py
+++ b/custom_components/truenas_ce/repairs.py
@@ -151,6 +151,8 @@ class MigrationRollbackRepairFlow(RepairsFlow):
         """Hand the adopted entities (and history) back to the legacy entry."""
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is not None:
+            # Scheduled, not awaited: the rollback removes this config entry,
+            # which would tear down this very flow mid-step if awaited inline.
             self.hass.async_create_task(
                 _async_rollback_and_log_errors(self.hass, entry)
             )


### PR DESCRIPTION
## Proposed change

Addresses 2 of 5 Copilot suppressed-review findings on the mirrored `home-assistant/core#179103` PR ([review](https://github.com/home-assistant/core/pull/179103#pullrequestreview-4966070775)):

- `SIGNAL_UPDATE_SENSORS` was an unnamespaced dispatcher signal string (`"update_sensors"`). Dispatcher signals share a single hass-wide namespace, so a generic name risks colliding with another integration's signal. Namespaced to `f"{DOMAIN}_update_sensors"`.
- The migration-rollback repair flow scheduled its rollback via `hass.async_create_task()` without tracking the result. An exception there would only ever surface as a generic, contextless asyncio "Task exception was never retrieved" log entry. Added `_async_rollback_and_log_errors()` to catch and log it with the affected config entry id.

The other 3 findings from the same review were evaluated and declined (with reasoning posted back on #179103): forcing `get_uid()` to only return `str` broke 13 tests (job/VM/service ids are legitimately `int` in the TrueNAS API), the device-identifier-uses-hostname concern is real but a much bigger architecture change deferred to the backlog, and the migration guide URL points at this repo's own (existing) docs, not link rot.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Mirrored fix will also be applied to the `home-assistant/core#179103` PR branch (separate repo, pushed by the user per this repo's standing workflow rule).

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Prevent dispatcher signal collisions and improve error reporting for asynchronous migration rollbacks.

Bug Fixes:
- Namespace the sensor update dispatcher signal to prevent collisions with signals from other integrations.
- Capture and log migration rollback failures with the affected config entry context instead of allowing unhandled background-task errors.