### PR TITLE
feat: push alerts/service/pool/cloudsync/replication/rsync/vm/container/app via TrueNAS event subscriptions

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -617,6 +617,9 @@ async def async_unload_entry(
             await coordinator.stop_alerts()
             await coordinator.stop_service_push()
             await coordinator.stop_pool_push()
+            await coordinator.stop_cloudsync_push()
+            await coordinator.stop_replication_push()
+            await coordinator.stop_rsync_push()
             await coordinator.api.close()
         if hasattr(config_entry, "runtime_data"):
             del config_entry.runtime_data

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -614,6 +614,7 @@ async def async_unload_entry(
         coordinator = get_truenas_coordinator(config_entry)
         if coordinator is not None:
             await coordinator.stop_app_stats()
+            await coordinator.stop_alerts()
             await coordinator.api.close()
         if hasattr(config_entry, "runtime_data"):
             del config_entry.runtime_data

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -615,6 +615,7 @@ async def async_unload_entry(
         if coordinator is not None:
             await coordinator.stop_app_stats()
             await coordinator.stop_alerts()
+            await coordinator.stop_service_push()
             await coordinator.api.close()
         if hasattr(config_entry, "runtime_data"):
             del config_entry.runtime_data

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -616,6 +616,7 @@ async def async_unload_entry(
             await coordinator.stop_app_stats()
             await coordinator.stop_alerts()
             await coordinator.stop_service_push()
+            await coordinator.stop_pool_push()
             await coordinator.api.close()
         if hasattr(config_entry, "runtime_data"):
             del config_entry.runtime_data

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -616,6 +616,9 @@ async def async_unload_entry(
             await coordinator.stop_app_stats()
             await coordinator.stop_alerts()
             await coordinator.stop_service_push()
+            await coordinator.stop_vm_push()
+            await coordinator.stop_container_push()
+            await coordinator.stop_app_push()
             await coordinator.api.close()
         if hasattr(config_entry, "runtime_data"):
             del config_entry.runtime_data

--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -488,7 +488,17 @@ class TrueNASAPI:
         """Check if a subscription is currently active in the client."""
         if not self.connected():
             return False
-        return await self._client.is_subscribed(subscription_id)
+        try:
+            return await self._client.is_subscribed(subscription_id)
+        except TrueNASError as exc:
+            self._error = _classify_exception(exc, during_call=True)
+            _LOGGER.warning(
+                "TrueNAS %s unable to check subscription status %s (%s)",
+                self._host,
+                subscription_id,
+                exc,
+            )
+            return False
 
     @property
     def error(self) -> str:

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -430,8 +430,10 @@ class _PushSourceState:
 
     def __init__(self) -> None:
         self.sub_id: str | None = None
+        self.event: str | None = None
         self.consumer: SubscriptionPushConsumer | None = None
         self.breaker = SubscriptionCircuitBreaker()
+        self.refresh_lock = asyncio.Lock()
 
 
 # ---------------------------
@@ -1450,7 +1452,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def get_service(self) -> None:
         """Refresh services, then ensure the push subscription is active."""
-        await self._refresh_service()
+        await self._refresh_locked(self._service_push, self._refresh_service)
         await self._ensure_push_subscription(
             self._service_push,
             self._SERVICE_EVENT,
@@ -1460,7 +1462,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_service_push(self, _batch: list[Any]) -> None:
         """Immediately refresh service state on push notification."""
-        await self._refresh_service()
+        await self._refresh_locked(self._service_push, self._refresh_service)
         self.async_set_updated_data(self.ds)
 
     async def stop_service_push(self) -> None:
@@ -1527,7 +1529,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def get_pool(self) -> None:
         """Refresh pools, then ensure the push subscription is active."""
-        await self._refresh_pool()
+        await self._refresh_locked(self._pool_push, self._refresh_pool)
         await self._ensure_push_subscription(
             self._pool_push,
             self._POOL_EVENT,
@@ -1537,7 +1539,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_pool_push(self, _batch: list[Any]) -> None:
         """Immediately refresh pool state on push notification."""
-        await self._refresh_pool()
+        await self._refresh_locked(self._pool_push, self._refresh_pool)
         self.async_set_updated_data(self.ds)
 
     async def stop_pool_push(self) -> None:
@@ -2043,7 +2045,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["vm"] = {}
             await self._stop_push_subscription(self._vm_push)
             return
-        await self._refresh_vm()
+        await self._refresh_locked(self._vm_push, self._refresh_vm)
         await self._ensure_push_subscription(
             self._vm_push,
             self._VM_EVENT,
@@ -2053,7 +2055,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_vm_push(self, _batch: list[Any]) -> None:
         """Immediately refresh VM state on push notification."""
-        await self._refresh_vm()
+        await self._refresh_locked(self._vm_push, self._refresh_vm)
         self.async_set_updated_data(self.ds)
 
     async def stop_vm_push(self) -> None:
@@ -2107,7 +2109,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["container"] = {}
             await self._stop_push_subscription(self._container_push)
             return
-        await self._refresh_container()
+        await self._refresh_locked(self._container_push, self._refresh_container)
         event = (
             "container.query"
             if self.supports_container_api()
@@ -2122,7 +2124,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_container_push(self, _batch: list[Any]) -> None:
         """Immediately refresh container state on push notification."""
-        await self._refresh_container()
+        await self._refresh_locked(self._container_push, self._refresh_container)
         self.async_set_updated_data(self.ds)
 
     async def stop_container_push(self) -> None:
@@ -2130,12 +2132,15 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._stop_push_subscription(self._container_push)
 
     async def _refresh_container(self) -> None:
-        """Get virt CONTAINER instances (Incus) from TrueNAS.
+        """Get container instances from TrueNAS via the supported API.
 
-        ``virt.instance.query`` returns both CONTAINER and VM Incus instances;
-        only CONTAINER ones are surfaced here (legacy libvirt VMs are handled by
-        ``get_vm``). Container ``cpu``/``memory`` may be ``None``, so both are
-        treated null-safely (this was the upstream crash, see #26).
+        On TrueNAS 26.0+ (``supports_container_api()``), dispatches to
+        ``container.query`` (LXC) via :meth:`_get_container_v26`. On older
+        versions, ``virt.instance.query`` returns both CONTAINER and VM Incus
+        instances; only CONTAINER ones are surfaced here (legacy libvirt VMs
+        are handled by ``get_vm``). Container ``cpu``/``memory`` may be
+        ``None`` on the legacy path, so both are treated null-safely (this
+        was the upstream crash, see #26).
         """
         if self.supports_container_api():
             await self._get_container_v26()
@@ -2336,7 +2341,16 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
 
         if state.sub_id and not await self.api.is_subscribed(state.sub_id):
-            self._clear_push_subscription(state)
+            await self._stop_push_subscription(state)
+
+        if state.sub_id and state.event != event:
+            _LOGGER.debug(
+                "TrueNAS %s subscription topic changed (%s -> %s); resubscribing",
+                label,
+                state.event,
+                event,
+            )
+            await self._stop_push_subscription(state)
 
         if state.sub_id:
             return
@@ -2369,12 +2383,14 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         consumer.start(task_factory=self.hass.async_create_background_task)
         state.sub_id = sub_id
+        state.event = event
         state.consumer = consumer
         _LOGGER.debug("TrueNAS %s push subscription established: %s", label, sub_id)
 
     def _clear_push_subscription(self, state: _PushSourceState) -> None:
         """Clear local subscription state for one source."""
         state.sub_id = None
+        state.event = None
         state.consumer = None
 
     async def _stop_push_subscription(self, state: _PushSourceState) -> None:
@@ -2389,6 +2405,19 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "TrueNAS failed to unsubscribe %s (%s)", state.sub_id, exc
                 )
         self._clear_push_subscription(state)
+
+    async def _refresh_locked(
+        self, state: _PushSourceState, refresh: Callable[[], Awaitable[None]]
+    ) -> None:
+        """Serialize one source's refresh calls.
+
+        Without this, a push notification's immediate refresh can race the
+        regular 60s poll's refresh of the same source; whichever finishes
+        last wins, so a slower poll can silently overwrite fresher
+        push-triggered state with stale data.
+        """
+        async with state.refresh_lock:
+            await refresh()
 
     # ---------------------------
     #   get_alerts
@@ -2672,7 +2701,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["cloudsync"] = {}
             await self._stop_push_subscription(self._cloudsync_push)
             return
-        await self._refresh_cloudsync()
+        await self._refresh_locked(self._cloudsync_push, self._refresh_cloudsync)
         await self._ensure_push_subscription(
             self._cloudsync_push,
             self._CLOUDSYNC_EVENT,
@@ -2682,7 +2711,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_cloudsync_push(self, _batch: list[Any]) -> None:
         """Immediately refresh cloudsync state on push notification."""
-        await self._refresh_cloudsync()
+        await self._refresh_locked(self._cloudsync_push, self._refresh_cloudsync)
         self.async_set_updated_data(self.ds)
 
     async def stop_cloudsync_push(self) -> None:
@@ -2723,7 +2752,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["replication"] = {}
             await self._stop_push_subscription(self._replication_push)
             return
-        await self._refresh_replication()
+        await self._refresh_locked(self._replication_push, self._refresh_replication)
         await self._ensure_push_subscription(
             self._replication_push,
             self._REPLICATION_EVENT,
@@ -2733,7 +2762,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_replication_push(self, _batch: list[Any]) -> None:
         """Immediately refresh replication state on push notification."""
-        await self._refresh_replication()
+        await self._refresh_locked(self._replication_push, self._refresh_replication)
         self.async_set_updated_data(self.ds)
 
     async def stop_replication_push(self) -> None:
@@ -2792,7 +2821,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["rsynctask"] = {}
             await self._stop_push_subscription(self._rsync_push)
             return
-        await self._refresh_rsync()
+        await self._refresh_locked(self._rsync_push, self._refresh_rsync)
         await self._ensure_push_subscription(
             self._rsync_push,
             self._RSYNC_EVENT,
@@ -2802,7 +2831,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_rsync_push(self, _batch: list[Any]) -> None:
         """Immediately refresh rsync task state on push notification."""
-        await self._refresh_rsync()
+        await self._refresh_locked(self._rsync_push, self._refresh_rsync)
         self.async_set_updated_data(self.ds)
 
     async def stop_rsync_push(self) -> None:
@@ -2891,7 +2920,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def get_app(self) -> None:
         """Refresh apps, then ensure the push subscription is active."""
-        await self._refresh_app()
+        await self._refresh_locked(self._app_push, self._refresh_app)
         await self._ensure_push_subscription(
             self._app_push,
             self._APP_EVENT,
@@ -2901,7 +2930,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _on_app_push(self, _batch: list[Any]) -> None:
         """Immediately refresh app state on push notification."""
-        await self._refresh_app()
+        await self._refresh_locked(self._app_push, self._refresh_app)
         self.async_set_updated_data(self.ds)
 
     async def stop_app_push(self) -> None:

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -521,6 +521,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._alerts_breaker = SubscriptionCircuitBreaker()
 
         self._service_push = _PushSourceState()
+        self._pool_push = _PushSourceState()
 
     # ---------------------------
     #   connected
@@ -1510,8 +1511,35 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_pool
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-22): core.subscribe on
+    # "pool.query" is accepted and returns a real subscription id. Pool health
+    # changes (degraded/faulted, capacity, scrub state, etc.) are infrequent,
+    # so -- like service -- any push message is treated as a pure "something
+    # changed, refetch now" signal and re-runs the same full query
+    # _refresh_pool already does every poll tick.
+    _POOL_EVENT = "pool.query"
+
     async def get_pool(self) -> None:
-        """Get pools from TrueNAS."""
+        """Refresh pools, then ensure the push subscription is active."""
+        await self._refresh_pool()
+        await self._ensure_push_subscription(
+            self._pool_push,
+            self._POOL_EVENT,
+            self._on_pool_push,
+            label="pool",
+        )
+
+    async def _on_pool_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh pool state on push notification."""
+        await self._refresh_pool()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_pool_push(self) -> None:
+        """Stop the pool push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._pool_push)
+
+    async def _refresh_pool(self) -> None:
+        """Query pool.query and recompute the pool state."""
         raw_pools = await self.api.query("pool.query")
         self.ds["pool"] = parse_api(
             data=self.ds["pool"],

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -521,6 +521,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._alerts_breaker = SubscriptionCircuitBreaker()
 
         self._service_push = _PushSourceState()
+        self._vm_push = _PushSourceState()
+        self._container_push = _PushSourceState()
+        self._app_push = _PushSourceState()
 
     # ---------------------------
     #   connected
@@ -1996,11 +1999,38 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_vm
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-22): core.subscribe on
+    # "vm.query" is accepted and returns a real subscription id. Like
+    # service/alerts, any push message is treated as a pure "something
+    # changed, refetch now" signal and re-runs the same full query
+    # _refresh_vm already does every poll tick.
+    _VM_EVENT = "vm.query"
+
     async def get_vm(self) -> None:
-        """Get VMs from TrueNAS."""
+        """Refresh VMs, then ensure the push subscription is active."""
         if not self._is_group_monitored(MONITOR_GROUP_VMS):
             self.ds["vm"] = {}
+            await self._stop_push_subscription(self._vm_push)
             return
+        await self._refresh_vm()
+        await self._ensure_push_subscription(
+            self._vm_push,
+            self._VM_EVENT,
+            self._on_vm_push,
+            label="vm",
+        )
+
+    async def _on_vm_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh VM state on push notification."""
+        await self._refresh_vm()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_vm_push(self) -> None:
+        """Stop the VM push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._vm_push)
+
+    async def _refresh_vm(self) -> None:
+        """Query vm.query and recompute the VM state."""
         self.ds["vm"] = parse_api(
             data=self.ds["vm"],
             source=await self.api.query("vm.query"),
@@ -2033,7 +2063,42 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_container
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-22): core.subscribe on
+    # both "container.query" and "virt.instance.query" is accepted and
+    # returns a real subscription id. Like service/alerts, any push message
+    # is treated as a pure "something changed, refetch now" signal and
+    # re-runs the same full query _refresh_container already does every poll
+    # tick. The topic is re-derived from supports_container_api() on every
+    # call (not cached) so a mid-session TrueNAS upgrade is picked up.
     async def get_container(self) -> None:
+        """Refresh containers, then ensure the push subscription is active."""
+        if not self._is_group_monitored(MONITOR_GROUP_CONTAINERS):
+            self.ds["container"] = {}
+            await self._stop_push_subscription(self._container_push)
+            return
+        await self._refresh_container()
+        event = (
+            "container.query"
+            if self.supports_container_api()
+            else "virt.instance.query"
+        )
+        await self._ensure_push_subscription(
+            self._container_push,
+            event,
+            self._on_container_push,
+            label="container",
+        )
+
+    async def _on_container_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh container state on push notification."""
+        await self._refresh_container()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_container_push(self) -> None:
+        """Stop the container push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._container_push)
+
+    async def _refresh_container(self) -> None:
         """Get virt CONTAINER instances (Incus) from TrueNAS.
 
         ``virt.instance.query`` returns both CONTAINER and VM Incus instances;
@@ -2041,10 +2106,6 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ``get_vm``). Container ``cpu``/``memory`` may be ``None``, so both are
         treated null-safely (this was the upstream crash, see #26).
         """
-        if not self._is_group_monitored(MONITOR_GROUP_CONTAINERS):
-            self.ds["container"] = {}
-            return
-
         if self.supports_container_api():
             await self._get_container_v26()
             return
@@ -2707,8 +2768,36 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_app
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-22): core.subscribe on
+    # "app.query" is accepted and returns a real subscription id. Like
+    # service/alerts, any push message is treated as a pure "something
+    # changed, refetch now" signal and re-runs the same full query
+    # _refresh_app already does every poll tick. get_app has no monitor-group
+    # gate today (unlike get_app_stats, which gates on MONITOR_GROUP_
+    # CONTAINERS), so this wrapper stays ungated too.
+    _APP_EVENT = "app.query"
+
     async def get_app(self) -> None:
-        """Get Apps from TrueNAS."""
+        """Refresh apps, then ensure the push subscription is active."""
+        await self._refresh_app()
+        await self._ensure_push_subscription(
+            self._app_push,
+            self._APP_EVENT,
+            self._on_app_push,
+            label="app",
+        )
+
+    async def _on_app_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh app state on push notification."""
+        await self._refresh_app()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_app_push(self) -> None:
+        """Stop the app push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._app_push)
+
+    async def _refresh_app(self) -> None:
+        """Query app.query and recompute the app state."""
         self.ds["app"] = parse_api(
             data=self.ds["app"],
             source=await self.api.query("app.query"),

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -61,6 +61,7 @@ from .const import (
     MONITOR_GROUP_VMS,
     UPTIME_EPOCH_TOLERANCE_SECONDS,
 )
+from .event_push import SubscriptionCircuitBreaker, SubscriptionPushConsumer
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -499,6 +500,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._app_stats_event_name: str | None = None
         self._app_stats_sub_id: str | None = None
+
+        self._alerts_sub_id: str | None = None
+        self._alerts_push_consumer: SubscriptionPushConsumer | None = None
+        self._alerts_breaker = SubscriptionCircuitBreaker()
 
     # ---------------------------
     #   connected
@@ -2175,7 +2180,20 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     #   get_alerts
     # ---------------------------
     async def get_alerts(self) -> None:
-        """Get alerts from TrueNAS."""
+        """Refresh alerts, then ensure the push subscription is active.
+
+        The full ``alert.list`` query below is cheap and stays unconditional
+        on every poll tick, so it doubles as the safety net if the push
+        subscription is inactive/tripped -- unlike ``app.stats``, alerts has
+        no cost difference between "query everything" and "read the queue",
+        so a failed subscription degrades straight back to today's plain
+        polling instead of needing a separate fallback path.
+        """
+        await self._refresh_alerts()
+        await self._ensure_alerts_subscription()
+
+    async def _refresh_alerts(self) -> None:
+        """Query alert.list and recompute the aggregated alerts state."""
         alerts = await self.api.query("alert.list")
         if not isinstance(alerts, list):
             _LOGGER.warning(
@@ -2213,6 +2231,93 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "disk_issues": disk_issues,
             "uuids": [a.get("uuid") for a in active_alerts if a.get("uuid")],
         }
+
+    # ---------------------------
+    #   alerts push subscription helpers
+    # ---------------------------
+    # Subscription lifecycle:
+    #   UNSUBSCRIBED: _alerts_sub_id is None.
+    #   SUBSCRIBED:   _alerts_sub_id and _alerts_push_consumer are set together.
+    #   stop_alerts clears both, unconditionally.
+    # Verified against a live TrueNAS instance (2026-08-21): core.subscribe on
+    # "alert.list" delivers a collection_update notification (msg: "removed")
+    # on alert.dismiss. The push consumer below treats arrival of any message
+    # as a pure "something changed, refetch now" signal and re-runs the same
+    # full query _refresh_alerts already does every poll tick, rather than
+    # trying to reconstruct the aggregated counts from partial CRUD payloads.
+    _ALERTS_EVENT = "alert.list"
+
+    async def _ensure_alerts_subscription(self) -> None:
+        """(Re-)establish the alerts push subscription if not already active."""
+        if not self.api.connected():
+            return
+
+        if self._alerts_sub_id and not await self.api.is_subscribed(
+            self._alerts_sub_id
+        ):
+            self._clear_alerts_subscription()
+
+        if self._alerts_sub_id:
+            return
+
+        if self._alerts_breaker.tripped:
+            if not self._alerts_breaker.should_attempt_reset():
+                return
+            self._alerts_breaker.reset()
+
+        try:
+            sub_id, queue = await self.api.subscribe_events(self._ALERTS_EVENT)
+        except Exception as err:
+            _LOGGER.exception("Failed to establish alerts subscription: %s", err)
+            return
+
+        if not sub_id or queue is None:
+            _LOGGER.debug("Alerts subscription failed: no sub_id/queue returned")
+            return
+
+        consumer = SubscriptionPushConsumer(
+            queue,
+            self._on_alerts_push,
+            breaker=self._alerts_breaker,
+            on_trip=self._on_alerts_breaker_trip,
+        )
+        consumer.start(task_factory=self.hass.async_create_background_task)
+        self._alerts_sub_id = sub_id
+        self._alerts_push_consumer = consumer
+        _LOGGER.debug("TrueNAS alerts push subscription established: %s", sub_id)
+
+    async def _on_alerts_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh alerts state on push notification (Sofort-Trigger)."""
+        await self._refresh_alerts()
+        self.async_set_updated_data(self.ds)
+
+    async def _on_alerts_breaker_trip(self) -> None:
+        """Unsubscribe and fall back to plain polling after the breaker trips."""
+        _LOGGER.warning(
+            "TrueNAS alerts subscription falling back to polling after circuit "
+            "breaker trip"
+        )
+        await self.stop_alerts()
+
+    def _clear_alerts_subscription(self) -> None:
+        """Clear local alerts subscription state."""
+        self._alerts_sub_id = None
+        self._alerts_push_consumer = None
+
+    async def stop_alerts(self) -> None:
+        """Stop the alerts push subscription, e.g. on unload."""
+        if self._alerts_push_consumer is not None:
+            await self._alerts_push_consumer.stop()
+        if self._alerts_sub_id and self.api.connected():
+            try:
+                await self.api.unsubscribe_events(self._alerts_sub_id)
+            except Exception as exc:
+                _LOGGER.debug(
+                    "TrueNAS failed to unsubscribe alerts %s (%s)",
+                    self._alerts_sub_id,
+                    exc,
+                )
+        self._clear_alerts_subscription()
 
     # ---------------------------
     #   get_certificates

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -522,6 +522,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._service_push = _PushSourceState()
         self._pool_push = _PushSourceState()
+        self._cloudsync_push = _PushSourceState()
+        self._replication_push = _PushSourceState()
+        self._rsync_push = _PushSourceState()
 
     # ---------------------------
     #   connected
@@ -2595,11 +2598,38 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_cloudsync
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-22): core.subscribe on
+    # "cloudsync.query" is accepted and returns a real subscription id. Like
+    # service/alerts, any push message is treated as a pure "something
+    # changed, refetch now" signal and re-runs the same full query
+    # _refresh_cloudsync already does every poll tick.
+    _CLOUDSYNC_EVENT = "cloudsync.query"
+
     async def get_cloudsync(self) -> None:
-        """Get cloudsync from TrueNAS."""
+        """Refresh cloudsync tasks, then ensure the push subscription is active."""
         if not self._is_group_monitored(MONITOR_GROUP_CLOUDSYNC):
             self.ds["cloudsync"] = {}
+            await self._stop_push_subscription(self._cloudsync_push)
             return
+        await self._refresh_cloudsync()
+        await self._ensure_push_subscription(
+            self._cloudsync_push,
+            self._CLOUDSYNC_EVENT,
+            self._on_cloudsync_push,
+            label="cloudsync",
+        )
+
+    async def _on_cloudsync_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh cloudsync state on push notification."""
+        await self._refresh_cloudsync()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_cloudsync_push(self) -> None:
+        """Stop the cloudsync push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._cloudsync_push)
+
+    async def _refresh_cloudsync(self) -> None:
+        """Query cloudsync.query and recompute the cloudsync state."""
         self.ds["cloudsync"] = parse_api(
             data=self.ds["cloudsync"],
             source=await self.api.query("cloudsync.query"),
@@ -2619,11 +2649,38 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_replication
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-22): core.subscribe on
+    # "replication.query" is accepted and returns a real subscription id. Like
+    # service/alerts, any push message is treated as a pure "something
+    # changed, refetch now" signal and re-runs the same full query
+    # _refresh_replication already does every poll tick.
+    _REPLICATION_EVENT = "replication.query"
+
     async def get_replication(self) -> None:
-        """Get replication from TrueNAS."""
+        """Refresh replication tasks, then ensure the push subscription is active."""
         if not self._is_group_monitored(MONITOR_GROUP_REPLICATION):
             self.ds["replication"] = {}
+            await self._stop_push_subscription(self._replication_push)
             return
+        await self._refresh_replication()
+        await self._ensure_push_subscription(
+            self._replication_push,
+            self._REPLICATION_EVENT,
+            self._on_replication_push,
+            label="replication",
+        )
+
+    async def _on_replication_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh replication state on push notification."""
+        await self._refresh_replication()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_replication_push(self) -> None:
+        """Stop the replication push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._replication_push)
+
+    async def _refresh_replication(self) -> None:
+        """Query replication.query and recompute the replication state."""
         self.ds["replication"] = parse_api(
             data=self.ds["replication"],
             source=await self.api.query("replication.query"),
@@ -2661,11 +2718,38 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_rsync
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-22): core.subscribe on
+    # "rsynctask.query" is accepted and returns a real subscription id. Like
+    # service/alerts, any push message is treated as a pure "something
+    # changed, refetch now" signal and re-runs the same full query
+    # _refresh_rsync already does every poll tick.
+    _RSYNC_EVENT = "rsynctask.query"
+
     async def get_rsync(self) -> None:
-        """Get rsync tasks from TrueNAS."""
+        """Refresh rsync tasks, then ensure the push subscription is active."""
         if not self._is_group_monitored(MONITOR_GROUP_RSYNC):
             self.ds["rsynctask"] = {}
+            await self._stop_push_subscription(self._rsync_push)
             return
+        await self._refresh_rsync()
+        await self._ensure_push_subscription(
+            self._rsync_push,
+            self._RSYNC_EVENT,
+            self._on_rsync_push,
+            label="rsync",
+        )
+
+    async def _on_rsync_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh rsync task state on push notification."""
+        await self._refresh_rsync()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_rsync_push(self) -> None:
+        """Stop the rsync push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._rsync_push)
+
+    async def _refresh_rsync(self) -> None:
+        """Query rsynctask.query and recompute the rsync task state."""
         self.ds["rsynctask"] = parse_api(
             data=self.ds["rsynctask"],
             source=await self.api.query("rsynctask.query"),

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -419,6 +419,21 @@ def _unwrap_app_stats_message(msg: dict[str, Any]) -> dict[str, Any] | None:
     return msg if isinstance(msg.get("fields"), list) else None
 
 
+class _PushSourceState:
+    """Per-source push-subscription bookkeeping (sub_id + consumer + breaker).
+
+    One instance per pushed ``coordinator.ds`` source (alerts, service, ...),
+    used by the generic ``_ensure_push_subscription``/``_stop_push_subscription``
+    helpers below so each new source only wires a handful of lines instead of
+    duplicating the full subscribe/consume/breaker lifecycle.
+    """
+
+    def __init__(self) -> None:
+        self.sub_id: str | None = None
+        self.consumer: SubscriptionPushConsumer | None = None
+        self.breaker = SubscriptionCircuitBreaker()
+
+
 # ---------------------------
 #   TrueNASControllerData
 # ---------------------------
@@ -504,6 +519,8 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._alerts_sub_id: str | None = None
         self._alerts_push_consumer: SubscriptionPushConsumer | None = None
         self._alerts_breaker = SubscriptionCircuitBreaker()
+
+        self._service_push = _PushSourceState()
 
     # ---------------------------
     #   connected
@@ -1416,8 +1433,35 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_service
     # ---------------------------
+    # Verified against a live TrueNAS instance (2026-08-21): core.subscribe on
+    # "service.query" is accepted and returns a real subscription id. Services
+    # change rarely (start/stop of a handful of daemons), so -- like alerts --
+    # any push message is treated as a pure "something changed, refetch now"
+    # signal and re-runs the same full query _refresh_service already does
+    # every poll tick.
+    _SERVICE_EVENT = "service.query"
+
     async def get_service(self) -> None:
-        """Get service info from TrueNAS."""
+        """Refresh services, then ensure the push subscription is active."""
+        await self._refresh_service()
+        await self._ensure_push_subscription(
+            self._service_push,
+            self._SERVICE_EVENT,
+            self._on_service_push,
+            label="service",
+        )
+
+    async def _on_service_push(self, _batch: list[Any]) -> None:
+        """Immediately refresh service state on push notification."""
+        await self._refresh_service()
+        self.async_set_updated_data(self.ds)
+
+    async def stop_service_push(self) -> None:
+        """Stop the service push subscription, e.g. on unload."""
+        await self._stop_push_subscription(self._service_push)
+
+    async def _refresh_service(self) -> None:
+        """Query service.query and recompute the service state."""
         service_names = {
             "afp": "AFP",
             "cifs": "SMB",
@@ -2175,6 +2219,84 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.ds["directoryservices"][uid]["healthy"] = (
                 vals.get("status") == "HEALTHY"
             )
+
+    # ---------------------------
+    #   generic push-subscription helpers
+    # ---------------------------
+    # Shared by every push-subscribed source added after alerts (the pilot,
+    # which keeps its own hand-rolled/tested implementation below rather than
+    # being retrofitted onto this, to avoid touching already live-verified
+    # code). New sources should follow the ``get_service``/``_refresh_service``
+    # pattern near the end of this file: a ``_PushSourceState`` instance field,
+    # an ``_EVENT`` constant, a thin ``get_<name>`` wrapper calling
+    # ``_refresh_<name>`` + ``_ensure_push_subscription``, an
+    # ``_on_<name>_push`` callback, and a ``stop_<name>_push`` for unload.
+    async def _ensure_push_subscription(
+        self,
+        state: _PushSourceState,
+        event: str,
+        on_push: Callable[[list[Any]], Awaitable[None]],
+        *,
+        label: str,
+    ) -> None:
+        """(Re-)establish a push subscription for one source if not active."""
+        if not self.api.connected():
+            return
+
+        if state.sub_id and not await self.api.is_subscribed(state.sub_id):
+            self._clear_push_subscription(state)
+
+        if state.sub_id:
+            return
+
+        if state.breaker.tripped:
+            if not state.breaker.should_attempt_reset():
+                return
+            state.breaker.reset()
+
+        try:
+            sub_id, queue = await self.api.subscribe_events(event)
+        except Exception as err:
+            _LOGGER.exception("Failed to establish %s subscription: %s", label, err)
+            return
+
+        if not sub_id or queue is None:
+            _LOGGER.debug("%s subscription failed: no sub_id/queue returned", label)
+            return
+
+        async def _on_trip() -> None:
+            _LOGGER.warning(
+                "TrueNAS %s subscription falling back to polling after circuit "
+                "breaker trip",
+                label,
+            )
+            await self._stop_push_subscription(state)
+
+        consumer = SubscriptionPushConsumer(
+            queue, on_push, breaker=state.breaker, on_trip=_on_trip
+        )
+        consumer.start(task_factory=self.hass.async_create_background_task)
+        state.sub_id = sub_id
+        state.consumer = consumer
+        _LOGGER.debug("TrueNAS %s push subscription established: %s", label, sub_id)
+
+    def _clear_push_subscription(self, state: _PushSourceState) -> None:
+        """Clear local subscription state for one source."""
+        state.sub_id = None
+        state.consumer = None
+
+    async def _stop_push_subscription(self, state: _PushSourceState) -> None:
+        """Stop one source's push subscription, e.g. on unload/breaker trip."""
+        if state.consumer is not None:
+            await state.consumer.stop()
+        if state.sub_id and self.api.connected():
+            try:
+                await self.api.unsubscribe_events(state.sub_id)
+            except Exception as exc:
+                _LOGGER.debug(
+                    "TrueNAS failed to unsubscribe %s (%s)", state.sub_id, exc
+                )
+        self._clear_push_subscription(state)
 
     # ---------------------------
     #   get_alerts

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -2498,7 +2498,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._alerts_sub_id and not await self.api.is_subscribed(
             self._alerts_sub_id
         ):
-            self._clear_alerts_subscription()
+            await self.stop_alerts()
 
         if self._alerts_sub_id:
             return

--- a/custom_components/truenas_ce/event_push.py
+++ b/custom_components/truenas_ce/event_push.py
@@ -26,6 +26,7 @@ Wiring these into a concrete ``coordinator.py`` data source (per the
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
@@ -164,26 +165,35 @@ class SubscriptionPushConsumer:
         self._task = task_factory(self._run(), f"{__name__}.push_consumer")
 
     async def stop(self) -> None:
-        """Cancel the background drain task and wait for it to finish."""
+        """Cancel the background drain task and wait for it to finish.
+
+        Safe to call from within the drain task itself (e.g. an ``on_trip``
+        callback invoked from :meth:`_run`): a task cannot await itself, so
+        that case just forgets the task and lets it unwind on its own instead
+        of cancelling/awaiting it.
+        """
         if self._task is None:
             return
-        self._task.cancel()
-        try:
-            await self._task
-        except asyncio.CancelledError:
-            pass
-        finally:
-            self._task = None
+        task, self._task = self._task, None
+        if task is asyncio.current_task():
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
     async def _run(self) -> None:
         try:
             while True:
-                batch = await self._collect_batch()
-                if self._breaker is not None and self._breaker.record_batch(len(batch)):
-                    if self._on_trip is not None:
-                        await self._on_trip()
+                batch, subscription_ended = await self._collect_batch()
+                if batch and not await self._drain_batch(batch):
                     return
-                await self._flush_callback(batch)
+                if subscription_ended:
+                    _LOGGER.debug(
+                        "SubscriptionPushConsumer: subscription ended, "
+                        "falling back to polling"
+                    )
+                    await self._notify_trip()
+                    return
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -192,14 +202,48 @@ class SubscriptionPushConsumer:
             )
             raise
 
-    async def _collect_batch(self) -> list[Any]:
-        """Wait for one message, then coalesce more within the debounce window."""
-        batch = [await self._queue.get()]
+    async def _drain_batch(self, batch: list[Any]) -> bool:
+        """Flush one batch; return False if the caller should stop draining."""
+        if self._breaker is not None and self._breaker.record_batch(len(batch)):
+            await self._notify_trip()
+            return False
+        try:
+            await self._flush_callback(batch)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _LOGGER.exception(
+                "SubscriptionPushConsumer: flush callback failed, falling "
+                "back to polling"
+            )
+            await self._notify_trip()
+            return False
+        return True
+
+    async def _notify_trip(self) -> None:
+        if self._on_trip is not None:
+            await self._on_trip()
+
+    async def _collect_batch(self) -> tuple[list[Any], bool]:
+        """Wait for one message, then coalesce more within the debounce window.
+
+        Returns ``(batch, subscription_ended)``. ``subscription_ended`` is
+        True once aiotruenas's internal subscription-terminator sentinel (a
+        non-dict queue item, see :meth:`TrueNASAPI.subscribe_events`) is
+        seen, meaning no further items will ever arrive on this queue.
+        """
+        first = await self._queue.get()
+        if not isinstance(first, dict):
+            return [], True
+        batch: list[Any] = [first]
         loop = asyncio.get_running_loop()
         deadline = loop.time() + self._debounce_seconds
         while (remaining := deadline - loop.time()) > 0:
             try:
-                batch.append(await asyncio.wait_for(self._queue.get(), remaining))
+                item = await asyncio.wait_for(self._queue.get(), remaining)
             except TimeoutError:
                 break
-        return batch
+            if not isinstance(item, dict):
+                return batch, True
+            batch.append(item)
+        return batch, False

--- a/custom_components/truenas_ce/event_push.py
+++ b/custom_components/truenas_ce/event_push.py
@@ -1,0 +1,205 @@
+"""Generic building blocks for event-subscription-based (push) data sources.
+
+Deliberately independent of Home Assistant and of :mod:`.api`/:mod:`.coordinator`
+so both pieces can be unit tested without a running TrueNAS connection or HA
+test harness:
+
+- ``SubscriptionCircuitBreaker`` decides when a subscription is too "chatty"
+  (e.g. a flapping VM/container) and should fall back to polling for a while.
+- ``SubscriptionPushConsumer`` drains a subscription's queue in the background
+  and delivers debounced batches to a callback immediately, instead of
+  waiting for the next poll tick to call ``get_subscription_events``.
+
+Wiring these into a concrete ``coordinator.py`` data source (per the
+``truenas-event-subscriptions-plan`` backlog note) means, per source:
+- construct a ``SubscriptionCircuitBreaker`` alongside the existing
+  ``_<name>_sub_id``/``_<name>_event_name`` state;
+- after subscribing, construct a ``SubscriptionPushConsumer`` wrapping the
+  returned queue, a callback that updates ``self.ds[<domain>]`` and calls
+  ``self.async_set_updated_data(self.ds)``, and an ``on_trip`` callback that
+  unsubscribes and clears the subscription state so the next poll cycle falls
+  back to ``api.query(...)``;
+- call ``start()``/``stop()`` from the same places ``_app_stats_sub_id`` is
+  set/cleared today.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Coroutine
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+FlushCallback = Callable[[list[Any]], Awaitable[None]]
+TripCallback = Callable[[], Awaitable[None]]
+TaskFactory = Callable[[Coroutine[Any, Any, None], str], "asyncio.Task[None]"]
+
+
+@dataclass(frozen=True)
+class CircuitBreakerConfig:
+    """Tuning knobs for :class:`SubscriptionCircuitBreaker`."""
+
+    message_threshold: int = 20
+    """A drained batch larger than this counts as one breaching cycle."""
+
+    consecutive_breaches_to_trip: int = 3
+    """Number of consecutive breaching cycles before the breaker trips."""
+
+    cooldown: timedelta = timedelta(minutes=5)
+    """How long the breaker stays open before a retry may be attempted."""
+
+
+class SubscriptionCircuitBreaker:
+    """Rate-based circuit breaker for a single event subscription.
+
+    Guards against a "crash-loop" style subscription (many state changes in a
+    short time) flooding the coordinator with messages. Call
+    :meth:`record_batch` once per drained batch; when it returns ``True`` the
+    caller must unsubscribe and fall back to polling until
+    :meth:`should_attempt_reset` returns ``True``.
+    """
+
+    def __init__(self, config: CircuitBreakerConfig | None = None) -> None:
+        self._config = config or CircuitBreakerConfig()
+        self._consecutive_breaches = 0
+        self._tripped = False
+        self._opened_at: datetime | None = None
+
+    @property
+    def tripped(self) -> bool:
+        """Return whether the breaker is currently open (fallback active)."""
+        return self._tripped
+
+    def record_batch(self, message_count: int) -> bool:
+        """Record a drained batch's size; return True if it just tripped."""
+        if self._tripped:
+            return False
+
+        if message_count > self._config.message_threshold:
+            self._consecutive_breaches += 1
+        else:
+            self._consecutive_breaches = 0
+
+        if self._consecutive_breaches < self._config.consecutive_breaches_to_trip:
+            return False
+
+        self._trip()
+        return True
+
+    def _trip(self) -> None:
+        self._tripped = True
+        self._opened_at = datetime.now(UTC)
+        _LOGGER.warning(
+            "Subscription circuit breaker tripped after %d consecutive "
+            "breaching cycles (threshold=%d messages/batch); falling back "
+            "to polling for %s",
+            self._consecutive_breaches,
+            self._config.message_threshold,
+            self._config.cooldown,
+        )
+
+    def should_attempt_reset(self) -> bool:
+        """Return True once the cooldown elapsed and a retry may be tried."""
+        if not self._tripped or self._opened_at is None:
+            return False
+        return datetime.now(UTC) - self._opened_at >= self._config.cooldown
+
+    def reset(self) -> None:
+        """Close the breaker again after a successful retry."""
+        self._tripped = False
+        self._opened_at = None
+        self._consecutive_breaches = 0
+
+
+def _default_task_factory(
+    coro: Coroutine[Any, Any, None], name: str
+) -> asyncio.Task[None]:
+    return asyncio.create_task(coro, name=name)
+
+
+class SubscriptionPushConsumer:
+    """Drains a subscription queue in the background and flushes debounced
+    batches immediately, instead of waiting for the next poll tick.
+
+    Couple this 1:1 to one subscription's lifecycle: create it in
+    ``start_<name>()`` right after subscribing and call :meth:`stop` in
+    ``stop_<name>()``/on unload/on reconnect, mirroring the existing
+    ``_app_stats_sub_id`` lifecycle handling in ``coordinator.py``.
+    """
+
+    def __init__(
+        self,
+        queue: asyncio.Queue[Any],
+        flush_callback: FlushCallback,
+        *,
+        debounce: timedelta = timedelta(seconds=1.5),
+        breaker: SubscriptionCircuitBreaker | None = None,
+        on_trip: TripCallback | None = None,
+    ) -> None:
+        self._queue = queue
+        self._flush_callback = flush_callback
+        self._debounce_seconds = debounce.total_seconds()
+        self._breaker = breaker
+        self._on_trip = on_trip
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def running(self) -> bool:
+        """Return whether the background drain task is currently active."""
+        return self._task is not None and not self._task.done()
+
+    def start(self, task_factory: TaskFactory = _default_task_factory) -> None:
+        """Start the background drain task, unless already running.
+
+        Pass a ``task_factory`` (e.g. ``hass.async_create_background_task``)
+        so HA can track/cancel the task on shutdown; a plain
+        ``asyncio.create_task`` is used by default for standalone use/tests.
+        """
+        if self.running:
+            return
+        self._task = task_factory(self._run(), f"{__name__}.push_consumer")
+
+    async def stop(self) -> None:
+        """Cancel the background drain task and wait for it to finish."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                batch = await self._collect_batch()
+                if self._breaker is not None and self._breaker.record_batch(len(batch)):
+                    if self._on_trip is not None:
+                        await self._on_trip()
+                    return
+                await self._flush_callback(batch)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _LOGGER.exception(
+                "SubscriptionPushConsumer: unhandled error, background task stopping"
+            )
+            raise
+
+    async def _collect_batch(self) -> list[Any]:
+        """Wait for one message, then coalesce more within the debounce window."""
+        batch = [await self._queue.get()]
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._debounce_seconds
+        while (remaining := deadline - loop.time()) > 0:
+            try:
+                batch.append(await asyncio.wait_for(self._queue.get(), remaining))
+            except TimeoutError:
+                break
+        return batch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ a bare ``assert`` at module-import time.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -31,11 +32,18 @@ collect_ignore_glob: list[str] = (
 
 
 def load_module_from_path(name: str, path: Path) -> ModuleType:
-    """Load a standalone module by file path."""
+    """Load a standalone module by file path.
+
+    Registers the module in ``sys.modules`` before executing it, since
+    ``dataclasses`` (used with ``from __future__ import annotations``) resolves
+    string annotations via a ``sys.modules`` lookup of the class's own module
+    and raises ``AttributeError`` otherwise.
+    """
     spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot load module {name!r} from {path}")
     module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -57,3 +65,10 @@ def vt() -> ModuleType:
     """The ``.github/validate_translations.py`` script under test."""
     path = REPO_ROOT / ".github" / "validate_translations.py"
     return load_module_from_path("validate_translations", path)
+
+
+@pytest.fixture(scope="session")
+def ep() -> ModuleType:
+    """The ``custom_components.truenas_ce.event_push`` module under test."""
+    path = REPO_ROOT / "custom_components" / "truenas_ce" / "event_push.py"
+    return load_module_from_path("event_push", path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -681,6 +681,18 @@ async def test_is_subscribed_delegates_when_connected(
     connected_api._client.is_subscribed.assert_called_once_with("sub-123")
 
 
+async def test_is_subscribed_degrades_to_false_on_client_error(
+    connected_api: TrueNASAPI,
+) -> None:
+    """A transient client/protocol error must degrade to 'not subscribed'
+    (#101 review) so callers fall back to resubscribing/polling instead of
+    letting the exception escape the source getter."""
+    connected_api._client.is_subscribed = AsyncMock(
+        side_effect=TrueNASCallError("boom")
+    )
+    assert await connected_api.is_subscribed("sub-123") is False
+
+
 async def test_subscribe_events_clears_previous_error_on_success(
     connected_api: TrueNASAPI,
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -74,6 +74,7 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._alerts_push_consumer = None
     coord._alerts_breaker = SubscriptionCircuitBreaker()
     coord._service_push = _PushSourceState()
+    coord._pool_push = _PushSourceState()
     coord.orphaned_statistics = []
     coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
     coord.host = "truenas.local"
@@ -2844,6 +2845,75 @@ async def test_add_boot_pool_noop_when_absent() -> None:
     coord.api.query = AsyncMock(return_value=None)
     await coord._add_boot_pool()
     assert coord.ds["pool"] == {}
+
+
+# ---------------------------
+#   get_pool push subscription wiring
+# ---------------------------
+async def test_get_pool_ensures_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"pool": {}, "dataset": {}}
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_pool()
+
+    coord.api.subscribe_events.assert_awaited_once_with("pool.query")
+    assert coord._pool_push.sub_id == "sub-1"
+    await coord._pool_push.consumer.stop()
+
+
+async def test_on_pool_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {
+        "pool": {},
+        "dataset": {"tank": {"mountpoint": "/mnt/tank", "available": 40, "used": 60}},
+    }
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "guid": "g1",
+                    "name": "tank",
+                    "path": "/mnt/tank",
+                    "fragmentation": "12",
+                    "topology": {},
+                }
+            ],
+            None,  # boot.get_state
+        ]
+    )
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_pool_push([{"msg": "changed"}])
+
+    assert coord.ds["pool"]["g1"]["available"] == 40
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_pool_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._pool_push,
+        coord._POOL_EVENT,
+        coord._on_pool_push,
+        label="pool",
+    )
+
+    await coord.stop_pool_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._pool_push.sub_id is None
 
 
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2613,6 +2613,7 @@ async def test_ensure_push_subscription_noop_when_already_active() -> None:
     coord.api.subscribe_events = AsyncMock()
     state = _PushSourceState()
     state.sub_id = "sub-existing"
+    state.event = "svc.query"
 
     await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
 
@@ -2634,6 +2635,30 @@ async def test_ensure_push_subscription_resubscribes_when_stale() -> None:
 
     coord.api.subscribe_events.assert_awaited_once_with("svc.query")
     assert state.sub_id == "sub-new"
+    await state.consumer.stop()
+
+
+async def test_ensure_push_subscription_resubscribes_when_topic_changes() -> None:
+    """A source's event topic changing (e.g. mid-session API upgrade) must
+    tear down the old subscription and establish a new one for the new
+    topic, not silently keep listening on the old one (#101 review)."""
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.is_subscribed = AsyncMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-new", asyncio.Queue()))
+    state = _PushSourceState()
+    state.sub_id = "sub-old"
+    state.event = "virt.instance.query"
+
+    await coord._ensure_push_subscription(
+        state, "container.query", AsyncMock(), label="container"
+    )
+
+    coord.api.subscribe_events.assert_awaited_once_with("container.query")
+    assert state.sub_id == "sub-new"
+    assert state.event == "container.query"
     await state.consumer.stop()
 
 
@@ -2741,6 +2766,33 @@ async def test_on_service_push_refreshes_and_notifies() -> None:
 
     assert coord.ds["service"][1]["running"] is True
     coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_refresh_locked_serializes_concurrent_refreshes() -> None:
+    """A slower poll refresh must not clobber a faster, later-started push
+    refresh of the same source once it has already applied its result
+    (#101 review: push vs. poll race on ``self.ds``)."""
+    coord = _bare_coordinator()
+    state = _PushSourceState()
+    order: list[str] = []
+
+    async def slow_refresh() -> None:
+        order.append("slow-start")
+        await asyncio.sleep(0.02)
+        order.append("slow-end")
+
+    async def fast_refresh() -> None:
+        order.append("fast-start")
+        order.append("fast-end")
+
+    slow_task = asyncio.create_task(coord._refresh_locked(state, slow_refresh))
+    await asyncio.sleep(0)  # let slow_refresh acquire the lock and start
+    fast_task = asyncio.create_task(coord._refresh_locked(state, fast_refresh))
+
+    await asyncio.gather(slow_task, fast_task)
+
+    # fast_refresh must wait for slow_refresh to fully finish, not interleave.
+    assert order == ["slow-start", "slow-end", "fast-start", "fast-end"]
 
 
 async def test_stop_service_push_unsubscribes_and_clears() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,6 +14,7 @@ used for ``TrueNASConfigFlow``.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -46,6 +47,7 @@ from custom_components.truenas_ce.const import (
     MONITOR_GROUP_VMS,
 )
 from custom_components.truenas_ce.coordinator import (
+    SubscriptionCircuitBreaker,
     TrueNASCoordinator,
     _accumulate_vdev_errors,
     _aggregate_topology_errors,
@@ -67,6 +69,9 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord = TrueNASCoordinator.__new__(TrueNASCoordinator)
     coord._app_stats_event_name = None
     coord._app_stats_sub_id = None
+    coord._alerts_sub_id = None
+    coord._alerts_push_consumer = None
+    coord._alerts_breaker = SubscriptionCircuitBreaker()
     coord.orphaned_statistics = []
     coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
     coord.host = "truenas.local"
@@ -632,6 +637,7 @@ async def test_get_alerts_malformed_response_resets_to_defaults() -> None:
     coord = _bare_coordinator()
     coord.ds = {"alerts": {}}
     coord.api = MagicMock()
+    coord.api.connected.return_value = False
     coord.api.query = AsyncMock(return_value={"not": "a list"})
     await coord.get_alerts()
     assert coord.ds["alerts"] == {
@@ -648,6 +654,7 @@ async def test_get_alerts_filters_dismissed_and_counts_levels() -> None:
     coord = _bare_coordinator()
     coord.ds = {"alerts": {}}
     coord.api = MagicMock()
+    coord.api.connected.return_value = False
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -695,6 +702,7 @@ async def test_get_alerts_no_disk_issues_when_unrelated() -> None:
     coord = _bare_coordinator()
     coord.ds = {"alerts": {}}
     coord.api = MagicMock()
+    coord.api.connected.return_value = False
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -708,6 +716,175 @@ async def test_get_alerts_no_disk_issues_when_unrelated() -> None:
     )
     await coord.get_alerts()
     assert coord.ds["alerts"]["disk_issues"] is False
+
+
+# ---------------------------
+#   alerts push subscription
+# ---------------------------
+def _hass_with_background_tasks() -> MagicMock:
+    """A hass stub whose async_create_background_task really schedules the coro.
+
+    A plain MagicMock would return a mock without ever awaiting the passed
+    coroutine, leaving it un-awaited (and the consumer loop never running) --
+    real ``asyncio.create_task`` is needed so ``SubscriptionPushConsumer``
+    behaves like it does in production.
+    """
+    hass = MagicMock()
+    hass.async_create_background_task = lambda coro, name: asyncio.create_task(
+        coro, name=name
+    )
+    return hass
+
+
+async def test_ensure_alerts_subscription_noop_when_not_connected() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.subscribe_events = AsyncMock()
+
+    await coord._ensure_alerts_subscription()
+
+    coord.api.subscribe_events.assert_not_awaited()
+    assert coord._alerts_sub_id is None
+
+
+async def test_ensure_alerts_subscription_subscribes_once() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord._ensure_alerts_subscription()
+
+    coord.api.subscribe_events.assert_awaited_once_with("alert.list")
+    assert coord._alerts_sub_id == "sub-1"
+    assert coord._alerts_push_consumer is not None
+    await coord._alerts_push_consumer.stop()
+
+
+async def test_ensure_alerts_subscription_noop_when_already_active() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.is_subscribed = AsyncMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock()
+    coord._alerts_sub_id = "sub-existing"
+
+    await coord._ensure_alerts_subscription()
+
+    coord.api.subscribe_events.assert_not_awaited()
+    assert coord._alerts_sub_id == "sub-existing"
+
+
+async def test_ensure_alerts_subscription_resubscribes_when_stale() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.is_subscribed = AsyncMock(return_value=False)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-new", asyncio.Queue()))
+    coord._alerts_sub_id = "sub-stale"
+
+    await coord._ensure_alerts_subscription()
+
+    coord.api.subscribe_events.assert_awaited_once_with("alert.list")
+    assert coord._alerts_sub_id == "sub-new"
+    await coord._alerts_push_consumer.stop()
+
+
+async def test_ensure_alerts_subscription_handles_subscribe_failure() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(side_effect=Exception("subscribe failed"))
+
+    await coord._ensure_alerts_subscription()
+
+    assert coord._alerts_sub_id is None
+    assert coord._alerts_push_consumer is None
+
+
+async def test_ensure_alerts_subscription_handles_no_sub_id_returned() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=(None, None))
+
+    await coord._ensure_alerts_subscription()
+
+    assert coord._alerts_sub_id is None
+
+
+async def test_ensure_alerts_subscription_respects_breaker_cooldown() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock()
+    for _ in range(3):  # default config trips after 3 consecutive breaches
+        coord._alerts_breaker.record_batch(9999)
+
+    await coord._ensure_alerts_subscription()
+
+    coord.api.subscribe_events.assert_not_awaited()
+    assert coord._alerts_sub_id is None
+
+
+async def test_on_alerts_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"alerts": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"dismissed": False, "level": "CRITICAL", "formatted": "x"}]
+    )
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_alerts_push([{"msg": "removed"}])
+
+    assert coord.ds["alerts"]["count"] == 1
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_on_alerts_breaker_trip_stops_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+    coord._alerts_sub_id = "sub-1"
+
+    await coord._on_alerts_breaker_trip()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._alerts_sub_id is None
+    assert coord._alerts_push_consumer is None
+
+
+async def test_stop_alerts_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_alerts_subscription()
+
+    await coord.stop_alerts()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._alerts_sub_id is None
+    assert coord._alerts_push_consumer is None
+
+
+async def test_stop_alerts_noop_when_not_subscribed() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+
+    await coord.stop_alerts()
+
+    coord.api.unsubscribe_events.assert_not_awaited()
+    assert coord._alerts_sub_id is None
 
 
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -75,6 +75,9 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._alerts_breaker = SubscriptionCircuitBreaker()
     coord._service_push = _PushSourceState()
     coord._pool_push = _PushSourceState()
+    coord._cloudsync_push = _PushSourceState()
+    coord._replication_push = _PushSourceState()
+    coord._rsync_push = _PushSourceState()
     coord.orphaned_statistics = []
     coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
     coord.host = "truenas.local"
@@ -2758,6 +2761,164 @@ async def test_stop_service_push_unsubscribes_and_clears() -> None:
 
 
 # ---------------------------
+#   get_cloudsync / get_replication / get_rsync push subscription wiring
+# ---------------------------
+async def test_get_cloudsync_ensures_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cloudsync": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CLOUDSYNC]}
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_cloudsync()
+
+    coord.api.subscribe_events.assert_awaited_once_with("cloudsync.query")
+    assert coord._cloudsync_push.sub_id == "sub-1"
+    await coord._cloudsync_push.consumer.stop()
+
+
+async def test_on_cloudsync_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cloudsync": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": "cs1", "description": "backup"}])
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_cloudsync_push([{"msg": "changed"}])
+
+    assert "cs1" in coord.ds["cloudsync"]
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_cloudsync_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._cloudsync_push,
+        coord._CLOUDSYNC_EVENT,
+        coord._on_cloudsync_push,
+        label="cloudsync",
+    )
+
+    await coord.stop_cloudsync_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._cloudsync_push.sub_id is None
+
+
+async def test_get_replication_ensures_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"replication": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_REPLICATION]}
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_replication()
+
+    coord.api.subscribe_events.assert_awaited_once_with("replication.query")
+    assert coord._replication_push.sub_id == "sub-1"
+    await coord._replication_push.consumer.stop()
+
+
+async def test_on_replication_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"replication": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[{"id": 1, "name": "repl1", "job": {"state": "RUNNING"}}]
+    )
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_replication_push([{"msg": "changed"}])
+
+    assert coord.ds["replication"][1]["state"] == "RUNNING"
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_replication_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._replication_push,
+        coord._REPLICATION_EVENT,
+        coord._on_replication_push,
+        label="replication",
+    )
+
+    await coord.stop_replication_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._replication_push.sub_id is None
+
+
+async def test_get_rsync_ensures_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"rsynctask": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_RSYNC]}
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_rsync()
+
+    coord.api.subscribe_events.assert_awaited_once_with("rsynctask.query")
+    assert coord._rsync_push.sub_id == "sub-1"
+    await coord._rsync_push.consumer.stop()
+
+
+async def test_on_rsync_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"rsynctask": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": 1, "path": "/mnt/tank"}])
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_rsync_push([{"msg": "changed"}])
+
+    assert 1 in coord.ds["rsynctask"]
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_rsync_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._rsync_push,
+        coord._RSYNC_EVENT,
+        coord._on_rsync_push,
+        label="rsync",
+    )
+
+    await coord.stop_rsync_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._rsync_push.sub_id is None
+
+
+# ---------------------------
 #   get_pool / _add_boot_pool
 # ---------------------------
 async def test_get_pool_uses_dataset_mountpoint_match() -> None:
