### PR TITLE
fix: preserve reference case in entity unique_id

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -59,7 +59,7 @@ from .entity import (
     _is_uid_excluded,
     format_unique_id,
     migrate_entry_identity_namespace,
-    migrate_slugified_unique_ids,
+    migrate_legacy_unique_ids,
     register_system_device,
     resolve_entry_identity,
 )
@@ -569,7 +569,7 @@ async def async_setup_entry(
     await coordinator.async_config_entry_first_refresh()
     config_entry.runtime_data = coordinator
     migrate_entry_identity_namespace(hass, config_entry)
-    migrate_slugified_unique_ids(hass, config_entry, coordinator, _ALL_DESCRIPTIONS)
+    migrate_legacy_unique_ids(hass, config_entry, coordinator, _ALL_DESCRIPTIONS)
     coordinator.system_device_id = register_system_device(
         hass, config_entry, coordinator
     )

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -68,29 +68,42 @@ def format_unique_id(identity: str, key: str, reference: object = None) -> str:
     Shared so the migration in __init__.py can resolve the same unique_id an
     entity produces.
 
-    ``reference`` is lowercased but not slugified: unique_id has no character
-    restrictions in HA, and slugify's lossy '/'/'-'/'_' collapsing would let
-    distinct references (e.g. ZFS datasets "tank/a-b" and "tank/a_b") collide
-    and silently drop one entity as a duplicate. See
-    ``migrate_slugified_unique_ids`` for the one-time rename this requires on
-    existing installations.
+    ``reference`` keeps its original case and is not slugified: unique_id has
+    no character restrictions in HA, and both slugify() and lower() are lossy
+    -- slugify's '/'/'-'/'_' collapsing and lower()'s case-folding would each
+    let distinct references (e.g. ZFS datasets "tank/a-b" vs "tank/a_b", or
+    "tank/Data" vs "tank/data") collide and silently drop one entity as a
+    duplicate. See ``migrate_legacy_unique_ids`` for the one-time rename this
+    requires on existing installations.
     """
     base = f"{identity.lower()}-{key}"
     if reference is None:
         return base
-    return f"{base}-{str(reference).lower()}"
+    return f"{base}-{reference!s}"
 
 
 def _legacy_format_unique_id(identity: str, key: str, reference: object = None) -> str:
-    """Pre-2.10 unique_id format (lossy ``slugify()`` of the reference).
+    """Pre-2.9 unique_id format (lossy ``slugify()`` of the lowercased reference).
 
-    Only used by ``migrate_slugified_unique_ids`` to locate registry entries
-    created under the old format; entities themselves use ``format_unique_id``.
+    Only used by ``migrate_legacy_unique_ids`` to locate registry entries
+    created under this old format; entities themselves use ``format_unique_id``.
     """
     base = f"{identity.lower()}-{key}"
     if reference is None:
         return base
     return f"{base}-{slugify(str(reference).lower())}"
+
+
+def _lowercased_unique_id(identity: str, key: str, reference: object = None) -> str:
+    """2.9/2.10-era unique_id format (lowercased but not slugified reference).
+
+    Only used by ``migrate_legacy_unique_ids`` to locate registry entries
+    created under this old format; entities themselves use ``format_unique_id``.
+    """
+    base = f"{identity.lower()}-{key}"
+    if reference is None:
+        return base
+    return f"{base}-{str(reference).lower()}"
 
 
 def format_device_identifier(identity: str, hostname: str) -> str:
@@ -166,8 +179,14 @@ def migrate_entry_identity_namespace(
             )
 
 
+_LegacyFormatter = Callable[[str, str, object], str]
+
+
 def _referenced_id_pairs(
-    identity: str, description: TrueNASEntityDescription, data: Mapping[str, Any]
+    identity: str,
+    description: TrueNASEntityDescription,
+    data: Mapping[str, Any],
+    legacy_formatter: _LegacyFormatter = _legacy_format_unique_id,
 ) -> set[tuple[str, str]]:
     """Return (old, new) format_unique_id pairs for one referenced description."""
     pairs: set[tuple[str, str]] = set()
@@ -178,7 +197,7 @@ def _referenced_id_pairs(
         reference = ref if ref is not None else uid
         pairs.add(
             (
-                _legacy_format_unique_id(identity, description.key, reference),
+                legacy_formatter(identity, description.key, reference),
                 format_unique_id(identity, description.key, reference),
             )
         )
@@ -186,7 +205,10 @@ def _referenced_id_pairs(
 
 
 def _composite_id_pairs(
-    identity: str, description: TrueNASEntityDescription, data: Mapping[str, Any]
+    identity: str,
+    description: TrueNASEntityDescription,
+    data: Mapping[str, Any],
+    legacy_formatter: _LegacyFormatter = _legacy_format_unique_id,
 ) -> set[tuple[str, str]]:
     """Return (old, new) format_unique_id pairs for one composite-ref description."""
     pairs: set[tuple[str, str]] = set()
@@ -204,7 +226,7 @@ def _composite_id_pairs(
             composed = f"{uid}::{ref}"
             pairs.add(
                 (
-                    _legacy_format_unique_id(identity, description.key, composed),
+                    legacy_formatter(identity, description.key, composed),
                     format_unique_id(identity, description.key, composed),
                 )
             )
@@ -231,7 +253,7 @@ def _resolve_renames(candidates: dict[str, set[str]]) -> dict[str, str]:
 
     A legacy id with more than one distinct candidate new id (a collision
     the fix eliminates going forward) is left out entirely rather than
-    arbitrarily renamed to one of them -- see ``migrate_slugified_unique_ids``
+    arbitrarily renamed to one of them -- see ``migrate_legacy_unique_ids``
     for why.
     """
     renames: dict[str, str] = {}
@@ -242,6 +264,18 @@ def _resolve_renames(candidates: dict[str, set[str]]) -> dict[str, str]:
         if new != old:
             renames[old] = new
     return renames
+
+
+# Every unique_id format a registry entry may still carry from before the fix
+# that introduced its successor -- oldest first. ``_legacy_format_unique_id``
+# predates ``_lowercased_unique_id`` was even the default (both were still
+# lowercasing the reference before ``format_unique_id`` stopped doing that
+# too), so an installation that skipped upgrades can have entries in either
+# format; both are checked so it is renamed straight to the current format.
+_LEGACY_UNIQUE_ID_FORMATTERS: tuple[_LegacyFormatter, ...] = (
+    _legacy_format_unique_id,
+    _lowercased_unique_id,
+)
 
 
 def _collect_unique_id_renames(
@@ -256,46 +290,54 @@ def _collect_unique_id_renames(
     ``data_reference`` -- skipping it whenever ``data_reference`` alone was
     unset silently left its legacy entries (e.g. per-app network sensors)
     unmigrated (Sourcery finding on an earlier version of this migration).
+
+    Checked against every format in ``_LEGACY_UNIQUE_ID_FORMATTERS``, merged
+    into one candidate map so a legacy id ambiguous under one format still
+    correctly blocks renaming under another (see ``_merge_rename_candidates``).
     """
     candidates: dict[str, set[str]] = {}
-    for description in descriptions:
-        has_composite = bool(getattr(description, "data_composite_references", ()))
-        if not getattr(description, "data_reference", None) and not has_composite:
-            continue
-        data = coordinator.data.get(description.data_path or "")
-        if not isinstance(data, dict):
-            continue
-        pairs = (
-            _composite_id_pairs(identity, description, data)
-            if has_composite
-            else _referenced_id_pairs(identity, description, data)
-        )
-        _merge_rename_candidates(pairs, candidates)
+    for legacy_formatter in _LEGACY_UNIQUE_ID_FORMATTERS:
+        for description in descriptions:
+            has_composite = bool(getattr(description, "data_composite_references", ()))
+            if not getattr(description, "data_reference", None) and not has_composite:
+                continue
+            data = coordinator.data.get(description.data_path or "")
+            if not isinstance(data, dict):
+                continue
+            pairs = (
+                _composite_id_pairs(identity, description, data, legacy_formatter)
+                if has_composite
+                else _referenced_id_pairs(identity, description, data, legacy_formatter)
+            )
+            _merge_rename_candidates(pairs, candidates)
     return _resolve_renames(candidates)
 
 
-def migrate_slugified_unique_ids(
+def migrate_legacy_unique_ids(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     coordinator: TrueNASCoordinator,
     descriptions: Sequence[TrueNASEntityDescription],
 ) -> None:
-    """Rewrite registry entries from the old lossy-slugified unique_id format.
+    """Rewrite registry entries from an earlier unique_id format.
 
-    ``format_unique_id`` used to run its reference through ``slugify()``,
-    which collapsed distinct references (e.g. ZFS datasets "tank/a-b" and
-    "tank/a_b", or app names like "immich-server" combined with an interface
-    name) onto the same unique_id, silently dropping one entity as a
-    duplicate. The fix stops slugifying, so every already-registered entity
-    for an existing installation must be renamed here -- otherwise HA treats
-    it as gone and creates a fresh, differently-IDed entity, breaking the
-    existing entity_id, history and any automations/dashboards referencing
-    it. Must run before ``register_system_device``, orphaned-entity cleanup
-    and any platform setup, so those find the already-renamed records.
+    ``format_unique_id``'s reference handling has tightened twice: it first
+    stopped running the reference through ``slugify()`` (which collapsed
+    distinct references like ZFS datasets "tank/a-b" and "tank/a_b", or app
+    names like "immich-server" combined with an interface name, onto the same
+    unique_id), then stopped lowercasing it too (which just as lossily
+    collapsed case-sensitive references like "tank/Data" and "tank/data").
+    Each tightening silently dropped one colliding entity as a duplicate, so
+    every already-registered entity for an existing installation must be
+    renamed here -- otherwise HA treats it as gone and creates a fresh,
+    differently-IDed entity, breaking the existing entity_id, history and any
+    automations/dashboards referencing it. Must run before
+    ``register_system_device``, orphaned-entity cleanup and any platform
+    setup, so those find the already-renamed records.
 
-    A single legacy slug can match more than one *current* reference (that
-    is exactly the collision the fix eliminates going forward). Which of
-    those references the one existing legacy entry actually belonged to is
+    A single legacy id can match more than one *current* reference (that is
+    exactly the collision each fix eliminates going forward). Which of those
+    references the one existing legacy entry actually belonged to is
     unrecoverable, so such an old id is left unrenamed rather than guessed
     at -- silently reassigning it to the wrong dataset/interface would be
     worse than leaving a stale entity behind for the existing orphan-cleanup

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -188,7 +188,7 @@ def _referenced_id_pairs(
     data: Mapping[str, Any],
     legacy_formatter: _LegacyFormatter = _legacy_format_unique_id,
 ) -> set[tuple[str, str]]:
-    """Return (old, new) format_unique_id pairs for one referenced description."""
+    """Return (legacy_unique_id, current_unique_id) pairs for one reference."""
     pairs: set[tuple[str, str]] = set()
     for uid, vals in data.items():
         if not isinstance(vals, dict):
@@ -210,7 +210,7 @@ def _composite_id_pairs(
     data: Mapping[str, Any],
     legacy_formatter: _LegacyFormatter = _legacy_format_unique_id,
 ) -> set[tuple[str, str]]:
-    """Return (old, new) format_unique_id pairs for one composite-ref description."""
+    """Return (legacy_unique_id, current_unique_id) pairs for one composite ref."""
     pairs: set[tuple[str, str]] = set()
     if len(description.data_composite_references) != 2:
         return pairs

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -268,10 +268,11 @@ def _resolve_renames(candidates: dict[str, set[str]]) -> dict[str, str]:
 
 # Every unique_id format a registry entry may still carry from before the fix
 # that introduced its successor -- oldest first. ``_legacy_format_unique_id``
-# predates ``_lowercased_unique_id`` was even the default (both were still
-# lowercasing the reference before ``format_unique_id`` stopped doing that
-# too), so an installation that skipped upgrades can have entries in either
-# format; both are checked so it is renamed straight to the current format.
+# is the oldest format, and ``_lowercased_unique_id`` was the subsequent
+# default format (both were still lowercasing the reference before
+# ``format_unique_id`` stopped doing that too), so an installation that
+# skipped upgrades can have entries in either format; both are checked so it
+# is renamed straight to the current format.
 _LEGACY_UNIQUE_ID_FORMATTERS: tuple[_LegacyFormatter, ...] = (
     _legacy_format_unique_id,
     _lowercased_unique_id,

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -21,6 +21,7 @@ from custom_components.truenas_ce.entity import (
     _get_composite_container,
     _is_uid_excluded,
     _legacy_format_unique_id,
+    _lowercased_unique_id,
     _new_referenced_entities,
     _referenced_id_pairs,
     _skip_keyless_description,
@@ -49,15 +50,23 @@ def test_format_unique_id_without_reference() -> None:
     assert format_unique_id("TrueNAS", "system_uptime") == "truenas-system_uptime"
 
 
-def test_format_unique_id_with_reference_lowercases_only() -> None:
+def test_format_unique_id_preserves_reference_case() -> None:
+    """Only ``identity`` is lowercased -- the reference keeps its own case."""
     result = format_unique_id("TrueNAS", "disk_temp", "Disk One!")
-    assert result == "truenas-disk_temp-disk one!"
+    assert result == "truenas-disk_temp-Disk One!"
 
 
 def test_format_unique_id_distinguishes_slash_and_dash_variants() -> None:
     """Distinct dataset references must not collapse to the same unique id."""
     assert format_unique_id("TrueNAS", "dataset", "tank/a-b") != format_unique_id(
         "TrueNAS", "dataset", "tank/a_b"
+    )
+
+
+def test_format_unique_id_distinguishes_case_variants() -> None:
+    """Case-sensitive dataset references must not collapse to the same unique id."""
+    assert format_unique_id("TrueNAS", "dataset", "tank/Data") != format_unique_id(
+        "TrueNAS", "dataset", "tank/data"
     )
 
 
@@ -72,6 +81,13 @@ def test_legacy_format_unique_id_matches_pre_fix_slugify_behavior() -> None:
     assert (
         _legacy_format_unique_id("TrueNAS", "disk_temp", "Disk One!")
         == "truenas-disk_temp-disk_one"
+    )
+
+
+def test_lowercased_unique_id_matches_pre_case_fix_behavior() -> None:
+    assert (
+        _lowercased_unique_id("TrueNAS", "disk_temp", "Disk One!")
+        == "truenas-disk_temp-disk one!"
     )
 
 
@@ -93,6 +109,20 @@ def test_referenced_id_pairs_only_flags_lossy_references() -> None:
     assert old_new[
         _legacy_format_unique_id("TrueNAS", "disk_temp", "eth0")
     ] == _legacy_format_unique_id("TrueNAS", "disk_temp", "eth0")
+
+
+def test_referenced_id_pairs_accepts_alternate_legacy_formatter() -> None:
+    """A different ``legacy_formatter`` (e.g. the lowercase-only era) is honored."""
+    data = {"a": {"guid": "tank/Data"}}
+    pairs = _referenced_id_pairs(
+        "TrueNAS", _REF_DESC, data, legacy_formatter=_lowercased_unique_id
+    )
+    assert pairs == {
+        (
+            _lowercased_unique_id("TrueNAS", "disk_temp", "tank/Data"),
+            format_unique_id("TrueNAS", "disk_temp", "tank/Data"),
+        )
+    }
 
 
 def test_composite_id_pairs_covers_nested_network_references() -> None:

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -342,7 +342,7 @@ async def test_migrate_legacy_unique_ids_renames_lowercased_reference(
         domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
     )
     entry.add_to_hass(hass)
-    coordinator = SimpleNamespace(data={"tank/Data": {"id": "tank/Data"}})
+    coordinator = SimpleNamespace(data={"dataset": {"tank/Data": {"id": "tank/Data"}}})
 
     ent_reg = er.async_get(hass)
     entity = ent_reg.async_get_or_create(

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -35,9 +35,10 @@ from custom_components.truenas_ce.const import (
 from custom_components.truenas_ce.entity import (
     _cleanup_orphaned_entities,
     _legacy_format_unique_id,
+    _lowercased_unique_id,
     format_unique_id,
     migrate_entry_identity_namespace,
-    migrate_slugified_unique_ids,
+    migrate_legacy_unique_ids,
     resolve_entry_identity,
 )
 from custom_components.truenas_ce.sensor_types import (
@@ -139,7 +140,7 @@ async def test_migrate_entry_identity_namespace_skips_shared_device(
 
 
 # ---------------------------
-#   migrate_slugified_unique_ids
+#   migrate_legacy_unique_ids
 # ---------------------------
 _DATASET_DESC = TrueNASSensorEntityDescription(
     key="dataset_used",
@@ -150,7 +151,7 @@ _DATASET_DESC = TrueNASSensorEntityDescription(
 )
 
 
-async def test_migrate_slugified_unique_ids_renames_lossy_reference(
+async def test_migrate_legacy_unique_ids_renames_lossy_reference(
     hass: HomeAssistant,
 ) -> None:
     """A dataset unique_id built with the old slugify()-based format must be
@@ -172,7 +173,7 @@ async def test_migrate_slugified_unique_ids_renames_lossy_reference(
         config_entry=entry,
     )
 
-    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
 
     migrated = ent_reg.async_get(entity.entity_id)
     assert migrated is not None
@@ -181,7 +182,7 @@ async def test_migrate_slugified_unique_ids_renames_lossy_reference(
     )
 
 
-async def test_migrate_slugified_unique_ids_leaves_previous_collision_unrenamed(
+async def test_migrate_legacy_unique_ids_leaves_previous_collision_unrenamed(
     hass: HomeAssistant,
 ) -> None:
     """Two datasets that used to collide onto the same slugified unique_id
@@ -214,14 +215,14 @@ async def test_migrate_slugified_unique_ids_leaves_previous_collision_unrenamed(
         config_entry=entry,
     )
 
-    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
 
     migrated = ent_reg.async_get(entity.entity_id)
     assert migrated is not None
     assert migrated.unique_id == "system-guid-dataset_used-tank_a_b"
 
 
-async def test_migrate_slugified_unique_ids_leaves_partial_collision_unrenamed(
+async def test_migrate_legacy_unique_ids_leaves_partial_collision_unrenamed(
     hass: HomeAssistant,
 ) -> None:
     """A collision is still a collision when one of the two live references
@@ -252,14 +253,14 @@ async def test_migrate_slugified_unique_ids_leaves_partial_collision_unrenamed(
         config_entry=entry,
     )
 
-    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
 
     migrated = ent_reg.async_get(entity.entity_id)
     assert migrated is not None
     assert migrated.unique_id == "system-guid-dataset_used-tank_a_b"
 
 
-async def test_migrate_slugified_unique_ids_noop_for_unaffected_reference(
+async def test_migrate_legacy_unique_ids_noop_for_unaffected_reference(
     hass: HomeAssistant,
 ) -> None:
     """A reference unaffected by the fix (e.g. plain alnum) must not be touched."""
@@ -277,14 +278,14 @@ async def test_migrate_slugified_unique_ids_noop_for_unaffected_reference(
         config_entry=entry,
     )
 
-    migrate_slugified_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
 
     migrated = ent_reg.async_get(entity.entity_id)
     assert migrated is not None
     assert migrated.unique_id == format_unique_id("system-guid", "dataset_used", "tank")
 
 
-async def test_migrate_slugified_unique_ids_renames_composite_only_reference(
+async def test_migrate_legacy_unique_ids_renames_composite_only_reference(
     hass: HomeAssistant,
 ) -> None:
     """A composite-reference description without a plain ``data_reference``
@@ -320,12 +321,82 @@ async def test_migrate_slugified_unique_ids_renames_composite_only_reference(
         config_entry=entry,
     )
 
-    migrate_slugified_unique_ids(hass, entry, coordinator, [net_desc])
+    migrate_legacy_unique_ids(hass, entry, coordinator, [net_desc])
 
     migrated = ent_reg.async_get(entity.entity_id)
     assert migrated is not None
     assert migrated.unique_id == format_unique_id(
         "system-guid", "net_rx", "immich-server::eth0"
+    )
+
+
+async def test_migrate_legacy_unique_ids_renames_lowercased_reference(
+    hass: HomeAssistant,
+) -> None:
+    """A dataset unique_id built with the previous lowercased-only format
+    must be renamed in place to the case-preserving format -- otherwise the
+    entity_id, history and any automations referencing it would be silently
+    replaced by a new, differently-IDed entity on upgrade.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(data={"tank/Data": {"id": "tank/Data"}})
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        _lowercased_unique_id("system-guid", "dataset_used", "tank/Data"),
+        config_entry=entry,
+    )
+
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == format_unique_id(
+        "system-guid", "dataset_used", "tank/Data"
+    )
+
+
+async def test_migrate_legacy_unique_ids_leaves_case_collision_unrenamed(
+    hass: HomeAssistant,
+) -> None:
+    """Two datasets that used to collide onto the same lowercased unique_id
+    (only one of which could ever be registered) must NOT be guessed at --
+    left unrenamed instead, same as a slugify collision.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(
+        data={
+            "dataset": {
+                "tank/Data": {"id": "tank/Data"},
+                "tank/data": {"id": "tank/data"},
+            }
+        }
+    )
+
+    ent_reg = er.async_get(hass)
+    # Only "tank/Data" ever made it into the registry; "tank/data" was
+    # silently dropped as a duplicate under the old algorithm.
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        _lowercased_unique_id("system-guid", "dataset_used", "tank/Data"),
+        config_entry=entry,
+    )
+
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_DATASET_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == _lowercased_unique_id(
+        "system-guid", "dataset_used", "tank/Data"
     )
 
 


### PR DESCRIPTION
## Proposed change
`format_unique_id()` lowercased the entity reference (e.g. ZFS dataset paths) when building an entity's `unique_id`. This collapses case-distinct references such as `tank/Data` and `tank/data` into the same `unique_id`, causing one of the two entities to be silently dropped as a duplicate.

Reference case is now preserved (only `identity` stays lowercased). A new `_lowercased_unique_id()` legacy formatter reproduces the old (buggy) format for registry lookups, and `migrate_slugified_unique_ids()` is generalized to `migrate_legacy_unique_ids()`, which now iterates over both known legacy formats (the original pre-#107 slugify format and this lowercased format) when locating and renaming existing registry entries — reusing the existing collision-safe rename logic (an ambiguous/colliding legacy id is left unrenamed).

Verified end-to-end on a live production Home Assistant instance: a real dataset entity's `unique_id` was correctly migrated from `...-dataset-core/apps/codeserver` to `...-dataset-Core/Apps/CodeServer`, with `entity_id`, history, and attributes unchanged, and no duplicate/orphaned entities (47/47 dataset sensors, 232/232 total sensors matched baseline).

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Found via a Copilot review finding on the `home-assistant/core` Bronze-scope PR (#179103), which shares this codebase's `entity.py` origin. The identical issue exists here in the HACS-distributed integration and affects real installations, so it's fixed here first; a code-only mirror (no migration needed, no existing installations) will follow in the `ha-core` fork.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Preserve entity reference case in unique IDs and migrate existing registry entries from both lossy legacy formats without guessing through collisions.

Bug Fixes:
- Preserve case-sensitive entity references in generated unique IDs so distinct references no longer collapse into duplicate entities.

Enhancements:
- Generalize unique ID migration to recognize both historical slugified and lowercased formats while retaining collision-safe, in-place registry renames.

Tests:
- Add coverage for case-preserving unique IDs, legacy formatter support, migration of lowercased IDs, and safe handling of case collisions.