### PR TITLE
fix: redact legacy config secrets in migration snapshots

### DIFF
--- a/custom_components/truenas_ce/migration.py
+++ b/custom_components/truenas_ce/migration.py
@@ -27,6 +27,7 @@ from logging import getLogger
 from typing import Any
 
 from homeassistant.components import persistent_notification
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry, ConfigEntryDisabler
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -42,6 +43,7 @@ from .const import (
     MIGRATION_LEGACY_CONFIG,
     MIGRATION_LEGACY_ENTRY_ID,
     MIGRATION_RECORDS,
+    TO_REDACT,
 )
 from .helper import sanitize_host
 
@@ -207,6 +209,21 @@ def _remove_legacy_entities(
         ent_reg.async_remove(record[_R_ENTITY_ID])
 
 
+def _redacted_legacy_config(legacy_entry: ConfigEntry) -> dict[str, Any]:
+    """Return the legacy entry's data/options with sensitive fields redacted.
+
+    Used everywhere a legacy snapshot is persisted (the migration backup file,
+    the reverse map on the new entry) — neither is ever read back to actually
+    restore anything (:func:`async_rollback_to_legacy` re-enables the
+    still-existing legacy entry instead), so there's no reason for either copy
+    to carry a live API key.
+    """
+    return {
+        "data": async_redact_data(dict(legacy_entry.data), TO_REDACT),
+        "options": async_redact_data(dict(legacy_entry.options), TO_REDACT),
+    }
+
+
 def _entry_backup_prefix(entry_id: str) -> str:
     """Return the per-entry ``.storage`` key prefix for migration backups.
 
@@ -238,10 +255,7 @@ async def _write_migration_backup(
         "created": now.isoformat(),
         "ce_entry_id": config_entry.entry_id,
         "legacy_entry_id": legacy_entry.entry_id,
-        "legacy_config": {
-            "data": dict(legacy_entry.data),
-            "options": dict(legacy_entry.options),
-        },
+        "legacy_config": _redacted_legacy_config(legacy_entry),
         "records": records,
     }
     try:
@@ -303,10 +317,7 @@ def _persist_migration_state(
     }
     if legacy_entry is not None:
         new_data[MIGRATION_LEGACY_ENTRY_ID] = legacy_entry.entry_id
-        new_data[MIGRATION_LEGACY_CONFIG] = {
-            "data": dict(legacy_entry.data),
-            "options": dict(legacy_entry.options),
-        }
+        new_data[MIGRATION_LEGACY_CONFIG] = _redacted_legacy_config(legacy_entry)
     if backup_key:
         new_data[MIGRATION_BACKUP_KEY] = backup_key
     hass.config_entries.async_update_entry(config_entry, data=new_data)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -30,6 +30,7 @@ from custom_components.truenas_ce.migration import (
     _find_legacy_entry,
     _log_reconnection,
     _persist_migration_state,
+    _redacted_legacy_config,
     _remap_and_restore,
     _remove_legacy_entities,
     _restore_overrides,
@@ -191,10 +192,27 @@ def test_persist_migration_state_with_legacy_entry_and_backup() -> None:
     assert new_data[MIGRATION_RECORDS] == records
     assert new_data[MIGRATION_LEGACY_ENTRY_ID] == "legacy-1"
     assert new_data[MIGRATION_LEGACY_CONFIG] == {
-        "data": {"host": "x"},
+        "data": {"host": "**REDACTED**"},
         "options": {"opt": 1},
     }
     assert new_data[MIGRATION_BACKUP_KEY] == "backup-key-1"
+
+
+# ---------------------------
+#   _redacted_legacy_config
+# ---------------------------
+def test_redacted_legacy_config_redacts_sensitive_fields() -> None:
+    legacy_entry = SimpleNamespace(
+        entry_id="legacy-1",
+        data={"host": "truenas.local", "api_key": "secret-key"},
+        options={"poll_interval": 60},
+    )
+
+    result = _redacted_legacy_config(legacy_entry)
+
+    assert result["data"]["host"] == "**REDACTED**"
+    assert result["data"]["api_key"] == "**REDACTED**"
+    assert result["options"] == {"poll_interval": 60}
 
 
 def test_persist_migration_state_without_legacy_entry() -> None:
@@ -587,7 +605,9 @@ def test_finalize_legacy_adoption_skips_unmatched_records() -> None:
 async def test_write_migration_backup_success() -> None:
     hass = MagicMock()
     entry = _config_entry()
-    legacy_entry = SimpleNamespace(entry_id="legacy-1", data={}, options={})
+    legacy_entry = SimpleNamespace(
+        entry_id="legacy-1", data={"api_key": "secret-key"}, options={}
+    )
 
     store_instance = MagicMock()
     store_instance.async_save = AsyncMock()
@@ -605,6 +625,8 @@ async def test_write_migration_backup_success() -> None:
 
     assert key == store_instance.key
     store_instance.async_save.assert_awaited_once()
+    saved_payload = store_instance.async_save.call_args[0][0]
+    assert saved_payload["legacy_config"]["data"]["api_key"] == "**REDACTED**"
     remove_mock.assert_awaited_once_with(
         hass, migration_module._entry_backup_prefix(entry.entry_id), store_instance.key
     )


### PR DESCRIPTION
## Proposed change

`_write_migration_backup()` and `_persist_migration_state()` in `migration.py` both copied the legacy `truenas` entry's `data`/`options` verbatim — including a live `api_key` — into a `.storage` backup file and into the new entry's own `data`, with no redaction. Neither snapshot is ever read back (`async_rollback_to_legacy` re-enables the still-existing legacy entry instead), so there was no reason for either copy to carry a live secret.

Found while porting a Copilot review from the `home-assistant/core` Bronze submission ([home-assistant/core#179103](https://github.com/home-assistant/core/pull/179103)) back to this repo: that PR's independently-written `migration.py` had the same gap on the `data` half only, which prompted a closer look at this repo's own version — it turned out this one redacted neither half.

Both write sites now go through a new shared helper, `_redacted_legacy_config()`, which runs `data`/`options` through the existing `async_redact_data`/`TO_REDACT` machinery already used by `diagnostics.py`.

## Type of change

- [x] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

- No behavior change for rollback itself — the snapshot is a safety net, never read back to reconstruct anything.
- `ruff check`/`ruff format --check`/`bandit`/full `pytest` suite (934 tests) all pass locally.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent migration snapshots from retaining live legacy configuration secrets.

Bug Fixes:
- Redact sensitive legacy configuration values, including API keys, before persisting migration backups or migration state.

Enhancements:
- Centralize legacy configuration snapshot redaction using the existing diagnostics redaction rules.

Tests:
- Add coverage verifying sensitive fields are redacted in migration state and backup snapshots.