@@ -3577,9 +3738,31 @@ async def test_get_cloudsync_parses_when_monitored() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CLOUDSYNC]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(return_value=[{"id": "cs1", "description": "backup"}])
     await coord.get_cloudsync()
     assert "cs1" in coord.ds["cloudsync"]
+
+
+async def test_get_cloudsync_not_monitored_stops_active_push() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"cloudsync": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+    consumer = MagicMock()
+    consumer.stop = AsyncMock()
+    coord._cloudsync_push.sub_id = "sub-1"
+    coord._cloudsync_push.consumer = consumer
+
+    await coord.get_cloudsync()
+
+    assert coord.ds["cloudsync"] == {}
+    consumer.stop.assert_awaited_once()
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._cloudsync_push.sub_id is None
 
 
 async def test_get_replication_falls_back_to_job_state() -> None:
@@ -3588,6 +3771,7 @@ async def test_get_replication_falls_back_to_job_state() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_REPLICATION]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[{"id": 1, "name": "repl1", "job": {"state": "RUNNING"}}]
     )
@@ -3607,6 +3791,27 @@ async def test_get_replication_empty_when_not_monitored() -> None:
     assert coord.ds["replication"] == {}
 
 
+async def test_get_replication_not_monitored_stops_active_push() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"replication": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+    consumer = MagicMock()
+    consumer.stop = AsyncMock()
+    coord._replication_push.sub_id = "sub-1"
+    coord._replication_push.consumer = consumer
+
+    await coord.get_replication()
+
+    assert coord.ds["replication"] == {}
+    consumer.stop.assert_awaited_once()
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._replication_push.sub_id is None
+
+
 async def test_get_rsync_empty_when_not_monitored() -> None:
     coord = _bare_coordinator()
     coord.ds = {"rsynctask": {"stale": {}}}
