### PR TITLE
fix: include entry title in rollback failure log, scope helper's exception intent

### DIFF
--- a/custom_components/truenas_ce/repairs.py
+++ b/custom_components/truenas_ce/repairs.py
@@ -112,12 +112,19 @@ async def _async_rollback_and_log_errors(
     inline. An unhandled exception in an untracked task would otherwise only
     surface as a generic asyncio "Task exception was never retrieved" log
     entry with no integration context.
+
+    Migration-rollback-specific: the broad ``except Exception`` is this
+    coroutine's whole purpose (turning an untracked task's crash into a
+    logged, actionable message), not a generic error-swallowing helper —
+    don't reuse it for other background tasks.
     """
     try:
         await async_rollback_to_legacy(hass, entry)
     except Exception:
         _LOGGER.exception(
-            "TrueNAS CE migration rollback failed for entry %s", entry.entry_id
+            "TrueNAS CE migration rollback failed for entry %s (%s)",
+            entry.entry_id,
+            entry.title,
         )
 
 


### PR DESCRIPTION
## Proposed change
Follow-up to #92: addresses two more Sourcery findings raised on that PR's third review pass, on the `_async_rollback_and_log_errors` helper in `repairs.py`.

- The failure log now includes `entry.title` alongside `entry.entry_id`, since the id alone isn't actionable when multiple TrueNAS CE entries exist.
- The docstring now states explicitly that the broad `except Exception` is this coroutine's whole purpose (turning an untracked `async_create_task`'s crash into a logged, actionable message), so it isn't mistaken for a reusable generic error-swallowing helper.

## Type of change
- [x] Bugfix

## Additional information
Two other findings from the same review round were evaluated and declined (narrowing the caught exception type / re-raising) — see the reasoning already posted on #92, unchanged for this round.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Improve migration rollback failure diagnostics and document the helper’s intentionally scoped exception handling.

Bug Fixes:
- Include the TrueNAS CE entry title in migration rollback failure logs to make failures actionable when entry IDs alone are ambiguous.

Enhancements:
- Clarify that the rollback helper’s broad exception handling is intentional and specific to reporting failures from untracked rollback tasks.