### PR TITLE
fix: prefix data__ device identifiers with instance name, guard composite-reference length

### DIFF
--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -190,6 +190,8 @@ def _composite_references(
     are skipped, mirroring ``_referenced_unique_ids`` behavior.
     """
     ids: set[str] = set()
+    if len(description.data_composite_references) != 2:
+        return ids
     container_key, leaf_key = description.data_composite_references
     for uid, vals in data.items():
         container = _get_composite_container(vals, container_key)
@@ -581,7 +583,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             dev_group = ha_group[6:]
             if dev_group in self._data:
                 dev_group = self._data[dev_group]
-                dev_connection_value = dev_group
+                dev_connection_value = f"{self._inst}_{dev_group}"
 
         if self.entity_description.ha_connection:
             dev_connection = self.entity_description.ha_connection

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -481,7 +481,8 @@ def test_device_info_data_group_instance_prefix_prevents_collision() -> None:
         desc,
         "d1",
     )
-    assert entity_a.device_info["identifiers"] != entity_b.device_info["identifiers"]
+    assert entity_a.device_info["identifiers"] == {("truenas_ce", "TrueNAS-A_tank")}
+    assert entity_b.device_info["identifiers"] == {("truenas_ce", "TrueNAS-B_tank")}
 
 
 def test_device_info_explicit_connection_and_value() -> None:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from _fakes import make_coordinator
+from _fakes import make_config_entry, make_coordinator
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -459,6 +459,29 @@ def test_device_info_data_group_resolves_group_from_data() -> None:
     info = entity.device_info
     assert info["name"] == "TrueNAS tank"
     assert info["identifiers"] == {("truenas_ce", "TrueNAS_tank")}
+
+
+def test_device_info_data_group_instance_prefix_prevents_collision() -> None:
+    """Two instances resolving the same group must not share a device identifier."""
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        ha_group="data__pool",
+    )
+    data = {"disk": {"d1": {"guid": "g1", "pool": "tank"}}}
+    entity_a = TrueNASEntity(
+        make_coordinator(data=data, config_entry=make_config_entry(name="TrueNAS-A")),
+        desc,
+        "d1",
+    )
+    entity_b = TrueNASEntity(
+        make_coordinator(data=data, config_entry=make_config_entry(name="TrueNAS-B")),
+        desc,
+        "d1",
+    )
+    assert entity_a.device_info["identifiers"] != entity_b.device_info["identifiers"]
 
 
 def test_device_info_explicit_connection_and_value() -> None:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -458,6 +458,7 @@ def test_device_info_data_group_resolves_group_from_data() -> None:
     )
     info = entity.device_info
     assert info["name"] == "TrueNAS tank"
+    assert info["identifiers"] == {("truenas_ce", "TrueNAS_tank")}
 
 
 def test_device_info_explicit_connection_and_value() -> None:

--- a/tests/test_entity_description.py
+++ b/tests/test_entity_description.py
@@ -157,6 +157,24 @@ def test_composite_references_ignores_non_list_container() -> None:
     assert result == set()
 
 
+def test_composite_references_invalid_length_returns_empty_set() -> None:
+    """A malformed (non-2-segment) composite reference yields no unique ids.
+
+    __post_init__ only logs a warning for this (frozen dataclasses can't
+    reject construction), so callers must not assume the tuple is unpackable.
+    """
+    description = TrueNASEntityDescription(
+        key="test_net",
+        name="Test Net",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_composite_references=("only_one",),
+    )
+    data = {"app1": {"networks": [{"interface_name": "eth0"}]}}
+    result = _composite_references("inst", description, data)
+    assert result == set()
+
+
 def test_composite_references_empty_data() -> None:
     description = TrueNASEntityDescription(
         key="test_net",


### PR DESCRIPTION
## Proposed change
Mirrors a Copilot finding (review 4969263481) from the `home-assistant/core` PR #179103 Bronze-quality-scale submission, which shares this code with `entity.py` here:

- `device_info`'s `data__`-prefixed `ha_group` branch built `dev_connection_value` from the raw data value (e.g. a pool name) without the instance prefix, unlike the analogous `ha_connection_value` branch right below it. Two TrueNAS instances (or two same-named pools/datasets) could collide on the same device identifier.
- `_composite_references` unpacked `description.data_composite_references` unconditionally. `TrueNASEntityDescription.__post_init__` can only *warn* about a malformed (non-2-segment) tuple — frozen dataclasses can't reject construction — so a bad tuple would crash with `ValueError` instead of being handled defensively like the rest of this function.

Currently no static entity description sets `ha_group="data__..."` in this repo, so the first fix isn't reachable from a live entity yet, but it's tested, reusable infrastructure and the fix is trivial and low-risk.

## Type of change
- [x] Bugfix

## Additional information
Both bugs also affect the `home-assistant/core` fork branch; fixed there independently in the same review round.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent data-backed device identifier collisions and safely ignore malformed composite references.

Bug Fixes:
- Prevent device identifier collisions by including the TrueNAS instance name when resolving data-backed device groups.
- Handle malformed composite references defensively instead of raising an unpacking error.

Tests:
- Add coverage for instance-specific data-group identifiers and invalid composite-reference lengths.