@@ -3618,12 +3823,34 @@ async def test_get_rsync_empty_when_not_monitored() -> None:
     assert coord.ds["rsynctask"] == {}
 
 
+async def test_get_rsync_not_monitored_stops_active_push() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"rsynctask": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+    consumer = MagicMock()
+    consumer.stop = AsyncMock()
+    coord._rsync_push.sub_id = "sub-1"
+    coord._rsync_push.consumer = consumer
+
+    await coord.get_rsync()
+
+    assert coord.ds["rsynctask"] == {}
+    consumer.stop.assert_awaited_once()
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._rsync_push.sub_id is None
+
+
 async def test_get_rsync_parses_when_monitored() -> None:
     coord = _bare_coordinator()
     coord.ds = {"rsynctask": {}}
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_RSYNC]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(return_value=[{"id": 1, "path": "/mnt/tank"}])
     await coord.get_rsync()
     assert 1 in coord.ds["rsynctask"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -74,6 +74,9 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._alerts_push_consumer = None
     coord._alerts_breaker = SubscriptionCircuitBreaker()
     coord._service_push = _PushSourceState()
+    coord._vm_push = _PushSourceState()
+    coord._container_push = _PushSourceState()
+    coord._app_push = _PushSourceState()
     coord.orphaned_statistics = []
     coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
     coord.host = "truenas.local"
@@ -3120,6 +3123,7 @@ async def test_get_vm_computes_memory_and_running() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_VMS]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -3142,6 +3146,7 @@ async def test_get_vm_handles_null_memory() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_VMS]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -3158,6 +3163,87 @@ async def test_get_vm_handles_null_memory() -> None:
 
 
 # ---------------------------
