### PR TITLE
fix: stop lossy unique_id slugification, migrate existing entities

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -59,6 +59,7 @@ from .entity import (
     _is_uid_excluded,
     format_unique_id,
     migrate_entry_identity_namespace,
+    migrate_slugified_unique_ids,
     register_system_device,
     resolve_entry_identity,
 )
@@ -568,6 +569,7 @@ async def async_setup_entry(
     await coordinator.async_config_entry_first_refresh()
     config_entry.runtime_data = coordinator
     migrate_entry_identity_namespace(hass, config_entry)
+    migrate_slugified_unique_ids(hass, config_entry, coordinator, _ALL_DESCRIPTIONS)
     coordinator.system_device_id = register_system_device(
         hass, config_entry, coordinator
     )

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -238,19 +238,26 @@ def migrate_slugified_unique_ids(
     worse than leaving a stale entity behind for the existing orphan-cleanup
     flow to catch (Sourcery finding on the initial version of this
     migration).
+
+    A composite-reference description (``data_composite_references`` set,
+    see ``TrueNASEntityDescription.__post_init__``) is valid without a plain
+    ``data_reference`` -- skipping it whenever ``data_reference`` alone was
+    unset silently left its legacy entries (e.g. per-app network sensors)
+    unmigrated (Sourcery finding on the initial version of this migration).
     """
     identity = resolve_entry_identity(config_entry)
     renames: dict[str, str] = {}
     ambiguous: set[str] = set()
     for description in descriptions:
-        if not getattr(description, "data_reference", None):
+        has_composite = bool(getattr(description, "data_composite_references", ()))
+        if not getattr(description, "data_reference", None) and not has_composite:
             continue
         data = coordinator.data.get(description.data_path or "")
         if not isinstance(data, dict):
             continue
         pairs = (
             _composite_id_pairs(identity, description, data)
-            if getattr(description, "data_composite_references", ())
+            if has_composite
             else _referenced_id_pairs(identity, description, data)
         )
         for old, new in pairs:

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -67,6 +67,25 @@ def format_unique_id(identity: str, key: str, reference: object = None) -> str:
     ``resolve_entry_identity``), not the user-editable display name.
     Shared so the migration in __init__.py can resolve the same unique_id an
     entity produces.
+
+    ``reference`` is lowercased but not slugified: unique_id has no character
+    restrictions in HA, and slugify's lossy '/'/'-'/'_' collapsing would let
+    distinct references (e.g. ZFS datasets "tank/a-b" and "tank/a_b") collide
+    and silently drop one entity as a duplicate. See
+    ``migrate_slugified_unique_ids`` for the one-time rename this requires on
+    existing installations.
+    """
+    base = f"{identity.lower()}-{key}"
+    if reference is None:
+        return base
+    return f"{base}-{str(reference).lower()}"
+
+
+def _legacy_format_unique_id(identity: str, key: str, reference: object = None) -> str:
+    """Pre-2.10 unique_id format (lossy ``slugify()`` of the reference).
+
+    Only used by ``migrate_slugified_unique_ids`` to locate registry entries
+    created under the old format; entities themselves use ``format_unique_id``.
     """
     base = f"{identity.lower()}-{key}"
     if reference is None:
@@ -145,6 +164,97 @@ def migrate_entry_identity_namespace(
             dev_reg.async_update_device(
                 device_entry.id, new_identifiers=new_identifiers
             )
+
+
+def _referenced_id_pairs(
+    identity: str, description: TrueNASEntityDescription, data: Mapping[str, Any]
+) -> set[tuple[str, str]]:
+    """Return (old, new) format_unique_id pairs for one referenced description."""
+    pairs: set[tuple[str, str]] = set()
+    for uid, vals in data.items():
+        if not isinstance(vals, dict):
+            continue
+        ref = vals.get(description.data_reference)
+        reference = ref if ref is not None else uid
+        pairs.add(
+            (
+                _legacy_format_unique_id(identity, description.key, reference),
+                format_unique_id(identity, description.key, reference),
+            )
+        )
+    return pairs
+
+
+def _composite_id_pairs(
+    identity: str, description: TrueNASEntityDescription, data: Mapping[str, Any]
+) -> set[tuple[str, str]]:
+    """Return (old, new) format_unique_id pairs for one composite-ref description."""
+    pairs: set[tuple[str, str]] = set()
+    if len(description.data_composite_references) != 2:
+        return pairs
+    container_key, leaf_key = description.data_composite_references
+    for uid, vals in data.items():
+        container = _get_composite_container(vals, container_key)
+        if container is None:
+            continue
+        for item in container:
+            ref = _extract_composite_ref(item, description, False, leaf_key)
+            if ref is None:
+                continue
+            composed = f"{uid}::{ref}"
+            pairs.add(
+                (
+                    _legacy_format_unique_id(identity, description.key, composed),
+                    format_unique_id(identity, description.key, composed),
+                )
+            )
+    return pairs
+
+
+def migrate_slugified_unique_ids(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: TrueNASCoordinator,
+    descriptions: Sequence[TrueNASEntityDescription],
+) -> None:
+    """Rewrite registry entries from the old lossy-slugified unique_id format.
+
+    ``format_unique_id`` used to run its reference through ``slugify()``,
+    which collapsed distinct references (e.g. ZFS datasets "tank/a-b" and
+    "tank/a_b", or app names like "immich-server" combined with an interface
+    name) onto the same unique_id, silently dropping one entity as a
+    duplicate. The fix stops slugifying, so every already-registered entity
+    for an existing installation must be renamed here -- otherwise HA treats
+    it as gone and creates a fresh, differently-IDed entity, breaking the
+    existing entity_id, history and any automations/dashboards referencing
+    it. Must run before ``register_system_device``, orphaned-entity cleanup
+    and any platform setup, so those find the already-renamed records.
+    """
+    identity = resolve_entry_identity(config_entry)
+    renames: dict[str, str] = {}
+    for description in descriptions:
+        if not getattr(description, "data_reference", None):
+            continue
+        data = coordinator.data.get(description.data_path or "")
+        if not isinstance(data, dict):
+            continue
+        pairs = (
+            _composite_id_pairs(identity, description, data)
+            if getattr(description, "data_composite_references", ())
+            else _referenced_id_pairs(identity, description, data)
+        )
+        renames |= {old: new for old, new in pairs if old != new}
+
+    if not renames:
+        return
+
+    ent_reg = er.async_get(hass)
+    for entity_entry in er.async_entries_for_config_entry(
+        ent_reg, config_entry.entry_id
+    ):
+        new_id = renames.get(entity_entry.unique_id)
+        if new_id is not None:
+            ent_reg.async_update_entity(entity_entry.entity_id, new_unique_id=new_id)
 
 
 @lru_cache(maxsize=1)

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -229,9 +229,19 @@ def migrate_slugified_unique_ids(
     existing entity_id, history and any automations/dashboards referencing
     it. Must run before ``register_system_device``, orphaned-entity cleanup
     and any platform setup, so those find the already-renamed records.
+
+    A single legacy slug can match more than one *current* reference (that
+    is exactly the collision the fix eliminates going forward). Which of
+    those references the one existing legacy entry actually belonged to is
+    unrecoverable, so such an old id is left unrenamed rather than guessed
+    at -- silently reassigning it to the wrong dataset/interface would be
+    worse than leaving a stale entity behind for the existing orphan-cleanup
+    flow to catch (Sourcery finding on the initial version of this
+    migration).
     """
     identity = resolve_entry_identity(config_entry)
     renames: dict[str, str] = {}
+    ambiguous: set[str] = set()
     for description in descriptions:
         if not getattr(description, "data_reference", None):
             continue
@@ -243,7 +253,15 @@ def migrate_slugified_unique_ids(
             if getattr(description, "data_composite_references", ())
             else _referenced_id_pairs(identity, description, data)
         )
-        renames |= {old: new for old, new in pairs if old != new}
+        for old, new in pairs:
+            if old == new or old in ambiguous:
+                continue
+            existing = renames.get(old)
+            if existing is None:
+                renames[old] = new
+            elif existing != new:
+                del renames[old]
+                ambiguous.add(old)
 
     if not renames:
         return

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -211,6 +211,69 @@ def _composite_id_pairs(
     return pairs
 
 
+def _merge_rename_candidates(
+    pairs: set[tuple[str, str]], candidates: dict[str, set[str]]
+) -> None:
+    """Record one description's (old, new) unique_id pairs by legacy id.
+
+    Every candidate new id is recorded here, including ones that equal the
+    old id -- an unaffected reference (unchanged by the fix) can still share
+    its legacy slug with a different, affected reference, so an early
+    old == new skip here would hide that collision instead of flagging it
+    (Sourcery finding on an earlier version of this migration).
+    """
+    for old, new in pairs:
+        candidates.setdefault(old, set()).add(new)
+
+
+def _resolve_renames(candidates: dict[str, set[str]]) -> dict[str, str]:
+    """Turn old-id -> candidate-new-ids into the final rename map.
+
+    A legacy id with more than one distinct candidate new id (a collision
+    the fix eliminates going forward) is left out entirely rather than
+    arbitrarily renamed to one of them -- see ``migrate_slugified_unique_ids``
+    for why.
+    """
+    renames: dict[str, str] = {}
+    for old, news in candidates.items():
+        if len(news) != 1:
+            continue
+        (new,) = news
+        if new != old:
+            renames[old] = new
+    return renames
+
+
+def _collect_unique_id_renames(
+    identity: str,
+    descriptions: Sequence[TrueNASEntityDescription],
+    coordinator: TrueNASCoordinator,
+) -> dict[str, str]:
+    """Build the old-to-new unique_id rename map across all descriptions.
+
+    A composite-reference description (``data_composite_references`` set,
+    see ``TrueNASEntityDescription.__post_init__``) is valid without a plain
+    ``data_reference`` -- skipping it whenever ``data_reference`` alone was
+    unset silently left its legacy entries (e.g. per-app network sensors)
+    unmigrated (Sourcery finding on an earlier version of this migration).
+    """
+    candidates: dict[str, set[str]] = {}
+    for description in descriptions:
+        has_composite = bool(getattr(description, "data_composite_references", ()))
+        if not getattr(description, "data_reference", None) and not has_composite:
+            continue
+        data = coordinator.data.get(description.data_path or "")
+        if not isinstance(data, dict):
+            continue
+        pairs = (
+            _composite_id_pairs(identity, description, data)
+            if has_composite
+            else _referenced_id_pairs(identity, description, data)
+        )
+        _merge_rename_candidates(pairs, candidates)
+    return _resolve_renames(candidates)
+
+
 def migrate_slugified_unique_ids(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -238,38 +301,9 @@ def migrate_slugified_unique_ids(
     worse than leaving a stale entity behind for the existing orphan-cleanup
     flow to catch (Sourcery finding on the initial version of this
     migration).
-
-    A composite-reference description (``data_composite_references`` set,
-    see ``TrueNASEntityDescription.__post_init__``) is valid without a plain
-    ``data_reference`` -- skipping it whenever ``data_reference`` alone was
-    unset silently left its legacy entries (e.g. per-app network sensors)
-    unmigrated (Sourcery finding on the initial version of this migration).
     """
     identity = resolve_entry_identity(config_entry)
-    renames: dict[str, str] = {}
-    ambiguous: set[str] = set()
-    for description in descriptions:
-        has_composite = bool(getattr(description, "data_composite_references", ()))
-        if not getattr(description, "data_reference", None) and not has_composite:
-            continue
-        data = coordinator.data.get(description.data_path or "")
-        if not isinstance(data, dict):
-            continue
-        pairs = (
-            _composite_id_pairs(identity, description, data)
-            if has_composite
-            else _referenced_id_pairs(identity, description, data)
-        )
-        for old, new in pairs:
-            if old == new or old in ambiguous:
-                continue
-            existing = renames.get(old)
-            if existing is None:
-                renames[old] = new
-            elif existing != new:
-                del renames[old]
-                ambiguous.add(old)
-
+    renames = _collect_unique_id_renames(identity, descriptions, coordinator)
     if not renames:
         return
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -16,10 +16,13 @@ from custom_components.truenas_ce.entity import (
     TrueNASEntityDescription,
     _append_if_new,
     _collect_new_entities,
+    _composite_id_pairs,
     _extract_composite_ref,
     _get_composite_container,
     _is_uid_excluded,
+    _legacy_format_unique_id,
     _new_referenced_entities,
+    _referenced_id_pairs,
     _skip_keyless_description,
     format_device_identifier,
     format_unique_id,
@@ -46,13 +49,68 @@ def test_format_unique_id_without_reference() -> None:
     assert format_unique_id("TrueNAS", "system_uptime") == "truenas-system_uptime"
 
 
-def test_format_unique_id_with_reference_slugifies() -> None:
+def test_format_unique_id_with_reference_lowercases_only() -> None:
     result = format_unique_id("TrueNAS", "disk_temp", "Disk One!")
-    assert result == "truenas-disk_temp-disk_one"
+    assert result == "truenas-disk_temp-disk one!"
+
+
+def test_format_unique_id_distinguishes_slash_and_dash_variants() -> None:
+    """Distinct dataset references must not collapse to the same unique id."""
+    assert format_unique_id("TrueNAS", "dataset", "tank/a-b") != format_unique_id(
+        "TrueNAS", "dataset", "tank/a_b"
+    )
 
 
 def test_format_device_identifier() -> None:
     assert format_device_identifier("TrueNAS", "nas.local") == "TrueNAS_nas.local"
+
+
+# ---------------------------
+#   _legacy_format_unique_id / _referenced_id_pairs / _composite_id_pairs
+# ---------------------------
+def test_legacy_format_unique_id_matches_pre_fix_slugify_behavior() -> None:
+    assert (
+        _legacy_format_unique_id("TrueNAS", "disk_temp", "Disk One!")
+        == "truenas-disk_temp-disk_one"
+    )
+
+
+def test_referenced_id_pairs_only_flags_lossy_references() -> None:
+    """Only references that actually differ under slugify vs. lower() need a rename."""
+    data = {
+        "a": {"guid": "tank/a-b"},
+        "b": {"guid": "eth0"},
+    }
+    pairs = _referenced_id_pairs("TrueNAS", _REF_DESC, data)
+    old_new = dict(pairs)
+    assert old_new[_legacy_format_unique_id("TrueNAS", "disk_temp", "tank/a-b")] == (
+        format_unique_id("TrueNAS", "disk_temp", "tank/a-b")
+    )
+    assert old_new[_legacy_format_unique_id("TrueNAS", "disk_temp", "eth0")] == (
+        format_unique_id("TrueNAS", "disk_temp", "eth0")
+    )
+    # "eth0" is unaffected by the fix, so its old and new ids are identical.
+    assert old_new[
+        _legacy_format_unique_id("TrueNAS", "disk_temp", "eth0")
+    ] == _legacy_format_unique_id("TrueNAS", "disk_temp", "eth0")
+
+
+def test_composite_id_pairs_covers_nested_network_references() -> None:
+    desc = TrueNASSensorEntityDescription(
+        key="net_rx",
+        name="RX",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_composite_references=("networks", "interface_name"),
+    )
+    data = {"immich-server": {"networks": [{"interface_name": "eth0"}]}}
+    pairs = _composite_id_pairs("TrueNAS", desc, data)
+    assert pairs == {
+        (
+            _legacy_format_unique_id("TrueNAS", "net_rx", "immich-server::eth0"),
+            format_unique_id("TrueNAS", "net_rx", "immich-server::eth0"),
+        )
+    }
 
 
 # ---------------------------

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -221,6 +221,44 @@ async def test_migrate_slugified_unique_ids_leaves_previous_collision_unrenamed(
     assert migrated.unique_id == "system-guid-dataset_used-tank_a_b"
 
 
+async def test_migrate_slugified_unique_ids_leaves_partial_collision_unrenamed(
+    hass: HomeAssistant,
+) -> None:
+    """A collision is still a collision when one of the two live references
+    happens to already equal its own legacy slug (e.g. "tank_a_b", unaffected
+    by the fix) while the other one ("tank/a-b") collides onto that same
+    slug. Skipping the unaffected side early must not hide that collision --
+    the shared legacy entry must be left unrenamed either way (Sourcery
+    finding on an earlier version of this migration).
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(
+        data={
+            "dataset": {
+                "tank/a-b": {"id": "tank/a-b"},
+                "tank_a_b": {"id": "tank_a_b"},
+            }
+        }
+    )
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "system-guid-dataset_used-tank_a_b",
+        config_entry=entry,
+    )
+
+    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == "system-guid-dataset_used-tank_a_b"
+
+
 async def test_migrate_slugified_unique_ids_noop_for_unaffected_reference(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -180,12 +180,15 @@ async def test_migrate_slugified_unique_ids_renames_lossy_reference(
     )
 
 
-async def test_migrate_slugified_unique_ids_resolves_previous_collision(
+async def test_migrate_slugified_unique_ids_leaves_previous_collision_unrenamed(
     hass: HomeAssistant,
 ) -> None:
     """Two datasets that used to collide onto the same slugified unique_id
-    (only one of which could ever be registered) must resolve to distinct
-    ids after the migration, so the previously-dropped one can now appear.
+    (only one of which could ever be registered) must NOT be guessed at:
+    which live reference the single legacy entry actually belonged to is
+    unrecoverable, so renaming it to either one risks reassigning its
+    history to the wrong dataset. It must be left unrenamed instead
+    (Sourcery finding on the initial version of this migration).
     """
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
@@ -214,11 +217,7 @@ async def test_migrate_slugified_unique_ids_resolves_previous_collision(
 
     migrated = ent_reg.async_get(entity.entity_id)
     assert migrated is not None
-    new_ids = {
-        format_unique_id("system-guid", "dataset_used", "tank/a-b"),
-        format_unique_id("system-guid", "dataset_used", "tank/a_b"),
-    }
-    assert migrated.unique_id in new_ids
+    assert migrated.unique_id == "system-guid-dataset_used-tank_a_b"
 
 
 async def test_migrate_slugified_unique_ids_noop_for_unaffected_reference(

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -34,6 +34,7 @@ from custom_components.truenas_ce.const import (
 )
 from custom_components.truenas_ce.entity import (
     _cleanup_orphaned_entities,
+    _legacy_format_unique_id,
     format_unique_id,
     migrate_entry_identity_namespace,
     migrate_slugified_unique_ids,
@@ -243,6 +244,51 @@ async def test_migrate_slugified_unique_ids_noop_for_unaffected_reference(
     migrated = ent_reg.async_get(entity.entity_id)
     assert migrated is not None
     assert migrated.unique_id == format_unique_id("system-guid", "dataset_used", "tank")
+
+
+async def test_migrate_slugified_unique_ids_renames_composite_only_reference(
+    hass: HomeAssistant,
+) -> None:
+    """A composite-reference description without a plain ``data_reference``
+    (e.g. per-app network sensors) is a valid configuration -- see
+    ``TrueNASEntityDescription.__post_init__`` -- and must still be migrated
+    (Sourcery finding on the initial version of this migration).
+    """
+    net_desc = TrueNASSensorEntityDescription(
+        key="net_rx",
+        name="RX",
+        data_path="app_stats",
+        data_dynamic_keys=True,
+        data_composite_references=("networks", "interface_name"),
+        func="TrueNASEntity",
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(
+        data={
+            "app_stats": {
+                "immich-server": {"networks": [{"interface_name": "eth0"}]},
+            }
+        }
+    )
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        _legacy_format_unique_id("system-guid", "net_rx", "immich-server::eth0"),
+        config_entry=entry,
+    )
+
+    migrate_slugified_unique_ids(hass, entry, coordinator, [net_desc])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == format_unique_id(
+        "system-guid", "net_rx", "immich-server::eth0"
+    )
 
 
 # ---------------------------

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -36,9 +36,13 @@ from custom_components.truenas_ce.entity import (
     _cleanup_orphaned_entities,
     format_unique_id,
     migrate_entry_identity_namespace,
+    migrate_slugified_unique_ids,
     resolve_entry_identity,
 )
-from custom_components.truenas_ce.sensor_types import SENSOR_TYPES
+from custom_components.truenas_ce.sensor_types import (
+    SENSOR_TYPES,
+    TrueNASSensorEntityDescription,
+)
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
 
@@ -131,6 +135,115 @@ async def test_migrate_entry_identity_namespace_skips_shared_device(
     untouched_device = dev_reg.async_get(shared_device.id)
     assert untouched_device is not None
     assert untouched_device.identifiers == {(DOMAIN, "TrueNAS_tank")}
+
+
+# ---------------------------
+#   migrate_slugified_unique_ids
+# ---------------------------
+_DATASET_DESC = TrueNASSensorEntityDescription(
+    key="dataset_used",
+    name="Used",
+    data_path="dataset",
+    data_reference="id",
+    func="TrueNASEntity",
+)
+
+
+async def test_migrate_slugified_unique_ids_renames_lossy_reference(
+    hass: HomeAssistant,
+) -> None:
+    """A dataset unique_id built with the old slugify()-based format must be
+    renamed in place to the new format -- otherwise the entity_id, history
+    and any automations referencing it would be silently replaced by a new,
+    differently-IDed entity on upgrade.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(data={"dataset": {"tank/a-b": {"id": "tank/a-b"}}})
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "system-guid-dataset_used-tank_a_b",  # old slugify()-based id
+        config_entry=entry,
+    )
+
+    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == format_unique_id(
+        "system-guid", "dataset_used", "tank/a-b"
+    )
+
+
+async def test_migrate_slugified_unique_ids_resolves_previous_collision(
+    hass: HomeAssistant,
+) -> None:
+    """Two datasets that used to collide onto the same slugified unique_id
+    (only one of which could ever be registered) must resolve to distinct
+    ids after the migration, so the previously-dropped one can now appear.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(
+        data={
+            "dataset": {
+                "tank/a-b": {"id": "tank/a-b"},
+                "tank/a_b": {"id": "tank/a_b"},
+            }
+        }
+    )
+
+    ent_reg = er.async_get(hass)
+    # Only "tank/a-b" ever made it into the registry; "tank/a_b" was silently
+    # dropped as a duplicate under the old algorithm.
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "system-guid-dataset_used-tank_a_b",
+        config_entry=entry,
+    )
+
+    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    new_ids = {
+        format_unique_id("system-guid", "dataset_used", "tank/a-b"),
+        format_unique_id("system-guid", "dataset_used", "tank/a_b"),
+    }
+    assert migrated.unique_id in new_ids
+
+
+async def test_migrate_slugified_unique_ids_noop_for_unaffected_reference(
+    hass: HomeAssistant,
+) -> None:
+    """A reference unaffected by the fix (e.g. plain alnum) must not be touched."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(data={"dataset": {"tank": {"id": "tank"}}})
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        format_unique_id("system-guid", "dataset_used", "tank"),
+        config_entry=entry,
+    )
+
+    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == format_unique_id("system-guid", "dataset_used", "tank")
 
 
 # ---------------------------


### PR DESCRIPTION
## Proposed change

`format_unique_id()` ran its `reference` argument through `slugify()`, which collapses `/`, `-`, `_` and spaces onto a single `_`. Two distinct references that only differ in those characters (e.g. ZFS datasets `tank/a-b` and `tank/a_b`, or an app name like `immich-server` combined with a network interface name) produced the *same* `unique_id`, so the second entity was silently dropped as a "duplicate" by `_append_if_new`. Confirmed with real data in this installation: the `Backup/truenas-config` dataset already has a hyphen in it.

The fix stops slugifying: `unique_id` has no character restrictions in Home Assistant, so lowercasing the reference is enough.

Since this repo has real installed unique_ids (unlike the ha-core Bronze submission that surfaced this, home-assistant/core#179103), the fix is not just an algorithm change: `migrate_slugified_unique_ids()` (new in `entity.py`, wired into `async_setup_entry`) walks every entity description with a reference against live coordinator data, computes what its unique_id was under the old and new format, and renames matching entity-registry entries in place via `entity_registry.async_update_entity(..., new_unique_id=...)` — before platform setup and orphaned-statistics cleanup run.

Only the internal `unique_id` changes; `entity_id` (and therefore history, automations, dashboards, anything referencing the entity) stays exactly the same. Verified against this installation's own `sensor.truenas_datasets_backup_truenas_config`: same entity_id, same state, no duplicate `_2` entity, no errors in the log after a full restart.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Addresses a copilot-pull-request-reviewer finding from the ha-core Bronze submission (home-assistant/core#179103, discussion_r3843429287) that also applies here.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Prevent unique ID collisions caused by lossy reference slugification and safely migrate unambiguous existing registry entries.

Bug Fixes:
- Preserve distinct reference values in generated unique IDs instead of collapsing them through lossy slugification.
- Migrate existing entity-registry entries to the corrected unique IDs while preserving their entity IDs and associated history and configurations.

Enhancements:
- Handle migrations for both direct and composite entity references, while avoiding ambiguous renames when legacy IDs correspond to multiple live references.

Tests:
- Add coverage for non-lossy unique ID generation, reference collisions, direct and composite-reference migrations, unaffected references, and ambiguous legacy IDs.