### PR TITLE
fix: mark migration done on manual takeover, abort adoption if legacy entry can't be disabled

### DIFF
--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -62,6 +62,7 @@ from .const import (
     ERR_WS_NOT_SUPPORTED,
     KNOWN_DOMAINS,
     LEGACY_DOMAIN,
+    MIGRATION_DONE,
     MONITOR_GROUP_CLOUDSYNC,
     MONITOR_GROUP_CONTAINERS,
     MONITOR_GROUP_CRONJOBS,
@@ -755,7 +756,14 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_migrate_manual(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Skip the takeover and configure TrueNAS CE from scratch."""
+        """Skip the takeover and configure TrueNAS CE from scratch.
+
+        Marks the entry as already migrated so ``async_adopt_legacy_entities``
+        never auto-adopts the legacy entry later -- without this, entering the
+        same host the legacy entry uses would silently override the user's
+        explicit "from scratch" choice on the first coordinator setup.
+        """
+        self.truenas_config[MIGRATION_DONE] = True
         return await self.async_step_user()
 
     def _validate_passphrase_names(

--- a/custom_components/truenas_ce/migration.py
+++ b/custom_components/truenas_ce/migration.py
@@ -98,11 +98,12 @@ async def async_adopt_legacy_entities(
         # (without persisting MIGRATION_DONE) if that fails, so a later setup
         # retries instead of stripping entities out from under a still-active
         # legacy coordinator.
-        disabled = legacy_entry.disabled_by is not None or (
-            await hass.config_entries.async_set_disabled_by(
+        if legacy_entry.disabled_by is not None:
+            disabled = True
+        else:
+            disabled = await hass.config_entries.async_set_disabled_by(
                 legacy_entry.entry_id, ConfigEntryDisabler.USER
             )
-        )
         if not disabled:
             _LOGGER.error(
                 "Adoption aborted: legacy '%s' entry %s could not be disabled;"

--- a/custom_components/truenas_ce/migration.py
+++ b/custom_components/truenas_ce/migration.py
@@ -94,11 +94,23 @@ async def async_adopt_legacy_entities(
 
     if legacy_entry is not None:
         # Disable the legacy entry first so its coordinator stops and cannot
-        # re-discover (re-add) the entities we are about to release.
-        if legacy_entry.disabled_by is None:
+        # re-discover (re-add) the entities we are about to release. Abort
+        # (without persisting MIGRATION_DONE) if that fails, so a later setup
+        # retries instead of stripping entities out from under a still-active
+        # legacy coordinator.
+        disabled = legacy_entry.disabled_by is not None or (
             await hass.config_entries.async_set_disabled_by(
                 legacy_entry.entry_id, ConfigEntryDisabler.USER
             )
+        )
+        if not disabled:
+            _LOGGER.error(
+                "Adoption aborted: legacy '%s' entry %s could not be disabled;"
+                " entities were left in place and will be retried on next setup",
+                LEGACY_DOMAIN,
+                legacy_entry.entry_id,
+            )
+            return []
         ent_reg = er.async_get(hass)
         # Capture the records read-only, write the safety snapshot, and only then
         # mutate the registry — so a failed backup never leaves a half-freed state.

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -44,6 +44,7 @@ from custom_components.truenas_ce.const import (
     DOMAIN,
     ERR_INVALID_KEY,
     LEGACY_DOMAIN,
+    MIGRATION_DONE,
 )
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
@@ -496,6 +497,38 @@ async def test_migrate_manual_skips_takeover(hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+
+
+@pytest.mark.usefixtures("_mock_connection_ok")
+async def test_migrate_manual_marks_migration_done(hass: HomeAssistant) -> None:
+    """Migrate-manual's entry must never be auto-adopted by the legacy entry later.
+
+    Regression test: entering the *same* host the legacy entry uses (the
+    normal case, since it's the same physical box) used to let
+    ``async_adopt_legacy_entities`` silently override the user's explicit
+    "from scratch" choice on the first coordinator setup, because nothing
+    recorded that this entry had already gone through the migration decision.
+    """
+    _legacy_entry().add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "migrate_manual"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "legacy.example.com",
+            CONF_API_KEY: "new-key",
+            CONF_VERIFY_SSL: True,
+            CONF_CRONJOB_SKIP_DISABLED: False,
+            CONF_DATA_UNIT: "GB",
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][MIGRATION_DONE] is True
 
 
 # ---------------------------

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -497,6 +497,31 @@ async def test_async_adopt_legacy_entities_skips_disable_when_already_disabled()
     hass.config_entries.async_set_disabled_by.assert_not_awaited()
 
 
+async def test_async_adopt_legacy_entities_aborts_when_disable_fails() -> None:
+    """A legacy entry that fails to disable must not lose its entities either.
+
+    If ``async_set_disabled_by`` returns falsy, adoption must abort without
+    persisting ``MIGRATION_DONE``, so a later setup (once the legacy entry can
+    be disabled) retries instead of stripping entities out from under a still-
+    active legacy coordinator.
+    """
+    hass = MagicMock()
+    legacy_entry = SimpleNamespace(
+        entry_id="legacy-1",
+        data={"host": "truenas.local"},
+        options={},
+        disabled_by=None,
+    )
+    hass.config_entries.async_entries.return_value = [legacy_entry]
+    hass.config_entries.async_set_disabled_by = AsyncMock(return_value=False)
+    entry = _config_entry(data={"host": "truenas.local"})
+
+    records = await async_adopt_legacy_entities(hass, entry)
+
+    assert records == []
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
 # ---------------------------
 #   finalize_legacy_adoption
 # ---------------------------


### PR DESCRIPTION
## Proposed change

Two related fixes to the legacy-to-`truenas_ce` migration flow:

- `async_step_migrate_manual` now sets `MIGRATION_DONE` so a later coordinator setup on the same host never lets `async_adopt_legacy_entities` silently override the user's "from scratch" choice.
- `async_adopt_legacy_entities` now aborts (without persisting `MIGRATION_DONE`) if disabling the legacy config entry fails, so a retry can happen later instead of stripping entities out from under a still-active legacy coordinator.

## Type of change

- [x] Bugfix

## Additional information

Mirrored from the same fix already applied against the `home-assistant/core` fork (PR #179103).

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent legacy migration from overriding manual setup choices or removing entities when the legacy entry remains active.

Bug Fixes:
- Preserve an explicit manual, from-scratch migration choice by marking the configuration entry as migrated.
- Abort legacy entity adoption when the legacy entry cannot be disabled, preserving entities and allowing a later retry.

Tests:
- Add regression coverage for manual migration state and failed legacy-entry disabling.