+#   get_vm push subscription wiring
+# ---------------------------
+async def test_get_vm_ensures_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"vm": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_VMS]}
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_vm()
+
+    coord.api.subscribe_events.assert_awaited_once_with("vm.query")
+    assert coord._vm_push.sub_id == "sub-1"
+    await coord._vm_push.consumer.stop()
+
+
+async def test_on_vm_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"vm": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "vm1",
+                "vcpus": 2,
+                "memory": 1024,
+                "status": {"state": "RUNNING"},
+            }
+        ]
+    )
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_vm_push([{"msg": "changed"}])
+
+    assert coord.ds["vm"][1]["running"] is True
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_vm_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._vm_push,
+        coord._VM_EVENT,
+        coord._on_vm_push,
+        label="vm",
+    )
+
+    await coord.stop_vm_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._vm_push.sub_id is None
+
+
+async def test_get_vm_not_monitored_stops_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"vm": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+    coord._vm_push.sub_id = "sub-1"
+
+    await coord.get_vm()
+
+    assert coord.ds["vm"] == {}
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._vm_push.sub_id is None
+
+
+# ---------------------------
 #   get_container
 # ---------------------------
 async def test_get_container_filters_container_type_and_computes_fields() -> None:
@@ -3166,6 +3252,7 @@ async def test_get_container_filters_container_type_and_computes_fields() -> Non
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -3196,6 +3283,7 @@ async def test_get_container_v26_uses_container_query() -> None:
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
     coord._version_major, coord._version_minor = 26, 0
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -3266,6 +3354,7 @@ async def test_get_container_normalizes_non_numeric_memory() -> None:
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[{"id": "c1", "name": "app1", "type": "CONTAINER", "memory": None}]
     )
