### PR TITLE
fix: namespace entity identity by stable entry id, not display name

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -58,6 +58,7 @@ from .entity import (
     _composite_references,
     _is_uid_excluded,
     format_unique_id,
+    migrate_entry_identity_namespace,
     register_system_device,
     resolve_entry_identity,
 )
@@ -566,6 +567,7 @@ async def async_setup_entry(
     coordinator = TrueNASCoordinator(hass, config_entry)
     await coordinator.async_config_entry_first_refresh()
     config_entry.runtime_data = coordinator
+    migrate_entry_identity_namespace(hass, config_entry)
     coordinator.system_device_id = register_system_device(
         hass, config_entry, coordinator
     )

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import CONF_NAME
 from homeassistant.core import (
     HomeAssistant,
     ServiceCall,
@@ -60,6 +59,7 @@ from .entity import (
     _is_uid_excluded,
     format_unique_id,
     register_system_device,
+    resolve_entry_identity,
 )
 from .helper import alert_action, scaled_data_unit
 from .migration import (
@@ -105,18 +105,18 @@ def _migrate_data_size_units(
         CONF_DATA_UNIT, config_entry.data.get(CONF_DATA_UNIT, DEFAULT_DATA_UNIT)
     )
     binary = data_unit == "GiB"
-    inst = config_entry.data[CONF_NAME]
+    identity = resolve_entry_identity(config_entry)
     ent_reg = er.async_get(hass)
 
     for description in SENSOR_TYPES:
         if getattr(description, "device_class", None) == SensorDeviceClass.DATA_SIZE:
-            _migrate_description(ent_reg, coordinator, inst, description, binary)
+            _migrate_description(ent_reg, coordinator, identity, description, binary)
 
 
 def _migrate_description(
     ent_reg: er.EntityRegistry,
     coordinator: TrueNASCoordinator,
-    inst: str,
+    identity: str,
     description: TrueNASSensorEntityDescription,
     binary: bool,
 ) -> None:
@@ -127,7 +127,7 @@ def _migrate_description(
 
     if not description.data_reference:
         value = data.get(description.data_attribute or "")
-        _force_entity_unit(ent_reg, inst, description, None, value, binary)
+        _force_entity_unit(ent_reg, identity, description, None, value, binary)
         return
 
     for uid, vals in data.items():
@@ -136,7 +136,7 @@ def _migrate_description(
         ref = vals.get(description.data_reference)
         _force_entity_unit(
             ent_reg,
-            inst,
+            identity,
             description,
             ref if ref is not None else uid,
             vals.get(description.data_attribute),
@@ -146,7 +146,7 @@ def _migrate_description(
 
 def _force_entity_unit(
     ent_reg: er.EntityRegistry,
-    inst: str,
+    identity: str,
     description: TrueNASSensorEntityDescription,
     reference: Any,
     value: Any,
@@ -154,7 +154,7 @@ def _force_entity_unit(
 ) -> None:
     """Write the magnitude-appropriate display unit of one entity to the registry."""
     entity_id = ent_reg.async_get_entity_id(
-        "sensor", DOMAIN, format_unique_id(inst, description.key, reference)
+        "sensor", DOMAIN, format_unique_id(identity, description.key, reference)
     )
     if entity_id is None:
         return
@@ -181,7 +181,7 @@ def _handle_keyless(
 
 
 def _referenced_unique_ids(
-    inst: str,
+    identity: str,
     description: TrueNASEntityDescription,
     data: dict[str, Any],
     honor_exclude: bool = True,
@@ -197,13 +197,13 @@ def _referenced_unique_ids(
             continue
         ref = vals.get(description.data_reference)
         reference = ref if ref is not None else uid
-        ids.add(format_unique_id(inst, description.key, reference))
+        ids.add(format_unique_id(identity, description.key, reference))
 
     return ids
 
 
 def _collect_active_unique_ids(
-    inst: str, coordinator: TrueNASCoordinator
+    identity: str, coordinator: TrueNASCoordinator
 ) -> tuple[set[str], set[str]]:
     """Return (active unique_ids, live bases) for the current TrueNAS objects.
 
@@ -228,7 +228,7 @@ def _collect_active_unique_ids(
 
     for description in _ALL_DESCRIPTIONS:
         _process_static_description(
-            inst,
+            identity,
             description,
             disabled_data_paths,
             honor_exclude,
@@ -239,7 +239,7 @@ def _collect_active_unique_ids(
 
     for description in _ALL_DESCRIPTIONS:
         new_active, new_live_bases = _process_dynamic_description(
-            inst,
+            identity,
             description,
             coordinator.data,
             honor_exclude,
@@ -266,7 +266,7 @@ def _build_disabled_data_paths(monitored: list[str]) -> set[str]:
 
 
 def _process_static_description(
-    inst: str,
+    identity: str,
     description: TrueNASEntityDescription,
     disabled_data_paths: set[str],
     honor_exclude: bool,
@@ -281,7 +281,7 @@ def _process_static_description(
     present. Keyless descriptions are handled by ``_handle_keyless``; referenced
     descriptions are expanded via ``_referenced_unique_ids``.
     """
-    base = format_unique_id(inst, description.key)
+    base = format_unique_id(identity, description.key)
     is_disabled_group = description.data_path in disabled_data_paths
 
     if not getattr(description, "data_reference", None):
@@ -294,11 +294,11 @@ def _process_static_description(
 
     live_bases.add(base)
     if sub_data and not is_disabled_group:
-        active |= _referenced_unique_ids(inst, description, sub_data, honor_exclude)
+        active |= _referenced_unique_ids(identity, description, sub_data, honor_exclude)
 
 
 def _process_dynamic_description(
-    inst: str,
+    identity: str,
     description: TrueNASEntityDescription,
     data: dict[str, Any],
     honor_exclude: bool,
@@ -314,7 +314,7 @@ def _process_dynamic_description(
     if not getattr(description, "data_dynamic_keys", False):
         return set(), set()
 
-    base = format_unique_id(inst, description.key)
+    base = format_unique_id(identity, description.key)
     live_bases: set[str] = {base}
 
     is_disabled_group = description.data_path in disabled_data_paths
@@ -336,9 +336,9 @@ def _process_dynamic_description(
 
     active: set[str] = set()
     if getattr(description, "data_composite_references", ()):
-        active |= _composite_references(inst, description, sub_data, honor_exclude)
+        active |= _composite_references(identity, description, sub_data, honor_exclude)
     else:
-        active |= _referenced_unique_ids(inst, description, sub_data, honor_exclude)
+        active |= _referenced_unique_ids(identity, description, sub_data, honor_exclude)
 
     return active, live_bases
 

--- a/custom_components/truenas_ce/button.py
+++ b/custom_components/truenas_ce/button.py
@@ -34,6 +34,7 @@ from .entity import (
     async_add_entities,
     format_device_identifier,
     format_unique_id,
+    resolve_entry_identity,
 )
 
 _LOGGER = getLogger(__name__)
@@ -164,10 +165,11 @@ class TrueNASStatisticsCleanupButton(
         """Initialize the cleanup button."""
         super().__init__(coordinator)
         inst = coordinator.config_entry.data[CONF_NAME]
-        self._attr_unique_id = format_unique_id(inst, BUTTON_STATISTICS_CLEANUP)
+        identity = resolve_entry_identity(coordinator.config_entry)
+        self._attr_unique_id = format_unique_id(identity, BUTTON_STATISTICS_CLEANUP)
         hostname = coordinator.data.get("system_info", {}).get("hostname", inst)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_device_identifier(inst, hostname))},
+            identifiers={(DOMAIN, format_device_identifier(identity, hostname))},
         )
 
     @property
@@ -203,10 +205,11 @@ class TrueNASMigrationRollbackButton(
         """Initialize the rollback button."""
         super().__init__(coordinator)
         inst = coordinator.config_entry.data[CONF_NAME]
-        self._attr_unique_id = format_unique_id(inst, BUTTON_MIGRATION_ROLLBACK)
+        identity = resolve_entry_identity(coordinator.config_entry)
+        self._attr_unique_id = format_unique_id(identity, BUTTON_MIGRATION_ROLLBACK)
         hostname = coordinator.data.get("system_info", {}).get("hostname", inst)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_device_identifier(inst, hostname))},
+            identifiers={(DOMAIN, format_device_identifier(identity, hostname))},
         )
 
     @property
@@ -239,10 +242,11 @@ class TrueNASRefreshButton(CoordinatorEntity[TrueNASCoordinator], ButtonEntity):
         """Initialize the refresh button."""
         super().__init__(coordinator)
         inst = coordinator.config_entry.data[CONF_NAME]
-        self._attr_unique_id = format_unique_id(inst, BUTTON_SYSTEM_REFRESH)
+        identity = resolve_entry_identity(coordinator.config_entry)
+        self._attr_unique_id = format_unique_id(identity, BUTTON_SYSTEM_REFRESH)
         hostname = coordinator.data.get("system_info", {}).get("hostname", inst)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_device_identifier(inst, hostname))},
+            identifiers={(DOMAIN, format_device_identifier(identity, hostname))},
         )
 
     async def async_press(self) -> None:

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -124,6 +124,17 @@ def migrate_entry_identity_namespace(
     for device_entry in dr.async_entries_for_config_entry(
         dev_reg, config_entry.entry_id
     ):
+        if len(device_entry.config_entries) > 1:
+            # Two entries that previously shared this display name (and e.g.
+            # a same-named pool) collided onto the same old, name-based
+            # device record. Renaming it in place for one entry would just
+            # get overwritten by the other entry's own migration pass,
+            # leaving entities misattributed. Leave it as-is: this entry's
+            # entities still get their unique_ids migrated above, so the
+            # normal device_info/get_or_create path in platform setup gives
+            # them a fresh, correctly-identified device instead of reusing
+            # the ambiguous shared one.
+            continue
         new_identifiers = {
             (domain, new_dev_prefix + value[len(old_dev_prefix) :])
             if domain == DOMAIN and value.startswith(old_dev_prefix)

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -85,6 +85,57 @@ def format_device_identifier(identity: str, hostname: str) -> str:
     return f"{identity}_{hostname}"
 
 
+def migrate_entry_identity_namespace(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Rewrite this entry's registry records from the old name-based identity.
+
+    Before ``resolve_entry_identity`` existed, every unique_id/device
+    identifier was namespaced by ``config_entry.data[CONF_NAME]`` (see
+    ``format_unique_id``/``format_device_identifier``'s history). Every
+    already-registered entity/device for an existing installation therefore
+    still carries that old prefix; left alone, it would never match the new
+    identity-based unique_ids/identifiers the entities compute from now on,
+    producing duplicate entities/devices instead of continuing the old ones.
+    Must run before ``register_system_device`` and any platform setup, so the
+    device/entity lookups in those find the already-renamed records.
+    """
+    old_name = config_entry.data.get(CONF_NAME, "")
+    identity = resolve_entry_identity(config_entry)
+    if not old_name or old_name == identity:
+        return
+
+    old_uid_prefix = f"{old_name.lower()}-"
+    new_uid_prefix = f"{identity.lower()}-"
+    ent_reg = er.async_get(hass)
+    for entity_entry in er.async_entries_for_config_entry(
+        ent_reg, config_entry.entry_id
+    ):
+        if entity_entry.unique_id.startswith(old_uid_prefix):
+            ent_reg.async_update_entity(
+                entity_entry.entity_id,
+                new_unique_id=new_uid_prefix
+                + entity_entry.unique_id[len(old_uid_prefix) :],
+            )
+
+    old_dev_prefix = f"{old_name}_"
+    new_dev_prefix = f"{identity}_"
+    dev_reg = dr.async_get(hass)
+    for device_entry in dr.async_entries_for_config_entry(
+        dev_reg, config_entry.entry_id
+    ):
+        new_identifiers = {
+            (domain, new_dev_prefix + value[len(old_dev_prefix) :])
+            if domain == DOMAIN and value.startswith(old_dev_prefix)
+            else (domain, value)
+            for domain, value in device_entry.identifiers
+        }
+        if new_identifiers != device_entry.identifiers:
+            dev_reg.async_update_device(
+                device_entry.id, new_identifiers=new_identifiers
+            )
+
+
 @lru_cache(maxsize=1)
 def _supports_via_device_id() -> bool:
     """Whether the running HA Core's device registry accepts via_device_id.

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -28,6 +28,7 @@ from .const import (
     ATTRIBUTION,
     BEHAVIOR_REMOVE_INACTIVE_NIC,
     CONF_BEHAVIORS,
+    CONF_SYSTEM_ID,
     DEFAULT_BEHAVIORS,
     DOMAIN,
     SIGNAL_UPDATE_SENSORS,
@@ -41,27 +42,47 @@ _UNKNOWN_KEY = "<unknown>"
 
 
 # ---------------------------
-#   format_unique_id
+#   resolve_entry_identity / format_unique_id
 # ---------------------------
-def format_unique_id(inst: str, key: str, reference: object = None) -> str:
-    """Build an entity unique_id from instance name, description key and reference.
+def resolve_entry_identity(config_entry: ConfigEntry) -> str:
+    """Return a stable per-entry identity string for unique_ids/device identifiers.
 
+    Prefers CONF_SYSTEM_ID (the TrueNAS system.global.id UUID, only populated
+    when that lookup succeeded during setup); falls back to the config
+    entry's own entry_id, which HA guarantees unique and stable for the
+    entry's lifetime. Never use CONF_NAME (the user-editable display name)
+    for this purpose -- two entries can share a display name, which would
+    otherwise collide entities/devices across different TrueNAS servers.
+    """
+    system_id = config_entry.data.get(CONF_SYSTEM_ID)
+    if isinstance(system_id, str) and system_id:
+        return system_id
+    return config_entry.entry_id
+
+
+def format_unique_id(identity: str, key: str, reference: object = None) -> str:
+    """Build an entity unique_id from the entry identity, key and reference.
+
+    ``identity`` must be a stable per-entry identity (see
+    ``resolve_entry_identity``), not the user-editable display name.
     Shared so the migration in __init__.py can resolve the same unique_id an
     entity produces.
     """
-    base = f"{inst.lower()}-{key}"
+    base = f"{identity.lower()}-{key}"
     if reference is None:
         return base
     return f"{base}-{slugify(str(reference).lower())}"
 
 
-def format_device_identifier(inst: str, hostname: str) -> str:
+def format_device_identifier(identity: str, hostname: str) -> str:
     """Build the main TrueNAS ("System") device identifier value.
 
+    ``identity`` must be a stable per-entry identity (see
+    ``resolve_entry_identity``), not the user-editable display name.
     Shared so other platforms (e.g. the diagnostic statistics-cleanup button)
     associate with the existing device instead of duplicating the format.
     """
-    return f"{inst}_{hostname}"
+    return f"{identity}_{hostname}"
 
 
 @lru_cache(maxsize=1)
@@ -94,8 +115,9 @@ def register_system_device(
     unique across config entries.
     """
     inst = coordinator.config_entry.data[CONF_NAME]
+    identity = resolve_entry_identity(coordinator.config_entry)
     system_info = coordinator.data["system_info"]
-    identifier = format_device_identifier(inst, system_info["hostname"])
+    identifier = format_device_identifier(identity, system_info["hostname"])
     http_scheme = "https" if coordinator.api.scheme == "wss" else "http"
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -174,7 +196,7 @@ class TrueNASEntityDescription(EntityDescription):
 
 
 def _composite_references(
-    inst: str,
+    identity: str,
     description: TrueNASEntityDescription,
     data: dict[str, Any],
     honor_exclude: bool = True,
@@ -183,8 +205,10 @@ def _composite_references(
 
     For each top-level uid in ``data``, the leaf value at
     ``data[uid][container_key][item][leaf_key]`` becomes a composite unique_id
-    of the form ``inst-key-uid::ref``. This supports entities like per-NIC
+    of the form ``identity-key-uid::ref``. This supports entities like per-NIC
     network sensors where the interface name lives inside a list of dicts.
+    ``identity`` must be a stable per-entry identity (see
+    ``resolve_entry_identity``), not the user-editable display name.
 
     When ``honor_exclude`` is True, items matching ``description.data_exclude``
     are skipped, mirroring ``_referenced_unique_ids`` behavior.
@@ -200,7 +224,7 @@ def _composite_references(
         for item in container:
             ref = _extract_composite_ref(item, description, honor_exclude, leaf_key)
             if ref is not None:
-                ids.add(format_unique_id(inst, description.key, f"{uid}::{ref}"))
+                ids.add(format_unique_id(identity, description.key, f"{uid}::{ref}"))
     return ids
 
 
@@ -344,8 +368,8 @@ def _cleanup_orphaned_entities(
     if not coordinator.last_update_success:
         return
 
-    inst = config_entry.data[CONF_NAME]
-    active, live_bases = _collect_active_unique_ids(inst, coordinator)
+    identity = resolve_entry_identity(config_entry)
+    active, live_bases = _collect_active_unique_ids(identity, coordinator)
 
     ent_reg = er.async_get(hass)
     for entity_entry in er.async_entries_for_config_entry(
@@ -481,6 +505,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._inst = coordinator.config_entry.data[CONF_NAME]
+        self._identity = resolve_entry_identity(coordinator.config_entry)
         self._config_entry = self.coordinator.config_entry
         self._attr_extra_state_attributes = {ATTR_ATTRIBUTION: ATTRIBUTION}
         self._uid = uid
@@ -563,27 +588,29 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             data_ref = self.entity_description.data_reference
             value = self._data.get(data_ref) if self._data and data_ref else None
             reference = value if value is not None else self._uid
-            return format_unique_id(self._inst, self.entity_description.key, reference)
+            return format_unique_id(
+                self._identity, self.entity_description.key, reference
+            )
 
-        return format_unique_id(self._inst, self.entity_description.key)
+        return format_unique_id(self._identity, self.entity_description.key)
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return a description for device registry."""
         ha_group = self.entity_description.ha_group or ""
         dev_connection = DOMAIN
-        dev_connection_value = f"{self._inst}_{ha_group}"
+        dev_connection_value = f"{self._identity}_{ha_group}"
         dev_group = ha_group
         if ha_group == "System":
             dev_connection_value = format_device_identifier(
-                self._inst, self.coordinator.data["system_info"]["hostname"]
+                self._identity, self.coordinator.data["system_info"]["hostname"]
             )
 
         if ha_group.startswith("data__"):
             dev_group = ha_group[6:]
             if dev_group in self._data:
                 dev_group = self._data[dev_group]
-                dev_connection_value = f"{self._inst}_{dev_group}"
+                dev_connection_value = f"{self._identity}_{dev_group}"
 
         if self.entity_description.ha_connection:
             dev_connection = self.entity_description.ha_connection
@@ -593,7 +620,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             if dev_connection_value.startswith("data__"):
                 data_key = dev_connection_value[6:]
                 connection_val = self._data.get(data_key, "unknown")
-                dev_connection_value = f"{self._inst}_{connection_val}"
+                dev_connection_value = f"{self._identity}_{connection_val}"
 
         if ha_group == "System":
             http_scheme = "https" if self.coordinator.api.scheme == "wss" else "http"
@@ -630,7 +657,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             device_info["via_device"] = (
                 DOMAIN,
                 format_device_identifier(
-                    self._inst, self.coordinator.data["system_info"]["hostname"]
+                    self._identity, self.coordinator.data["system_info"]["hostname"]
                 ),
             )
         return cast(DeviceInfo, device_info)

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -12,7 +12,7 @@ from typing import Any, NoReturn
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, UnitOfInformation, UnitOfTime
+from homeassistant.const import UnitOfInformation, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_platform as ep
@@ -33,7 +33,12 @@ from .const import (
     SIGNAL_UPDATE_SENSORS,
 )
 from .coordinator import TrueNASCoordinator, get_truenas_coordinator
-from .entity import TrueNASEntity, async_add_entities, format_unique_id
+from .entity import (
+    TrueNASEntity,
+    async_add_entities,
+    format_unique_id,
+    resolve_entry_identity,
+)
 from .helper import alert_action, scaled_data_unit
 from .sensor_types import (  # noqa: F401
     SENSOR_SERVICES,
@@ -143,12 +148,12 @@ def _discover_app_stats(
         if entity.unique_id is not None
     }
 
-    inst = coord.config_entry.data[CONF_NAME]
+    identity = resolve_entry_identity(coord.config_entry)
 
     for description in _app_stats_descriptions():
         for uid, app_data in app_stats_data.items():
             _maybe_discover_app_stats_sensor(
-                description, uid, app_data, inst, loaded, app_stats_entities, coord
+                description, uid, app_data, identity, loaded, app_stats_entities, coord
             )
 
     if app_stats_entities:
@@ -164,7 +169,7 @@ def _maybe_discover_app_stats_sensor(
     description: TrueNASSensorEntityDescription,
     uid: str,
     app_data: dict[str, Any],
-    inst: str,
+    identity: str,
     loaded: set[str],
     entities: list[TrueNASAppStatsSensor],
     coord: TrueNASCoordinator,
@@ -183,10 +188,10 @@ def _maybe_discover_app_stats_sensor(
         "app_stats_network_tx",
     ):
         _discover_network_sensors(
-            description, uid, app_data, inst, loaded, entities, coord
+            description, uid, app_data, identity, loaded, entities, coord
         )
     else:
-        _discover_standard_sensor(description, uid, inst, loaded, entities, coord)
+        _discover_standard_sensor(description, uid, identity, loaded, entities, coord)
 
 
 # ---------------------------
@@ -264,7 +269,7 @@ def _discover_network_sensors(
     description: TrueNASSensorEntityDescription,
     uid: str,
     app_data: dict[str, Any],
-    inst: str,
+    identity: str,
     loaded: set[str],
     entities: list[TrueNASAppStatsSensor],
     coord: TrueNASCoordinator,
@@ -280,7 +285,7 @@ def _discover_network_sensors(
         if not interface_name:
             continue
         composed_uid = _compose_app_network_uid(uid, interface_name)
-        unique_id = format_unique_id(inst, description.key, composed_uid)
+        unique_id = format_unique_id(identity, description.key, composed_uid)
         if unique_id in loaded:
             continue
         entities.append(TrueNASAppStatsSensor(coord, description, composed_uid))
@@ -290,13 +295,13 @@ def _discover_network_sensors(
 def _discover_standard_sensor(
     description: TrueNASSensorEntityDescription,
     uid: str,
-    inst: str,
+    identity: str,
     loaded: set[str],
     entities: list[TrueNASAppStatsSensor],
     coord: TrueNASCoordinator,
 ) -> None:
     """Create a single standard app stats sensor if not already loaded."""
-    unique_id = format_unique_id(inst, description.key, uid)
+    unique_id = format_unique_id(identity, description.key, uid)
     if unique_id in loaded:
         return
     entities.append(TrueNASAppStatsSensor(coord, description, uid))
@@ -1053,7 +1058,7 @@ class TrueNASAppStatsSensor(TrueNASEntity, SensorEntity):
     @property
     def unique_id(self) -> str:
         """Return a truly unique id, preventing conflict between apps sharing eth0."""
-        return format_unique_id(self._inst, self.entity_description.key, self._uid)
+        return format_unique_id(self._identity, self.entity_description.key, self._uid)
 
     @property
     def name(self) -> str | None:

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -27,13 +27,22 @@ def make_config_entry(
     *,
     name: str = "TrueNAS",
     host: str = "truenas.local",
+    entry_id: str = "TrueNAS",
     data: dict[str, Any] | None = None,
     options: dict[str, Any] | None = None,
 ) -> SimpleNamespace:
-    """Build a minimal stand-in for a ConfigEntry."""
+    """Build a minimal stand-in for a ConfigEntry.
+
+    ``entry_id`` defaults to the same string as the default ``name`` so
+    identity-based unique_ids/device identifiers (see
+    ``entity.resolve_entry_identity``) keep matching pre-existing test
+    expectations written against the old name-based format; pass distinct
+    ``entry_id``/``data={CONF_SYSTEM_ID: ...}`` values to exercise the
+    identity-vs-display-name distinction explicitly.
+    """
     entry_data = {CONF_NAME: name, CONF_HOST: host, **(data or {})}
     return SimpleNamespace(
-        entry_id="test-entry-id",
+        entry_id=entry_id,
         data=entry_data,
         options=options or {},
         async_get_entry=MagicMock(return_value=None),

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -10,7 +10,7 @@ from _fakes import make_config_entry, make_coordinator
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.truenas_ce.const import DOMAIN
+from custom_components.truenas_ce.const import CONF_SYSTEM_ID, DOMAIN
 from custom_components.truenas_ce.entity import (
     TrueNASEntity,
     TrueNASEntityDescription,
@@ -23,6 +23,7 @@ from custom_components.truenas_ce.entity import (
     _skip_keyless_description,
     format_device_identifier,
     format_unique_id,
+    resolve_entry_identity,
 )
 from custom_components.truenas_ce.sensor_types import TrueNASSensorEntityDescription
 
@@ -472,17 +473,159 @@ def test_device_info_data_group_instance_prefix_prevents_collision() -> None:
     )
     data = {"disk": {"d1": {"guid": "g1", "pool": "tank"}}}
     entity_a = TrueNASEntity(
-        make_coordinator(data=data, config_entry=make_config_entry(name="TrueNAS-A")),
+        make_coordinator(
+            data=data,
+            config_entry=make_config_entry(name="TrueNAS-A", entry_id="entry-a"),
+        ),
         desc,
         "d1",
     )
     entity_b = TrueNASEntity(
-        make_coordinator(data=data, config_entry=make_config_entry(name="TrueNAS-B")),
+        make_coordinator(
+            data=data,
+            config_entry=make_config_entry(name="TrueNAS-B", entry_id="entry-b"),
+        ),
         desc,
         "d1",
     )
-    assert entity_a.device_info["identifiers"] == {("truenas_ce", "TrueNAS-A_tank")}
-    assert entity_b.device_info["identifiers"] == {("truenas_ce", "TrueNAS-B_tank")}
+    assert entity_a.device_info["identifiers"] == {("truenas_ce", "entry-a_tank")}
+    assert entity_b.device_info["identifiers"] == {("truenas_ce", "entry-b_tank")}
+
+
+def test_device_info_same_name_different_system_id_prevents_collision() -> None:
+    """Two config entries sharing CONF_NAME must still get distinct devices.
+
+    Regression test for the Copilot-review finding (mirrored back from
+    home-assistant/core PR #179103): entities/devices used to be namespaced
+    by the user-editable display name (CONF_NAME), so two TrueNAS servers
+    with the same name (e.g. both left on the "TrueNAS" fallback) would
+    collide. They must now be namespaced by the stable per-entry identity
+    (CONF_SYSTEM_ID, falling back to entry_id).
+    """
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        ha_group="data__pool",
+    )
+    data = {"disk": {"d1": {"guid": "g1", "pool": "tank"}}}
+    entity_a = TrueNASEntity(
+        make_coordinator(
+            data=data,
+            config_entry=make_config_entry(
+                name="TrueNAS",
+                entry_id="entry-a",
+                data={CONF_SYSTEM_ID: "system-aaa"},
+            ),
+        ),
+        desc,
+        "d1",
+    )
+    entity_b = TrueNASEntity(
+        make_coordinator(
+            data=data,
+            config_entry=make_config_entry(
+                name="TrueNAS",
+                entry_id="entry-b",
+                data={CONF_SYSTEM_ID: "system-bbb"},
+            ),
+        ),
+        desc,
+        "d1",
+    )
+    assert entity_a.device_info["identifiers"] == {("truenas_ce", "system-aaa_tank")}
+    assert entity_b.device_info["identifiers"] == {("truenas_ce", "system-bbb_tank")}
+    assert entity_a.unique_id != entity_b.unique_id
+    # Display name still collides -- that's cosmetic only, not an identity bug.
+    assert (
+        entity_a.device_info["name"] == entity_b.device_info["name"] == "TrueNAS tank"
+    )
+
+
+def test_device_info_same_name_missing_system_id_falls_back_to_entry_id() -> None:
+    """Two entries sharing CONF_NAME with no CONF_SYSTEM_ID still get distinct devices.
+
+    CONF_SYSTEM_ID is only populated when the system.global.id lookup
+    succeeded during setup, so both entries falling back to entry_id must
+    still avoid a collision.
+    """
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp",
+        name="Temperature",
+        data_path="disk",
+        data_reference="guid",
+        ha_group="data__pool",
+    )
+    data = {"disk": {"d1": {"guid": "g1", "pool": "tank"}}}
+    entity_a = TrueNASEntity(
+        make_coordinator(
+            data=data,
+            config_entry=make_config_entry(name="TrueNAS", entry_id="entry-a"),
+        ),
+        desc,
+        "d1",
+    )
+    entity_b = TrueNASEntity(
+        make_coordinator(
+            data=data,
+            config_entry=make_config_entry(name="TrueNAS", entry_id="entry-b"),
+        ),
+        desc,
+        "d1",
+    )
+    assert entity_a.device_info["identifiers"] == {("truenas_ce", "entry-a_tank")}
+    assert entity_b.device_info["identifiers"] == {("truenas_ce", "entry-b_tank")}
+    assert entity_a.unique_id != entity_b.unique_id
+
+
+def test_unique_id_same_name_different_system_id_prevents_collision() -> None:
+    """Entity unique_ids must be namespaced by identity, not the display name."""
+    desc = TrueNASSensorEntityDescription(
+        key="disk_temp", name="Temperature", data_path="disk", data_reference="guid"
+    )
+    entity_a = TrueNASEntity(
+        make_coordinator(
+            data={"disk": {"d1": {"guid": "g1"}}},
+            config_entry=make_config_entry(
+                name="TrueNAS", data={CONF_SYSTEM_ID: "system-aaa"}
+            ),
+        ),
+        desc,
+        "d1",
+    )
+    entity_b = TrueNASEntity(
+        make_coordinator(
+            data={"disk": {"d1": {"guid": "g1"}}},
+            config_entry=make_config_entry(
+                name="TrueNAS", data={CONF_SYSTEM_ID: "system-bbb"}
+            ),
+        ),
+        desc,
+        "d1",
+    )
+    assert entity_a.unique_id == "system-aaa-disk_temp-g1"
+    assert entity_b.unique_id == "system-bbb-disk_temp-g1"
+
+
+def test_resolve_entry_identity_prefers_system_id() -> None:
+    """resolve_entry_identity uses CONF_SYSTEM_ID when present."""
+    entry = make_config_entry(
+        entry_id="entry-1", data={CONF_SYSTEM_ID: "system-guid-123"}
+    )
+    assert resolve_entry_identity(entry) == "system-guid-123"
+
+
+def test_resolve_entry_identity_falls_back_to_entry_id_when_missing() -> None:
+    """resolve_entry_identity falls back to entry_id when system_id is absent."""
+    entry = make_config_entry(entry_id="entry-1")
+    assert resolve_entry_identity(entry) == "entry-1"
+
+
+def test_resolve_entry_identity_falls_back_to_entry_id_when_blank() -> None:
+    """resolve_entry_identity falls back to entry_id when system_id is empty."""
+    entry = make_config_entry(entry_id="entry-1", data={CONF_SYSTEM_ID: ""})
+    assert resolve_entry_identity(entry) == "entry-1"
 
 
 def test_device_info_explicit_connection_and_value() -> None:

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -101,6 +101,38 @@ async def test_migrate_entry_identity_namespace_noop_when_identity_unchanged(
     assert migrated_entity.unique_id == "truenas-uptime"
 
 
+async def test_migrate_entry_identity_namespace_skips_shared_device(
+    hass: HomeAssistant,
+) -> None:
+    """A device shared by two entries (same old display name + pool name)
+    must not have its identifiers rewritten for just one of them -- that
+    would misattribute it once the other entry's own migration pass runs
+    (Sourcery finding on the initial version of this migration).
+    """
+    entry_a = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-aaa"}
+    )
+    entry_a.add_to_hass(hass)
+    entry_b = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-bbb"}
+    )
+    entry_b.add_to_hass(hass)
+
+    dev_reg = dr.async_get(hass)
+    shared_device = dev_reg.async_get_or_create(
+        config_entry_id=entry_a.entry_id, identifiers={(DOMAIN, "TrueNAS_tank")}
+    )
+    dev_reg.async_get_or_create(
+        config_entry_id=entry_b.entry_id, identifiers={(DOMAIN, "TrueNAS_tank")}
+    )
+
+    migrate_entry_identity_namespace(hass, entry_a)
+
+    untouched_device = dev_reg.async_get(shared_device.id)
+    assert untouched_device is not None
+    assert untouched_device.identifiers == {(DOMAIN, "TrueNAS_tank")}
+
+
 # ---------------------------
 #   _cleanup_orphaned_entities
 # ---------------------------

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -27,6 +27,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 import custom_components.truenas_ce as init_module
 from custom_components.truenas_ce.const import (
     CONF_MONITORED_GROUPS,
+    CONF_SYSTEM_ID,
     DOMAIN,
     GROUP_DATA_PATHS,
     MONITOR_GROUP_SNAPSHOTS,
@@ -34,10 +35,70 @@ from custom_components.truenas_ce.const import (
 from custom_components.truenas_ce.entity import (
     _cleanup_orphaned_entities,
     format_unique_id,
+    migrate_entry_identity_namespace,
+    resolve_entry_identity,
 )
 from custom_components.truenas_ce.sensor_types import SENSOR_TYPES
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+# ---------------------------
+#   migrate_entry_identity_namespace
+# ---------------------------
+async def test_migrate_entry_identity_namespace_renames_existing_records(
+    hass: HomeAssistant,
+) -> None:
+    """Upgrading past the old CONF_NAME-based identity must not orphan the
+    pre-existing registry records -- they get renamed in place instead of
+    being left behind for new, identity-based duplicates to replace them.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid-123"},
+    )
+    entry.add_to_hass(hass)
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "TrueNAS_truenas.local")},
+    )
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, "truenas-uptime", config_entry=entry, device_id=device.id
+    )
+
+    migrate_entry_identity_namespace(hass, entry)
+
+    migrated_entity = ent_reg.async_get(entity.entity_id)
+    assert migrated_entity is not None
+    assert migrated_entity.unique_id == "system-guid-123-uptime"
+
+    migrated_device = dev_reg.async_get(device.id)
+    assert migrated_device is not None
+    assert migrated_device.identifiers == {(DOMAIN, "system-guid-123_truenas.local")}
+
+
+async def test_migrate_entry_identity_namespace_noop_when_identity_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    """No CONF_SYSTEM_ID and entry_id already equal to CONF_NAME: nothing to rename."""
+    entry = MockConfigEntry(
+        entry_id="TrueNAS", domain=DOMAIN, data={CONF_NAME: "TrueNAS"}
+    )
+    entry.add_to_hass(hass)
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, "truenas-uptime", config_entry=entry
+    )
+
+    migrate_entry_identity_namespace(hass, entry)
+
+    migrated_entity = ent_reg.async_get(entity.entity_id)
+    assert migrated_entity is not None
+    assert migrated_entity.unique_id == "truenas-uptime"
 
 
 # ---------------------------
@@ -248,7 +309,8 @@ async def test_async_setup_entry_creates_snapshottask_sensor_via_dispatcher(
         d for d in SENSOR_TYPES if d.data_path == snapshottask_data_path
     )
     ent_reg = er.async_get(hass)
-    unique_id = format_unique_id("TrueNAS", snapshottask_description.key, 1)
+    identity = resolve_entry_identity(entry)
+    unique_id = format_unique_id(identity, snapshottask_description.key, 1)
     entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
     assert entity_id is not None
     assert hass.states.get(entity_id) is not None


### PR DESCRIPTION
## Proposed change

`entity.py`'s `format_unique_id`/`format_device_identifier` and the orphan-cleanup unique_id reconstruction in `__init__.py` were namespaced by `CONF_NAME` (the user-editable display name). Since `config_flow`'s `name_exists` uniqueness check was already dropped in favor of `CONF_SYSTEM_ID`/`entry_id`-based config-entry uniqueness (#100), nothing stops two different TrueNAS servers from sharing a display name (e.g. both left on the "TrueNAS" fallback) — when that happens their entities/devices collide.

This introduces `entity.resolve_entry_identity()`, which prefers `CONF_SYSTEM_ID` (the TrueNAS `system.global.id` UUID, when the lookup succeeded during setup) and falls back to the config entry's own `entry_id` (HA-guaranteed unique and stable). This identity is threaded through every place that previously used the display name for identity purposes: `register_system_device`, `TrueNASEntity`'s `unique_id`/`device_info`, `_composite_references`, the orphan-cleanup unique_id reconstruction (`_collect_active_unique_ids` and friends), `sensor.py`'s app-stats/network sensor discovery, and the three diagnostic buttons. Purely-display uses of the name (entity/device names, the config-entry title) are untouched.

This mirrors the same fix already applied to the `home-assistant/core` submission (PR #179103) after a Copilot review finding there.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Existing tests that hardcoded the old display-name-based unique_id/device-identifier format were updated (`tests/_fakes.py`'s `make_config_entry` now takes an `entry_id` param, defaulting to the same string as the default `name` so pre-existing expectations keep passing). New regression tests cover the identity-collision case directly (`test_device_info_same_name_different_system_id_prevents_collision`, `test_device_info_same_name_missing_system_id_falls_back_to_entry_id`, `test_unique_id_same_name_different_system_id_prevents_collision`, plus direct `resolve_entry_identity` tests).

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Namespace TrueNAS entities and devices by stable per-entry identity instead of editable display names.

Bug Fixes:
- Prevent entity and device collisions when multiple TrueNAS entries share the same display name by using stable system or config-entry identities.

Enhancements:
- Add migration of existing name-based registry records to the new identity namespace while preserving ambiguous shared devices.
- Use the resolved stable identity consistently for entity IDs, device identifiers, orphan cleanup, sensor discovery, and diagnostic buttons without changing display names.

Tests:
- Add regression coverage for system-ID and entry-ID identity resolution, same-name entry isolation, and registry migration scenarios.