### PR TITLE
chore: bump version to 2.8.0, add changelog entry and README docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,50 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.8.0] — Live Push Updates & Migration/Security Hardening
+
+### Added
+- **Live push updates via TrueNAS event subscriptions:** Alerts, Services, Pools, Cloudsync,
+  Replication and Rsync tasks, VMs, Containers and Apps now update as soon as TrueNAS reports a
+  change instead of waiting for the next poll. Each source keeps polling unconditionally as a
+  safety net, and a shared circuit breaker automatically falls back to plain polling (with cooldown
+  + retry) if a source's subscription turns out to be too noisy or drops. (#101)
+
+### Fixed
+- **Security — API key no longer replayed against an unauthenticated discovered host (#98):**
+  zeroconf rediscovery no longer probes a newly discovered device with every configured entry's
+  real API key; a rediscovered host now always goes through the normal user-facing confirmation
+  step instead.
+- **Security — API key no longer pre-filled during migration takeover (#91):** the config-flow
+  field for adopting a legacy `truenas` entry always starts blank; leaving it blank keeps the
+  previously stored key instead of exposing it in the frontend's form state.
+- **Case-insensitive host handling could create duplicate entries or miss a legacy entry (#90,
+  #100):** hostnames differing only in casing (e.g. `NAS.local` vs `nas.local`) are now recognized
+  as the same device for duplicate detection and for matching a legacy entry during migration.
+- **Device identifier collisions across multiple TrueNAS instances (#94):** device identifiers
+  built from data-prefixed groups (e.g. pools/datasets) now include the instance prefix
+  consistently, preventing two same-named objects on different instances from colliding.
+- **Migration backup collisions with multiple config entries (#95):** the `.storage`
+  migration-backup snapshot key is now namespaced per config entry, so migrating two instances
+  around the same time can no longer overwrite or prune the wrong backup.
+- **Migration flow edge cases:**
+  - A manual "start from scratch" takeover is now recorded as done, so it can no longer be silently
+    overridden by legacy-entity adoption running afterwards. Adoption also now aborts (without
+    marking migration done) if disabling the legacy entry fails, instead of stripping entities out
+    from under a still-active legacy coordinator. (#97)
+  - When multiple old `truenas` entries exist, the correct one is now matched by host instead of
+    always offering the first one found. (#100)
+  - Two distinct TrueNAS boxes sharing the same display name are no longer blocked from both being
+    added — host/system-id already guard against real duplicates. (#100)
+  - A Repairs issue is now raised if the migration-rollback background task fails (#99) or
+    completes without actually rolling anything back (#100), instead of that only being logged
+    (#92, #93 laid the diagnostic-logging groundwork this builds on).
+- **Defensive hardening** surfaced during the Home Assistant Core Bronze-quality-scale submission's
+  review, mirrored back here: guards against non-dict app-stats/unit-of-measurement data, removal
+  of a dead `{port}` translation placeholder and other unreachable fallback code, and a namespaced
+  `update_sensors` dispatcher signal to avoid cross-integration collisions. No user-facing behavior
+  change under normal operation. (#87, #88, #89, #92, #96)
+
 ## [2.7.0] — App Update Progress & TrueNAS 26 Container Support
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
 > repository and don't carry over.
 
 Monitor and control your TrueNAS device from Home Assistant.
+ * **Live push updates** (event-driven) for Alerts, Services, Pools, Cloudsync, Replication,
+   Rsync Tasks, VMs, Containers and Apps — near-instant instead of waiting for the next poll,
+   with automatic fallback to polling
  * Monitor System (CPU, Load, Memory, Temperature, **ARC Hit Ratio**, Uptime)
  * Monitor Network interfaces in a dedicated device group (RX/TX traffic + link connectivity per NIC)
  * Monitor Disks
@@ -116,8 +119,8 @@ actions (target the container's binary sensor).
 > *Settings → Devices & Services → TrueNAS → Configure → Monitored groups*.
 > On an existing install, enable **Containers** once after upgrading.
 >
-> Note: a restart is a background job, so the brief down-state may not be sampled by the
-> poll — the steady state is always reported correctly.
+> Note: a restart is a background job; its brief down-state is usually caught live via
+> [event push](#live-push-updates), and the steady state is always reported correctly regardless.
 
 ## Apps
 Monitor each running TrueNAS **app** (Kubernetes workload) with live, event-based statistics:
@@ -163,8 +166,9 @@ Replication tasks can be started on demand through the `replication_run` action.
 >
 > Note: triggering a run on demand (the **Run** button or `replication_run`) shows
 > `RUNNING` immediately and re-syncs to the real state on the next poll. A **scheduled**
-> run that finishes between two polls may only be sampled in its final state (e.g.
-> `FINISHED`) — the persistent state always matches the TrueNAS WebUI.
+> run is usually caught live via [event push](#live-push-updates); on the rare miss it's
+> only sampled in its final state (e.g. `FINISHED`) — the persistent state always matches
+> the TrueNAS WebUI.
 
 ## Rsync Tasks
 Monitor status and attributes for each TrueNAS rsync task.
@@ -287,6 +291,24 @@ action: truenas_ce.alert_list
 data:
   properties: "*"
 ```
+
+## Live Push Updates
+Several core groups — **Alerts, Services, Pools, Cloudsync, Replication Tasks, Rsync Tasks,
+Virtual Machines, Containers and Apps** — subscribe to TrueNAS's event stream on top of the
+regular poll. A state change (an alert firing, a task finishing, a VM stopping, …) usually shows
+up in Home Assistant within a second or two instead of waiting for the next poll interval.
+
+Polling never stops — it keeps running unconditionally as a safety net, so nothing depends on the
+push subscription actually working. A shared circuit breaker automatically drops a source back to
+plain polling (with cooldown and retry) if its subscription turns out to be too noisy or drops
+unexpectedly. No configuration is needed, and there's no user-visible change beyond faster updates
+when it works.
+
+App CPU/RAM/network/block-I/O statistics (see [Apps](#apps)) already worked this way before; this
+extends the same mechanism to whole-object state across the groups above.
+
+> **Snapshot Tasks** have no discrete TrueNAS subscribe target and remain poll-only — see
+> [Known Limitations](#known-limitations).
 
 ## Diagnostics
 Monitor overall system health and active alerts directly from the device page. The integration provides a dedicated diagnostic sensor that automatically detects any disk or pool issues.
@@ -425,11 +447,13 @@ After setup you can fine-tune the integration via **Settings → Devices & Servi
   corresponding sensor (e.g. scrub state, snapshot task state) does reflect an optimistic `RUNNING`
   state right away and re-syncs to the real TrueNAS state on the next poll.
 * **A background job that starts and finishes between two polls may only be sampled in its final
-  state.** This applies to container restarts, and to Replication/Rsync/Snapshot tasks that run on a
-  *TrueNAS schedule* rather than through the integration's own Run button/action — the transient
-  "running" state can be missed if it starts and ends inside one poll interval. The persistent end
-  state always matches TrueNAS's own WebUI; only interim progress can be missed if it's fast enough.
-  Lowering the poll interval (see [Options](#options)) reduces the chance of missing it.
+  state.** Since v2.8.0, VM/Container restarts and Replication/Rsync task runs are also pushed via
+  TrueNAS event subscriptions (see [Live Push Updates](#live-push-updates)) and usually caught live,
+  so this mainly still applies to **Snapshot Tasks** running on a *TrueNAS schedule* — TrueNAS has
+  no discrete subscribe target for them, so they remain poll-only and a transient "running" state
+  can be missed if it starts and ends inside one poll interval. The persistent end state always
+  matches TrueNAS's own WebUI; only interim progress can be missed if it's fast enough. Lowering the
+  poll interval (see [Options](#options)) reduces the chance of missing it.
 * **The on-demand pool-scrub button has no threshold guard.** Pressing it starts a scrub immediately
   regardless of how recently the pool was last scrubbed — TrueNAS's own scheduled-scrub frequency
   setting is not checked. Use it deliberately, not as a substitute for a properly scheduled scrub.

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,7 +15,7 @@
         "aiotruenas>=1.1.0",
         "websockets>=15.0.1"
     ],
-    "version": "2.7.0",
+    "version": "2.8.0",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change
Prepares the v2.8.0 release: bumps `manifest.json`, adds the CHANGELOG entry summarizing everything merged since v2.7.0 (PRs #87–#101), and documents the new live push-update feature in the README (new "Live Push Updates" section, a top-level feature bullet, and small cross-references from the Containers/Replication notes and Known Limitations).

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information
Docs/version-only change, no code touched.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the v2.8.0 release with updated version metadata, release notes, and documentation for live push updates.

Enhancements:
- Document live push updates across supported TrueNAS resource groups, including polling fallback behavior and remaining snapshot-task limitations.

Documentation:
- Add the v2.8.0 changelog entry covering live updates, migration and security hardening, and defensive improvements.
- Update README feature descriptions and operational notes to explain event-driven updates and their limitations.

Chores:
- Bump the integration version to 2.8.0.