@@ -3292,10 +3381,107 @@ async def test_get_container_logs_when_query_returns_non_list(
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(return_value=None)
     with caplog.at_level("DEBUG"):
         await coord.get_container()
     assert coord.ds["container"] == {}
+
+
+# ---------------------------
+#   get_container push subscription wiring
+# ---------------------------
+async def test_get_container_ensures_push_subscription_legacy_topic() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
+    coord._version_major, coord._version_minor = 25, 10
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_container()
+
+    coord.api.subscribe_events.assert_awaited_once_with("virt.instance.query")
+    assert coord._container_push.sub_id == "sub-1"
+    await coord._container_push.consumer.stop()
+
+
+async def test_get_container_ensures_push_subscription_v26_topic() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: [MONITOR_GROUP_CONTAINERS]}
+    coord._version_major, coord._version_minor = 26, 0
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_container()
+
+    coord.api.subscribe_events.assert_awaited_once_with("container.query")
+    assert coord._container_push.sub_id == "sub-1"
+    await coord._container_push.consumer.stop()
+
+
+async def test_on_container_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {}}
+    coord._version_major, coord._version_minor = 25, 10
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"id": "c1", "name": "app1", "type": "CONTAINER", "status": "RUNNING"}
+        ]
+    )
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_container_push([{"msg": "changed"}])
+
+    assert coord.ds["container"]["c1"]["running"] is True
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_container_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._container_push,
+        "virt.instance.query",
+        coord._on_container_push,
+        label="container",
+    )
+
+    await coord.stop_container_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._container_push.sub_id is None
+
+
+async def test_get_container_not_monitored_stops_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"container": {"stale": {}}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_MONITORED_GROUPS: []}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+    coord._container_push.sub_id = "sub-1"
+
+    await coord.get_container()
+
+    assert coord.ds["container"] == {}
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._container_push.sub_id is None
 
 
 # ---------------------------
