### PR TITLE
fix: namespace migration backups per config entry

### DIFF
--- a/custom_components/truenas_ce/migration.py
+++ b/custom_components/truenas_ce/migration.py
@@ -189,6 +189,16 @@ def _remove_legacy_entities(
         ent_reg.async_remove(record[_R_ENTITY_ID])
 
 
+def _entry_backup_prefix(entry_id: str) -> str:
+    """Return the per-entry ``.storage`` key prefix for migration backups.
+
+    Namespaced by config entry id so two TrueNAS instances migrating around
+    the same time never collide on the same timestamped key, and so removing
+    stale snapshots for one entry can never prune another entry's backup.
+    """
+    return f"{_BACKUP_KEY_PREFIX}_{entry_id}"
+
+
 async def _write_migration_backup(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -202,9 +212,8 @@ async def _write_migration_backup(
     migration. Returns the ``.storage`` key on success, else ``None``.
     """
     timestamp = dt_util.utcnow().strftime("%Y%m%d_%H%M%S")
-    store: Store[dict[str, Any]] = Store(
-        hass, _BACKUP_VERSION, f"{_BACKUP_KEY_PREFIX}_{timestamp}"
-    )
+    prefix = _entry_backup_prefix(config_entry.entry_id)
+    store: Store[dict[str, Any]] = Store(hass, _BACKUP_VERSION, f"{prefix}_{timestamp}")
     payload = {
         "created": dt_util.utcnow().isoformat(),
         "ce_entry_id": config_entry.entry_id,
@@ -221,19 +230,23 @@ async def _write_migration_backup(
         _LOGGER.warning("Could not write CE migration backup snapshot: %s", err)
         return None
     _LOGGER.info("Wrote CE migration backup snapshot '%s'", store.key)
-    await _remove_backups(hass, store.key)
+    await _remove_backups(hass, prefix, store.key)
     return store.key
 
 
-async def _remove_backups(hass: HomeAssistant, keep_key: str | None) -> None:
-    """Remove migration backup snapshots from ``.storage``.
+async def _remove_backups(
+    hass: HomeAssistant, prefix: str, keep_key: str | None
+) -> None:
+    """Remove this entry's migration backup snapshots from ``.storage``.
 
-    Scans the ``.storage`` directory for ``truenas_ce_migration_backup_*`` stores
-    and removes every one except ``keep_key`` — pass ``None`` to remove all. Used
+    Scans the ``.storage`` directory for stores matching ``prefix`` (already
+    namespaced by config entry id -- see :func:`_entry_backup_prefix`) and
+    removes every one except ``keep_key`` — pass ``None`` to remove all. Used
     to keep only the latest snapshot after a write, and to drop all of them on
-    rollback. Listing the directory (rather than trusting a stored key) makes the
-    rollback cleanup robust even if the key was never persisted. Best effort —
-    failures are logged, never raised.
+    rollback, without ever touching another config entry's backups. Listing
+    the directory (rather than trusting a stored key) makes the rollback
+    cleanup robust even if the key was never persisted. Best effort — failures
+    are logged, never raised.
     """
     storage_dir = hass.config.path(".storage")
 
@@ -242,7 +255,7 @@ async def _remove_backups(hass: HomeAssistant, keep_key: str | None) -> None:
             return [
                 name
                 for name in os.listdir(storage_dir)
-                if name.startswith(_BACKUP_KEY_PREFIX) and name != keep_key
+                if name.startswith(prefix) and name != keep_key
             ]
         except OSError:
             return []
@@ -519,7 +532,9 @@ async def async_rollback_to_legacy(
     ]
     _remap_and_restore(ent_reg, pairs)
 
-    # The migration is fully undone — drop all safety snapshots.
-    await _remove_backups(hass, keep_key=None)
+    # The migration is fully undone — drop this entry's safety snapshots.
+    await _remove_backups(
+        hass, _entry_backup_prefix(config_entry.entry_id), keep_key=None
+    )
 
     return True

--- a/custom_components/truenas_ce/migration.py
+++ b/custom_components/truenas_ce/migration.py
@@ -211,11 +211,13 @@ async def _write_migration_backup(
     on the config entry remains the primary undo), so it must not abort the
     migration. Returns the ``.storage`` key on success, else ``None``.
     """
-    timestamp = dt_util.utcnow().strftime("%Y%m%d_%H%M%S")
+    now = dt_util.utcnow()
     prefix = _entry_backup_prefix(config_entry.entry_id)
-    store: Store[dict[str, Any]] = Store(hass, _BACKUP_VERSION, f"{prefix}_{timestamp}")
+    store: Store[dict[str, Any]] = Store(
+        hass, _BACKUP_VERSION, f"{prefix}_{now.strftime('%Y%m%d_%H%M%S')}"
+    )
     payload = {
-        "created": dt_util.utcnow().isoformat(),
+        "created": now.isoformat(),
         "ce_entry_id": config_entry.entry_id,
         "legacy_entry_id": legacy_entry.entry_id,
         "legacy_config": {
@@ -503,6 +505,7 @@ async def async_rollback_to_legacy(
         return False
 
     records = config_entry.data.get(MIGRATION_RECORDS, [])
+    prefix = _entry_backup_prefix(config_entry.entry_id)
 
     _LOGGER.info(
         "Rolling back '%s' adoption: returning %d entities to legacy entry %s",
@@ -533,8 +536,6 @@ async def async_rollback_to_legacy(
     _remap_and_restore(ent_reg, pairs)
 
     # The migration is fully undone — drop this entry's safety snapshots.
-    await _remove_backups(
-        hass, _entry_backup_prefix(config_entry.entry_id), keep_key=None
-    )
+    await _remove_backups(hass, prefix, keep_key=None)
 
     return True

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -570,7 +570,9 @@ async def test_write_migration_backup_success() -> None:
 
     assert key == store_instance.key
     store_instance.async_save.assert_awaited_once()
-    remove_mock.assert_awaited_once_with(hass, store_instance.key)
+    remove_mock.assert_awaited_once_with(
+        hass, migration_module._entry_backup_prefix(entry.entry_id), store_instance.key
+    )
 
 
 async def test_write_migration_backup_failure_returns_none() -> None:
@@ -608,7 +610,9 @@ async def test_remove_backups_removes_all_except_keep_key() -> None:
         ),
         patch.object(migration_module, "Store", return_value=store_instance),
     ):
-        await migration_module._remove_backups(hass, "truenas_ce_migration_backup_1")
+        await migration_module._remove_backups(
+            hass, "truenas_ce_migration_backup", "truenas_ce_migration_backup_1"
+        )
 
     store_instance.async_remove.assert_awaited_once()
 
@@ -619,7 +623,9 @@ async def test_remove_backups_handles_listdir_error() -> None:
     hass.async_add_executor_job = AsyncMock(side_effect=lambda func: func())
 
     with patch("os.listdir", side_effect=OSError("no such dir")):
-        await migration_module._remove_backups(hass, None)  # must not raise
+        await migration_module._remove_backups(
+            hass, "truenas_ce_migration_backup", None
+        )  # must not raise
 
 
 async def test_remove_backups_logs_on_remove_failure(
@@ -637,7 +643,9 @@ async def test_remove_backups_logs_on_remove_failure(
         patch.object(migration_module, "Store", return_value=store_instance),
         caplog.at_level("WARNING"),
     ):
-        await migration_module._remove_backups(hass, None)
+        await migration_module._remove_backups(
+            hass, "truenas_ce_migration_backup", None
+        )
 
     assert "Could not remove CE migration backup" in caplog.text
 
@@ -739,4 +747,6 @@ async def test_async_rollback_to_legacy_full_flow() -> None:
     assert result is True
     hass.config_entries.async_remove.assert_awaited_once_with(entry.entry_id)
     hass.config_entries.async_set_disabled_by.assert_awaited_once_with("legacy-1", None)
-    rm_mock.assert_awaited_once_with(hass, keep_key=None)
+    rm_mock.assert_awaited_once_with(
+        hass, migration_module._entry_backup_prefix(entry.entry_id), keep_key=None
+    )

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -611,7 +611,9 @@ async def test_remove_backups_removes_all_except_keep_key() -> None:
         patch.object(migration_module, "Store", return_value=store_instance),
     ):
         await migration_module._remove_backups(
-            hass, "truenas_ce_migration_backup", "truenas_ce_migration_backup_1"
+            hass,
+            migration_module._BACKUP_KEY_PREFIX,
+            "truenas_ce_migration_backup_1",
         )
 
     store_instance.async_remove.assert_awaited_once()
@@ -624,7 +626,7 @@ async def test_remove_backups_handles_listdir_error() -> None:
 
     with patch("os.listdir", side_effect=OSError("no such dir")):
         await migration_module._remove_backups(
-            hass, "truenas_ce_migration_backup", None
+            hass, migration_module._BACKUP_KEY_PREFIX, None
         )  # must not raise
 
 
@@ -644,7 +646,7 @@ async def test_remove_backups_logs_on_remove_failure(
         caplog.at_level("WARNING"),
     ):
         await migration_module._remove_backups(
-            hass, "truenas_ce_migration_backup", None
+            hass, migration_module._BACKUP_KEY_PREFIX, None
         )
 
     assert "Could not remove CE migration backup" in caplog.text


### PR DESCRIPTION
## Proposed change

The `.storage` migration-backup snapshot key in `migration.py` was global (`truenas_ce_migration_backup_<timestamp>`), not scoped per config entry. If two TrueNAS instances migrate around the same time, `_write_migration_backup`'s cleanup (`_remove_backups`) could delete the *other* instance's backup snapshot, and a same-second timestamp collision could overwrite it outright.

This namespaces both the backup key and the cleanup scan by config entry id (`_entry_backup_prefix`), so one entry's migration backup can never collide with or prune another's.

Found while porting the migration module to the [home-assistant/core PR](https://github.com/home-assistant/core/pull/179103) (a Copilot review flagged it there); this mirrors the same fix back here as its own PR, kept separate from #94 which is being reviewed in parallel.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

No behavior change for the common single-instance case; only affects the edge case of concurrent/near-simultaneous migrations across multiple config entries.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Isolate migration backup snapshots per config entry to make concurrent TrueNAS migrations safe.

Bug Fixes:
- Namespace migration backup snapshots and cleanup by config entry to prevent collisions, overwrites, and cross-entry deletion during concurrent migrations.

Tests:
- Update migration tests for per-entry backup prefixes and rollback cleanup.