@@ -3612,6 +3798,7 @@ async def test_get_app_catalog_update_available() -> None:
     coord = _bare_coordinator()
     coord.ds = {"app": {}}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -3634,6 +3821,7 @@ async def test_get_app_custom_app_falls_back_to_image_updates() -> None:
     coord = _bare_coordinator()
     coord.ds = {"app": {}}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -3655,6 +3843,7 @@ async def test_get_app_no_update_for_noncustom_without_upgrade() -> None:
     coord = _bare_coordinator()
     coord.ds = {"app": {}}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -3670,6 +3859,71 @@ async def test_get_app_no_update_for_noncustom_without_upgrade() -> None:
     coord._refresh_app_update_jobs = AsyncMock()
     await coord.get_app()
     assert coord.ds["app"]["app1"]["update_available"] is False
+
+
+# ---------------------------
+#   get_app push subscription wiring
+# ---------------------------
+async def test_get_app_ensures_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {}}
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord._refresh_app_update_jobs = AsyncMock()
+
+    await coord.get_app()
+
+    coord.api.subscribe_events.assert_awaited_once_with("app.query")
+    assert coord._app_push.sub_id == "sub-1"
+    await coord._app_push.consumer.stop()
+
+
+async def test_on_app_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"app": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": "app1",
+                "name": "app1",
+                "state": "RUNNING",
+                "upgrade_available": False,
+                "custom_app": False,
+                "image_updates_available": False,
+            }
+        ]
+    )
+    coord._refresh_app_update_jobs = AsyncMock()
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_app_push([{"msg": "changed"}])
+
+    assert coord.ds["app"]["app1"]["running"] is True
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_app_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._app_push,
+        coord._APP_EVENT,
+        coord._on_app_push,
+        label="app",
+    )
+
+    await coord.stop_app_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._app_push.sub_id is None
 
 
 async def test_refresh_app_update_job_mirrors_running_progress() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -59,6 +59,7 @@ from custom_components.truenas_ce.coordinator import (
     _is_truenas_sensor_id,
     _median,
     _netdata_mean_value,
+    _PushSourceState,
     _stat_name_similar,
     _to_int,
 )
@@ -72,6 +73,7 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._alerts_sub_id = None
     coord._alerts_push_consumer = None
     coord._alerts_breaker = SubscriptionCircuitBreaker()
+    coord._service_push = _PushSourceState()
     coord.orphaned_statistics = []
     coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
     coord.host = "truenas.local"
@@ -2539,6 +2541,7 @@ async def test_get_service_derives_running_and_display_name() -> None:
     coord = _bare_coordinator()
     coord.ds = {"service": {}}
     coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
     coord.api.query = AsyncMock(
         return_value=[
             {
@@ -2561,6 +2564,196 @@ async def test_get_service_derives_running_and_display_name() -> None:
     assert coord.ds["service"][1]["running"] is True
     assert coord.ds["service"][1]["display_name"] == "SMB"
     assert coord.ds["service"][2]["display_name"] == "Custom SSH"
+
+
+# ---------------------------
+#   generic push-subscription helpers (_ensure_push_subscription et al.)
+# ---------------------------
+async def test_ensure_push_subscription_noop_when_not_connected() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.subscribe_events = AsyncMock()
+    state = _PushSourceState()
+
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    coord.api.subscribe_events.assert_not_awaited()
+    assert state.sub_id is None
+
+
+async def test_ensure_push_subscription_subscribes_once() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    state = _PushSourceState()
+
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    coord.api.subscribe_events.assert_awaited_once_with("svc.query")
+    assert state.sub_id == "sub-1"
+    assert state.consumer is not None
+    await state.consumer.stop()
+
+
+async def test_ensure_push_subscription_noop_when_already_active() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.is_subscribed = AsyncMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock()
+    state = _PushSourceState()
+    state.sub_id = "sub-existing"
+
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    coord.api.subscribe_events.assert_not_awaited()
+    assert state.sub_id == "sub-existing"
+
+
+async def test_ensure_push_subscription_resubscribes_when_stale() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.is_subscribed = AsyncMock(return_value=False)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-new", asyncio.Queue()))
+    state = _PushSourceState()
+    state.sub_id = "sub-stale"
+
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    coord.api.subscribe_events.assert_awaited_once_with("svc.query")
+    assert state.sub_id == "sub-new"
+    await state.consumer.stop()
+
+
+async def test_ensure_push_subscription_handles_subscribe_failure() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(side_effect=Exception("subscribe failed"))
+    state = _PushSourceState()
+
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    assert state.sub_id is None
+    assert state.consumer is None
+
+
+async def test_ensure_push_subscription_handles_no_sub_id_returned() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=(None, None))
+    state = _PushSourceState()
+
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    assert state.sub_id is None
+
+
+async def test_ensure_push_subscription_respects_breaker_cooldown() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock()
+    state = _PushSourceState()
+    for _ in range(3):  # default config trips after 3 consecutive breaches
+        state.breaker.record_batch(9999)
+
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    coord.api.subscribe_events.assert_not_awaited()
+    assert state.sub_id is None
+
+
+async def test_stop_push_subscription_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    state = _PushSourceState()
+    await coord._ensure_push_subscription(state, "svc.query", AsyncMock(), label="svc")
+
+    await coord._stop_push_subscription(state)
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert state.sub_id is None
+    assert state.consumer is None
+
+
+async def test_stop_push_subscription_noop_when_not_subscribed() -> None:
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.unsubscribe_events = AsyncMock()
+    state = _PushSourceState()
+
+    await coord._stop_push_subscription(state)
+
+    coord.api.unsubscribe_events.assert_not_awaited()
+    assert state.sub_id is None
+
+
+# ---------------------------
+#   get_service push subscription wiring
+# ---------------------------
+async def test_get_service_ensures_push_subscription() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"service": {}}
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.query = AsyncMock(return_value=[])
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+
+    await coord.get_service()
+
+    coord.api.subscribe_events.assert_awaited_once_with("service.query")
+    assert coord._service_push.sub_id == "sub-1"
+    await coord._service_push.consumer.stop()
+
+
+async def test_on_service_push_refreshes_and_notifies() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"service": {}}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"id": 1, "service": "ssh", "name": "", "enable": True, "state": "RUNNING"}
+        ]
+    )
+    coord.async_set_updated_data = MagicMock()
+
+    await coord._on_service_push([{"msg": "changed"}])
+
+    assert coord.ds["service"][1]["running"] is True
+    coord.async_set_updated_data.assert_called_once_with(coord.ds)
+
+
+async def test_stop_service_push_unsubscribes_and_clears() -> None:
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-1", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    await coord._ensure_push_subscription(
+        coord._service_push,
+        coord._SERVICE_EVENT,
+        coord._on_service_push,
+        label="service",
+    )
+
+    await coord.stop_service_push()
+
+    coord.api.unsubscribe_events.assert_awaited_once_with("sub-1")
+    assert coord._service_push.sub_id is None
 
 
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -802,6 +802,29 @@ async def test_ensure_alerts_subscription_resubscribes_when_stale() -> None:
     await coord._alerts_push_consumer.stop()
 
 
+async def test_ensure_alerts_subscription_stops_orphaned_consumer_when_stale() -> None:
+    """A stale alerts subscription must stop the old consumer's background
+    task, not just drop the local reference, or it keeps running orphaned
+    and delivering duplicate refreshes (#101 review, same bug as the
+    generic _ensure_push_subscription path)."""
+    coord = _bare_coordinator()
+    coord.hass = _hass_with_background_tasks()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.api.is_subscribed = AsyncMock(return_value=False)
+    coord.api.subscribe_events = AsyncMock(return_value=("sub-new", asyncio.Queue()))
+    coord.api.unsubscribe_events = AsyncMock()
+    coord._alerts_sub_id = "sub-stale"
+    old_consumer = coord._alerts_push_consumer = MagicMock()
+    old_consumer.stop = AsyncMock()
+
+    await coord._ensure_alerts_subscription()
+
+    old_consumer.stop.assert_awaited_once()
+    assert coord._alerts_push_consumer is not old_consumer
+    await coord._alerts_push_consumer.stop()
+
+
 async def test_ensure_alerts_subscription_handles_subscribe_failure() -> None:
     coord = _bare_coordinator()
     coord.api = MagicMock()

--- a/tests/test_event_push.py
+++ b/tests/test_event_push.py
@@ -164,6 +164,102 @@ async def test_consumer_trip_stops_without_flushing_and_calls_on_trip(
         await consumer.stop()
 
 
+async def test_consumer_trip_callback_calling_stop_does_not_raise(
+    ep: ModuleType,
+) -> None:
+    """An ``on_trip`` callback that calls ``consumer.stop()`` on itself (as
+    the coordinator's ``_ensure_push_subscription`` does) must not deadlock
+    or raise -- a task cannot await itself, so ``stop()`` must detect that
+    case (regression test for #101 review comment)."""
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def flush(batch: list) -> None:
+        pass
+
+    breaker = ep.SubscriptionCircuitBreaker(
+        ep.CircuitBreakerConfig(message_threshold=0, consecutive_breaches_to_trip=1)
+    )
+    consumer: ep.SubscriptionPushConsumer
+
+    async def on_trip() -> None:
+        await consumer.stop()
+
+    consumer = ep.SubscriptionPushConsumer(
+        queue,
+        flush,
+        debounce=timedelta(milliseconds=10),
+        breaker=breaker,
+        on_trip=on_trip,
+    )
+    consumer.start()
+    try:
+        await queue.put({"id": 1})
+        await asyncio.sleep(0.05)
+        assert consumer.running is False
+    finally:
+        await consumer.stop()
+
+
+async def test_consumer_non_dict_item_ends_subscription_and_calls_on_trip(
+    ep: ModuleType,
+) -> None:
+    """A non-dict queue item is aiotruenas's subscription-terminator
+    sentinel; the consumer must stop draining and notify ``on_trip`` so the
+    coordinator falls back to polling instead of hanging on a dead queue."""
+    queue: asyncio.Queue = asyncio.Queue()
+    flushed: list[list] = []
+    tripped = asyncio.Event()
+
+    async def flush(batch: list) -> None:
+        flushed.append(batch)
+
+    async def on_trip() -> None:
+        tripped.set()
+
+    consumer = ep.SubscriptionPushConsumer(
+        queue, flush, debounce=timedelta(milliseconds=10), on_trip=on_trip
+    )
+    consumer.start()
+    try:
+        await queue.put({"id": 1})
+        await queue.put(None)  # stand-in for aiotruenas's private sentinel type
+        await asyncio.wait_for(tripped.wait(), timeout=1)
+        assert flushed == [[{"id": 1}]]
+        await asyncio.sleep(0.02)
+        assert consumer.running is False
+    finally:
+        await consumer.stop()
+
+
+async def test_consumer_flush_callback_error_calls_on_trip_instead_of_dying(
+    ep: ModuleType,
+) -> None:
+    """If the flush callback raises (e.g. a transient query failure), the
+    consumer must stop cleanly via ``on_trip`` rather than letting the
+    background task die silently while the coordinator still thinks the
+    subscription is healthy."""
+    queue: asyncio.Queue = asyncio.Queue()
+    tripped = asyncio.Event()
+
+    async def flush(batch: list) -> None:
+        raise RuntimeError("transient query failure")
+
+    async def on_trip() -> None:
+        tripped.set()
+
+    consumer = ep.SubscriptionPushConsumer(
+        queue, flush, debounce=timedelta(milliseconds=10), on_trip=on_trip
+    )
+    consumer.start()
+    try:
+        await queue.put({"id": 1})
+        await asyncio.wait_for(tripped.wait(), timeout=1)
+        await asyncio.sleep(0.02)
+        assert consumer.running is False
+    finally:
+        await consumer.stop()
+
+
 async def test_consumer_stop_is_idempotent_and_cancels_cleanly(
     ep: ModuleType,
 ) -> None:

--- a/tests/test_event_push.py
+++ b/tests/test_event_push.py
@@ -1,0 +1,219 @@
+"""Unit tests for ``custom_components.truenas_ce.event_push``.
+
+Pure-asyncio tests (no Home Assistant import needed), loaded via the ``ep``
+fixture like ``test_apiparser.py`` loads ``apiparser.py`` -- see
+``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from types import ModuleType
+
+
+# ---------------------------
+#   SubscriptionCircuitBreaker
+# ---------------------------
+def _breaker(ep: ModuleType, **overrides):
+    config = ep.CircuitBreakerConfig(
+        message_threshold=overrides.pop("message_threshold", 5),
+        consecutive_breaches_to_trip=overrides.pop("consecutive_breaches_to_trip", 3),
+        cooldown=overrides.pop("cooldown", timedelta(minutes=5)),
+    )
+    return ep.SubscriptionCircuitBreaker(config)
+
+
+def test_breaker_stays_closed_under_threshold(ep: ModuleType) -> None:
+    breaker = _breaker(ep)
+    for _ in range(10):
+        assert breaker.record_batch(1) is False
+    assert breaker.tripped is False
+
+
+def test_breaker_trips_after_consecutive_breaches(ep: ModuleType) -> None:
+    breaker = _breaker(ep, consecutive_breaches_to_trip=3)
+    assert breaker.record_batch(10) is False
+    assert breaker.record_batch(10) is False
+    assert breaker.record_batch(10) is True
+    assert breaker.tripped is True
+
+
+def test_breaker_resets_streak_on_non_breaching_batch(ep: ModuleType) -> None:
+    breaker = _breaker(ep, consecutive_breaches_to_trip=3)
+    assert breaker.record_batch(10) is False
+    assert breaker.record_batch(10) is False
+    assert breaker.record_batch(1) is False  # under threshold, resets the streak
+    assert breaker.record_batch(10) is False
+    assert breaker.record_batch(10) is False
+    assert breaker.tripped is False
+
+
+def test_breaker_ignores_further_batches_once_tripped(ep: ModuleType) -> None:
+    breaker = _breaker(ep, consecutive_breaches_to_trip=1)
+    assert breaker.record_batch(10) is True
+    assert breaker.record_batch(10) is False  # already open, no re-trip signal
+    assert breaker.tripped is True
+
+
+def test_breaker_should_attempt_reset_respects_cooldown(ep: ModuleType) -> None:
+    breaker = _breaker(
+        ep, consecutive_breaches_to_trip=1, cooldown=timedelta(seconds=999)
+    )
+    breaker.record_batch(10)
+    assert breaker.tripped is True
+    assert breaker.should_attempt_reset() is False
+
+
+async def test_breaker_should_attempt_reset_after_cooldown(ep: ModuleType) -> None:
+    breaker = _breaker(
+        ep, consecutive_breaches_to_trip=1, cooldown=timedelta(milliseconds=1)
+    )
+    breaker.record_batch(10)
+    await asyncio.sleep(0.02)
+    assert breaker.should_attempt_reset() is True
+
+
+def test_breaker_reset_closes_and_clears_streak(ep: ModuleType) -> None:
+    breaker = _breaker(ep, consecutive_breaches_to_trip=2)
+    breaker.record_batch(10)
+    breaker.record_batch(10)
+    assert breaker.tripped is True
+    breaker.reset()
+    assert breaker.tripped is False
+    assert breaker.record_batch(10) is False  # streak was cleared, needs to build up
+
+
+# ---------------------------
+#   SubscriptionPushConsumer
+# ---------------------------
+async def test_consumer_flushes_after_debounce_window(ep: ModuleType) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    flushed: list[list] = []
+
+    async def flush(batch: list) -> None:
+        flushed.append(batch)
+
+    consumer = ep.SubscriptionPushConsumer(
+        queue, flush, debounce=timedelta(milliseconds=20)
+    )
+    consumer.start()
+    try:
+        await queue.put({"id": 1})
+        await asyncio.sleep(0.05)
+        assert flushed == [[{"id": 1}]]
+    finally:
+        await consumer.stop()
+
+
+async def test_consumer_coalesces_messages_within_debounce_window(
+    ep: ModuleType,
+) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    flushed: list[list] = []
+
+    async def flush(batch: list) -> None:
+        flushed.append(batch)
+
+    consumer = ep.SubscriptionPushConsumer(
+        queue, flush, debounce=timedelta(milliseconds=50)
+    )
+    consumer.start()
+    try:
+        await queue.put({"id": 1})
+        await asyncio.sleep(0.01)
+        await queue.put({"id": 2})
+        await asyncio.sleep(0.1)
+        assert flushed == [[{"id": 1}, {"id": 2}]]
+    finally:
+        await consumer.stop()
+
+
+async def test_consumer_trip_stops_without_flushing_and_calls_on_trip(
+    ep: ModuleType,
+) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    flushed: list[list] = []
+    tripped = asyncio.Event()
+
+    async def flush(batch: list) -> None:
+        flushed.append(batch)
+
+    async def on_trip() -> None:
+        tripped.set()
+
+    breaker = ep.SubscriptionCircuitBreaker(
+        ep.CircuitBreakerConfig(message_threshold=0, consecutive_breaches_to_trip=1)
+    )
+    consumer = ep.SubscriptionPushConsumer(
+        queue,
+        flush,
+        debounce=timedelta(milliseconds=10),
+        breaker=breaker,
+        on_trip=on_trip,
+    )
+    consumer.start()
+    try:
+        await queue.put({"id": 1})
+        await asyncio.wait_for(tripped.wait(), timeout=1)
+        assert not flushed
+        assert breaker.tripped is True
+        await asyncio.sleep(0.02)
+        assert consumer.running is False
+    finally:
+        await consumer.stop()
+
+
+async def test_consumer_stop_is_idempotent_and_cancels_cleanly(
+    ep: ModuleType,
+) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def flush(batch: list) -> None:
+        pass
+
+    consumer = ep.SubscriptionPushConsumer(queue, flush)
+    consumer.start()
+    assert consumer.running is True
+    await consumer.stop()
+    assert consumer.running is False
+    await consumer.stop()  # second stop() must be a no-op, not raise
+
+
+async def test_consumer_start_is_a_noop_while_already_running(
+    ep: ModuleType,
+) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    calls: list[str] = []
+
+    async def flush(batch: list) -> None:
+        pass
+
+    def task_factory(coro, name):
+        calls.append(name)
+        return asyncio.create_task(coro, name=name)
+
+    consumer = ep.SubscriptionPushConsumer(queue, flush)
+    consumer.start(task_factory=task_factory)
+    consumer.start(task_factory=task_factory)
+    assert len(calls) == 1  # second start() must not spawn a second task
+    await consumer.stop()
+
+
+async def test_consumer_custom_task_factory_is_used(ep: ModuleType) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    calls: list[str] = []
+
+    async def flush(batch: list) -> None:
+        pass
+
+    def task_factory(coro, name):
+        calls.append(name)
+        return asyncio.create_task(coro, name=name)
+
+    consumer = ep.SubscriptionPushConsumer(queue, flush)
+    consumer.start(task_factory=task_factory)
+    try:
+        assert len(calls) == 1
+    finally:
+        await consumer.stop()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -858,6 +858,9 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
         stop_app_stats=AsyncMock(),
         stop_alerts=AsyncMock(),
         stop_service_push=AsyncMock(),
+        stop_vm_push=AsyncMock(),
+        stop_container_push=AsyncMock(),
+        stop_app_push=AsyncMock(),
         api=SimpleNamespace(close=AsyncMock()),
     )
     entry.runtime_data = coordinator
@@ -869,6 +872,9 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
     coordinator.stop_app_stats.assert_awaited_once()
     coordinator.stop_alerts.assert_awaited_once()
     coordinator.stop_service_push.assert_awaited_once()
+    coordinator.stop_vm_push.assert_awaited_once()
+    coordinator.stop_container_push.assert_awaited_once()
+    coordinator.stop_app_push.assert_awaited_once()
     coordinator.api.close.assert_awaited_once()
     assert not hasattr(entry, "runtime_data")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -857,6 +857,7 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
     coordinator = SimpleNamespace(
         stop_app_stats=AsyncMock(),
         stop_alerts=AsyncMock(),
+        stop_service_push=AsyncMock(),
         api=SimpleNamespace(close=AsyncMock()),
     )
     entry.runtime_data = coordinator
@@ -867,6 +868,7 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
     assert result is True
     coordinator.stop_app_stats.assert_awaited_once()
     coordinator.stop_alerts.assert_awaited_once()
+    coordinator.stop_service_push.assert_awaited_once()
     coordinator.api.close.assert_awaited_once()
     assert not hasattr(entry, "runtime_data")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -858,6 +858,7 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
         stop_app_stats=AsyncMock(),
         stop_alerts=AsyncMock(),
         stop_service_push=AsyncMock(),
+        stop_pool_push=AsyncMock(),
         api=SimpleNamespace(close=AsyncMock()),
     )
     entry.runtime_data = coordinator
@@ -869,6 +870,7 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
     coordinator.stop_app_stats.assert_awaited_once()
     coordinator.stop_alerts.assert_awaited_once()
     coordinator.stop_service_push.assert_awaited_once()
+    coordinator.stop_pool_push.assert_awaited_once()
     coordinator.api.close.assert_awaited_once()
     assert not hasattr(entry, "runtime_data")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -859,6 +859,9 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
         stop_alerts=AsyncMock(),
         stop_service_push=AsyncMock(),
         stop_pool_push=AsyncMock(),
+        stop_cloudsync_push=AsyncMock(),
+        stop_replication_push=AsyncMock(),
+        stop_rsync_push=AsyncMock(),
         api=SimpleNamespace(close=AsyncMock()),
     )
     entry.runtime_data = coordinator
@@ -871,6 +874,9 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
     coordinator.stop_alerts.assert_awaited_once()
     coordinator.stop_service_push.assert_awaited_once()
     coordinator.stop_pool_push.assert_awaited_once()
+    coordinator.stop_cloudsync_push.assert_awaited_once()
+    coordinator.stop_replication_push.assert_awaited_once()
+    coordinator.stop_rsync_push.assert_awaited_once()
     coordinator.api.close.assert_awaited_once()
     assert not hasattr(entry, "runtime_data")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -856,6 +856,7 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
 
     coordinator = SimpleNamespace(
         stop_app_stats=AsyncMock(),
+        stop_alerts=AsyncMock(),
         api=SimpleNamespace(close=AsyncMock()),
     )
     entry.runtime_data = coordinator
@@ -865,6 +866,7 @@ async def test_async_unload_entry_stops_coordinator_on_success() -> None:
 
     assert result is True
     coordinator.stop_app_stats.assert_awaited_once()
+    coordinator.stop_alerts.assert_awaited_once()
     coordinator.api.close.assert_awaited_once()
     assert not hasattr(entry, "runtime_data")
 


### PR DESCRIPTION
## Proposed change

Adds live "Sofort-Trigger" push updates on top of the existing 60s poll for the coordinator's higher-value, discrete-state sources, instead of waiting for the next poll tick. Each source keeps its regular poll unconditionally as a safety net (a subscription that silently never fires just degrades back to today's behavior), and a shared circuit breaker automatically unsubscribes and falls back to plain polling if a source turns out to be too chatty (rate-limited, with cooldown + retry).

Implemented and live-verified against production TrueNAS (subscribe accepted, subscription established, no errors):
- **Alerts** (`alert.list`) — pilot; also confirmed a real `collection_update` event fires on `alert.dismiss`.
- **Service** (`service.query`)
- **Pool** (`pool.query`)
- **Cloudsync / Replication / Rsync tasks** (`cloudsync.query` / `replication.query` / `rsynctask.query`)
- **VM / Container / App** (`vm.query`, `container.query` or `virt.instance.query` depending on TrueNAS version, `app.query`) — this one was intentionally deferred until the circuit breaker existed, since flapping VMs/containers/apps can generate rapid state transitions.

Two backlog candidates turned out not to be technically viable and were intentionally skipped (no code changes, no forced/best-guess implementation):
- **UPS** — TrueNAS has no discrete ON_BATTERY/ONLINE status method (`ups.status`/`ups.query` don't exist); only continuous netdata graph readings (charge/voltage/etc.) are available, which are meant to stay polled.
- **Directory Services** — `core.get_methods` shows no query/collection method under `directoryservices.*`, only singleton `config`/`status` endpoints; not a valid `core.subscribe` collection target.

A generic `_PushSourceState` + `_ensure_push_subscription`/`_stop_push_subscription` helper on the coordinator was extracted after the Alerts pilot so every subsequent source only wires a handful of lines (constant + thin wrapper + refresh + on-push callback + stop) instead of duplicating the full subscribe/consume/breaker lifecycle each time.

## Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Live-verified end-to-end on a production instance: after deploying as a local RC build, debug logs confirmed all 9 push subscriptions (alerts, service, pool, cloudsync, replication, rsync, vm, container, app, plus the pre-existing app.stats) establish successfully with zero errors, and normal polling/entity data continued unaffected.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deliver immediate coordinator updates through resilient TrueNAS event subscriptions without removing the existing polling safety net.

New Features:
- Add event-driven refreshes for alerts, services, pools, cloud sync, replication, rsync tasks, VMs, containers, and apps while retaining regular polling as a fallback.

Bug Fixes:
- Handle subscription-status query failures as inactive subscriptions so sources can recover through resubscription or polling.
- Prevent concurrent push and polling refreshes from overwriting source state out of order.

Enhancements:
- Introduce shared subscription lifecycle management with debounced consumers and per-source circuit breakers that fall back to polling for noisy or failed subscriptions.
- Select the appropriate container subscription topic for different TrueNAS API versions and cleanly stop subscriptions when sources are disabled or unloaded.

Tests:
- Add coverage for subscription consumers, circuit-breaker behavior, lifecycle management, push-triggered refreshes, fallback handling, and unload cleanup.