### PR TITLE
fix: hostname-free device identifier, uuids translation, connection-test and apiparser pruning

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -573,7 +573,6 @@ async def async_setup_entry(
     migrate_legacy_unique_ids(hass, config_entry, coordinator, _ALL_DESCRIPTIONS)
     migrate_legacy_device_identifier(
         hass,
-        config_entry,
         resolve_entry_identity(config_entry),
         coordinator.data["system_info"]["hostname"],
     )

--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -59,6 +59,7 @@ from .entity import (
     _is_uid_excluded,
     format_unique_id,
     migrate_entry_identity_namespace,
+    migrate_legacy_device_identifier,
     migrate_legacy_unique_ids,
     register_system_device,
     resolve_entry_identity,
@@ -570,6 +571,12 @@ async def async_setup_entry(
     config_entry.runtime_data = coordinator
     migrate_entry_identity_namespace(hass, config_entry)
     migrate_legacy_unique_ids(hass, config_entry, coordinator, _ALL_DESCRIPTIONS)
+    migrate_legacy_device_identifier(
+        hass,
+        config_entry,
+        resolve_entry_identity(config_entry),
+        coordinator.data["system_info"]["hostname"],
+    )
     coordinator.system_device_id = register_system_device(
         hass, config_entry, coordinator
     )

--- a/custom_components/truenas_ce/api.py
+++ b/custom_components/truenas_ce/api.py
@@ -251,7 +251,7 @@ class TrueNASAPI:
             return self.connected(), self._error
 
         result = await self.query("system.info")
-        if result is None:
+        if not isinstance(result, dict) or not result.get("hostname"):
             self._error = self._error or ERR_MALFORMED_RESULT
             return False, self._error
 

--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -179,7 +179,15 @@ def parse_api(
     only: list[dict[str, Any]] | None = None,
     skip: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Get data from API."""
+    """Get data from API.
+
+    For keyed/key_search'd data, a uid present in ``data`` from a previous
+    call but absent from this (non-empty) ``source`` is dropped: it means
+    the underlying object (disk, pool, task, app, interface, ...) no longer
+    exists, so keeping it would leave a stale entity behind indefinitely.
+    See ``_empty_source_result`` for the None-source (query failed) and
+    empty-list-source (nothing left at all) cases.
+    """
     if data is None:
         data = {}
     if isinstance(source, dict):
@@ -192,6 +200,7 @@ def parse_api(
         return _empty_source_result(data, key, key_search, vals, source is None)
 
     keymap = generate_keymap(data, key_search)
+    seen_uids: set[str] = set()
     for entry in source:
         if _should_skip_entry(entry, only, skip):
             continue
@@ -201,8 +210,14 @@ def parse_api(
         )
         if not matched:
             continue
+        if uid is not None:
+            seen_uids.add(uid)
 
         data = _apply_entry(data, entry, uid, vals, ensure_vals, val_proc)
+
+    if key or key_search:
+        for stale_uid in set(data) - seen_uids:
+            del data[stale_uid]
 
     return data
 

--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -178,6 +178,7 @@ def parse_api(
     ensure_vals: list[ApiValueSpec] | None = None,
     only: list[dict[str, Any]] | None = None,
     skip: list[dict[str, Any]] | None = None,
+    prune: bool = True,
 ) -> dict[str, Any]:
     """Get data from API.
 
@@ -187,6 +188,11 @@ def parse_api(
     exists, so keeping it would leave a stale entity behind indefinitely.
     See ``_empty_source_result`` for the None-source (query failed) and
     empty-list-source (nothing left at all) cases.
+
+    ``prune=False`` opts out of that dropping for callers that intentionally
+    pass a partial ``source`` covering only a subset of ``data`` (e.g. adding
+    a single extra record to an already-populated map) -- otherwise every
+    uid outside that subset would be misread as removed and deleted.
     """
     if data is None:
         data = {}
@@ -215,7 +221,7 @@ def parse_api(
 
         data = _apply_entry(data, entry, uid, vals, ensure_vals, val_proc)
 
-    if key or key_search:
+    if prune and (key or key_search):
         for stale_uid in set(data) - seen_uids:
             del data[stale_uid]
 

--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -221,11 +221,23 @@ def parse_api(
 
         data = _apply_entry(data, entry, uid, vals, ensure_vals, val_proc)
 
-    if prune and (key or key_search):
-        for stale_uid in set(data) - seen_uids:
-            del data[stale_uid]
+    if prune:
+        _prune_stale_uids(data, key, key_search, seen_uids)
 
     return data
+
+
+# ---------------------------
+#   _prune_stale_uids
+# ---------------------------
+def _prune_stale_uids(
+    data: dict[str, Any], key: str | None, key_search: str | None, seen_uids: set[str]
+) -> None:
+    """Drop keyed/key_search'd entries no longer present in the current source."""
+    if not (key or key_search):
+        return
+    for stale_uid in set(data) - seen_uids:
+        del data[stale_uid]
 
 
 # ---------------------------

--- a/custom_components/truenas_ce/button.py
+++ b/custom_components/truenas_ce/button.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -164,12 +164,10 @@ class TrueNASStatisticsCleanupButton(
     def __init__(self, coordinator: TrueNASCoordinator) -> None:
         """Initialize the cleanup button."""
         super().__init__(coordinator)
-        inst = coordinator.config_entry.data[CONF_NAME]
         identity = resolve_entry_identity(coordinator.config_entry)
         self._attr_unique_id = format_unique_id(identity, BUTTON_STATISTICS_CLEANUP)
-        hostname = coordinator.data.get("system_info", {}).get("hostname", inst)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_device_identifier(identity, hostname))},
+            identifiers={(DOMAIN, format_device_identifier(identity))},
         )
 
     @property
@@ -204,12 +202,10 @@ class TrueNASMigrationRollbackButton(
     def __init__(self, coordinator: TrueNASCoordinator) -> None:
         """Initialize the rollback button."""
         super().__init__(coordinator)
-        inst = coordinator.config_entry.data[CONF_NAME]
         identity = resolve_entry_identity(coordinator.config_entry)
         self._attr_unique_id = format_unique_id(identity, BUTTON_MIGRATION_ROLLBACK)
-        hostname = coordinator.data.get("system_info", {}).get("hostname", inst)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_device_identifier(identity, hostname))},
+            identifiers={(DOMAIN, format_device_identifier(identity))},
         )
 
     @property
@@ -241,12 +237,10 @@ class TrueNASRefreshButton(CoordinatorEntity[TrueNASCoordinator], ButtonEntity):
     def __init__(self, coordinator: TrueNASCoordinator) -> None:
         """Initialize the refresh button."""
         super().__init__(coordinator)
-        inst = coordinator.config_entry.data[CONF_NAME]
         identity = resolve_entry_identity(coordinator.config_entry)
         self._attr_unique_id = format_unique_id(identity, BUTTON_SYSTEM_REFRESH)
-        hostname = coordinator.data.get("system_info", {}).get("hostname", inst)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_device_identifier(identity, hostname))},
+            identifiers={(DOMAIN, format_device_identifier(identity))},
         )
 
     async def async_press(self) -> None:

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -1631,6 +1631,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             key="guid",
             vals=_POOL_VALS,
             ensure_vals=_POOL_ENSURE_VALS,
+            prune=False,
         )
         self._apply_pool_errors([raw_boot])
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -106,15 +106,53 @@ def _lowercased_unique_id(identity: str, key: str, reference: object = None) -> 
     return f"{base}-{str(reference).lower()}"
 
 
-def format_device_identifier(identity: str, hostname: str) -> str:
+def format_device_identifier(identity: str) -> str:
     """Build the main TrueNAS ("System") device identifier value.
 
     ``identity`` must be a stable per-entry identity (see
-    ``resolve_entry_identity``), not the user-editable display name.
-    Shared so other platforms (e.g. the diagnostic statistics-cleanup button)
-    associate with the existing device instead of duplicating the format.
+    ``resolve_entry_identity``), not the user-editable display name. Uses
+    ``identity`` alone -- an earlier format also appended the TrueNAS
+    hostname, but hostname is user-editable (System Settings > General)
+    while identity is already stable, so renaming the TrueNAS host silently
+    orphaned this device and created a duplicate. Shared so other platforms
+    (e.g. the diagnostic statistics-cleanup button) associate with the
+    existing device instead of duplicating the format. See
+    ``migrate_legacy_device_identifier`` for the one-time rename this
+    requires on existing installations.
+    """
+    return identity
+
+
+def _legacy_format_device_identifier(identity: str, hostname: str) -> str:
+    """Pre-2.9 device identifier format (``identity`` plus the TrueNAS hostname).
+
+    Only used by ``migrate_legacy_device_identifier`` to locate the registry
+    entry created under this old format; devices themselves use
+    ``format_device_identifier``.
     """
     return f"{identity}_{hostname}"
+
+
+def migrate_legacy_device_identifier(
+    hass: HomeAssistant, config_entry: ConfigEntry, identity: str, hostname: str
+) -> None:
+    """Rewrite the System device's registry identifier from the earlier format.
+
+    Must run before ``register_system_device`` so it finds the
+    already-renamed record instead of creating a second device. ``hostname``
+    is the *current* TrueNAS hostname: if it already changed on an existing
+    installation before this migration shipped, the old device under the
+    stale hostname is unrecoverable here (same tradeoff as
+    ``migrate_legacy_unique_ids`` -- nothing to guess from, so it is left
+    alone for the existing orphaned-device situation rather than misapplied).
+    """
+    legacy_identifier = _legacy_format_device_identifier(identity, hostname)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, legacy_identifier)})
+    if device is not None:
+        dev_reg.async_update_device(
+            device.id, new_identifiers={(DOMAIN, format_device_identifier(identity))}
+        )
 
 
 def migrate_entry_identity_namespace(
@@ -390,8 +428,8 @@ def register_system_device(
     """
     inst = coordinator.config_entry.data[CONF_NAME]
     identity = resolve_entry_identity(coordinator.config_entry)
+    identifier = format_device_identifier(identity)
     system_info = coordinator.data["system_info"]
-    identifier = format_device_identifier(identity, system_info["hostname"])
     http_scheme = "https" if coordinator.api.scheme == "wss" else "http"
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -876,9 +914,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         dev_connection_value = f"{self._identity}_{ha_group}"
         dev_group = ha_group
         if ha_group == "System":
-            dev_connection_value = format_device_identifier(
-                self._identity, self.coordinator.data["system_info"]["hostname"]
-            )
+            dev_connection_value = format_device_identifier(self._identity)
 
         if ha_group.startswith("data__"):
             dev_group = ha_group[6:]
@@ -930,9 +966,7 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         else:
             device_info["via_device"] = (
                 DOMAIN,
-                format_device_identifier(
-                    self._identity, self.coordinator.data["system_info"]["hostname"]
-                ),
+                format_device_identifier(self._identity),
             )
         return cast(DeviceInfo, device_info)
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -134,7 +134,7 @@ def _legacy_format_device_identifier(identity: str, hostname: str) -> str:
 
 
 def migrate_legacy_device_identifier(
-    hass: HomeAssistant, config_entry: ConfigEntry, identity: str, hostname: str
+    hass: HomeAssistant, identity: str, hostname: str
 ) -> None:
     """Rewrite the System device's registry identifier from the earlier format.
 

--- a/custom_components/truenas_ce/helper.py
+++ b/custom_components/truenas_ce/helper.py
@@ -18,6 +18,10 @@ _SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 # Everything from the first path/query/fragment delimiter is not part of host.
 _HOST_TAIL_RE = re.compile(r"[/?#]")
 
+# Attribute keys that must stay exactly as declared in strings.json's
+# state_attributes for translation lookup to match (see format_attribute).
+_UNFORMATTED_ATTRIBUTES = {"uuids"}
+
 
 # ---------------------------
 #   sanitize_host
@@ -88,7 +92,15 @@ def scaled_data_unit(value: object, binary: bool) -> tuple[str, int | None]:
 #   format_attribute
 # ---------------------------
 def format_attribute(attr: str) -> str:
-    """Format attribute."""
+    """Format attribute.
+
+    Left as-is when a translation is declared for it in strings.json's
+    ``state_attributes`` (currently only "uuids"): HA looks up that
+    translation by the literal attribute key, so humanizing it here would
+    make the lookup miss and silently fall back to the untranslated key.
+    """
+    if attr in _UNFORMATTED_ATTRIBUTES:
+        return attr
     attr = attr.replace("_", " ")
     attr = attr.replace("-", " ")
     attr = attr.capitalize()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -319,7 +319,7 @@ async def test_connection_test_connects_before_querying(api: TrueNASAPI) -> None
         api._client.connected = True
 
     api._client.connect.side_effect = _mark_connected
-    api._client.call.return_value = {"version": "25.04"}
+    api._client.call.return_value = {"version": "25.04", "hostname": "truenas.local"}
     ok, error = await api.connection_test()
     assert ok is True
     assert error == ""
@@ -328,10 +328,23 @@ async def test_connection_test_connects_before_querying(api: TrueNASAPI) -> None
 
 
 async def test_connection_test_succeeds(connected_api: TrueNASAPI) -> None:
-    connected_api._client.call.return_value = {"version": "25.04"}
+    connected_api._client.call.return_value = {
+        "version": "25.04",
+        "hostname": "truenas.local",
+    }
     ok, error = await connected_api.connection_test()
     assert ok is True
     assert error == ""
+
+
+async def test_connection_test_fails_when_hostname_missing(
+    connected_api: TrueNASAPI,
+) -> None:
+    """A truthy-but-malformed payload (e.g. ``{}``) must not pass as success."""
+    connected_api._client.call.return_value = {"version": "25.04"}
+    ok, error = await connected_api.connection_test()
+    assert ok is False
+    assert error == ERR_MALFORMED_RESULT
 
 
 # ---------------------------

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -275,6 +275,35 @@ def test_parse_api_empty_list_source_with_key_prunes_data(ap: ModuleType) -> Non
     assert ap.parse_api(data={"existing": {}}, source=[], key="id") == {}
 
 
+def test_parse_api_prunes_uid_missing_from_nonempty_source(ap: ModuleType) -> None:
+    """A previously-seen object (e.g. a physically removed disk) absent from an
+    otherwise successful, non-empty response must be dropped, not left behind
+    forever alongside the objects that are still present."""
+    data = {"1": {"name": "pool0"}, "2": {"name": "pool1"}}
+    source = [{"id": "2", "name": "pool1"}]
+    result = ap.parse_api(data=data, source=source, key="id", vals=[{"name": "name"}])
+    assert result == {"2": {"name": "pool1"}}
+
+
+def test_parse_api_prunes_uid_missing_from_key_search_source(ap: ModuleType) -> None:
+    data = {"uid-1": {"guid": "guid-1", "name": "old"}, "uid-2": {"guid": "guid-2"}}
+    source = [{"guid": "guid-1", "name": "new"}]
+    result = ap.parse_api(
+        data=data, source=source, key_search="guid", vals=[{"name": "name"}]
+    )
+    assert result == {"uid-1": {"guid": "guid-1", "name": "new"}}
+
+
+def test_parse_api_keyless_source_does_not_prune(ap: ModuleType) -> None:
+    """Keyless (single-object) data has no per-uid identity to prune by."""
+    result = ap.parse_api(
+        data={"total": 42, "stale": "kept"},
+        source=[{"total": 43}],
+        vals=[{"name": "total"}],
+    )
+    assert result == {"total": 43, "stale": "kept"}
+
+
 def test_parse_api_single_dict_source_is_wrapped(ap: ModuleType) -> None:
     result = ap.parse_api(
         source={"id": "1", "name": "pool0"},

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -294,6 +294,24 @@ def test_parse_api_prunes_uid_missing_from_key_search_source(ap: ModuleType) -> 
     assert result == {"uid-1": {"guid": "guid-1", "name": "new"}}
 
 
+def test_parse_api_prune_false_keeps_uids_absent_from_partial_source(
+    ap: ModuleType,
+) -> None:
+    """A caller merging one extra record into an already-populated map (e.g.
+    adding the boot-pool to the regular pools) must not have that unrelated
+    subset misread as "everything else was removed"."""
+    data = {"1": {"name": "pool0"}, "2": {"name": "pool1"}}
+    source = [{"id": "boot-pool", "name": "boot-pool"}]
+    result = ap.parse_api(
+        data=data, source=source, key="id", vals=[{"name": "name"}], prune=False
+    )
+    assert result == {
+        "1": {"name": "pool0"},
+        "2": {"name": "pool1"},
+        "boot-pool": {"name": "boot-pool"},
+    }
+
+
 def test_parse_api_keyless_source_does_not_prune(ap: ModuleType) -> None:
     """Keyless (single-object) data has no per-uid identity to prune by."""
     result = ap.parse_api(

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -71,7 +71,7 @@ def test_format_unique_id_distinguishes_case_variants() -> None:
 
 
 def test_format_device_identifier() -> None:
-    assert format_device_identifier("TrueNAS", "nas.local") == "TrueNAS_nas.local"
+    assert format_device_identifier("TrueNAS") == "TrueNAS"
 
 
 # ---------------------------
@@ -530,7 +530,7 @@ def test_device_info_non_system_group_falls_back_to_via_device() -> None:
     ):
         info = entity.device_info
     assert info["name"] == "TrueNAS Disks"
-    assert info["via_device"] == ("truenas_ce", "TrueNAS_truenas.local")
+    assert info["via_device"] == ("truenas_ce", "TrueNAS")
     assert "via_device_id" not in info
 
 

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -162,7 +162,7 @@ async def test_migrate_legacy_device_identifier_renames_existing_record(
         identifiers={(DOMAIN, "system-guid-123_truenas.local")},
     )
 
-    migrate_legacy_device_identifier(hass, entry, "system-guid-123", "truenas.local")
+    migrate_legacy_device_identifier(hass, "system-guid-123", "truenas.local")
 
     migrated_device = dev_reg.async_get(device.id)
     assert migrated_device is not None
@@ -186,7 +186,7 @@ async def test_migrate_legacy_device_identifier_noop_when_no_legacy_record(
         identifiers={(DOMAIN, "system-guid-123")},
     )
 
-    migrate_legacy_device_identifier(hass, entry, "system-guid-123", "truenas.local")
+    migrate_legacy_device_identifier(hass, "system-guid-123", "truenas.local")
 
     untouched_device = dev_reg.async_get(device.id)
     assert untouched_device is not None

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -38,6 +38,7 @@ from custom_components.truenas_ce.entity import (
     _lowercased_unique_id,
     format_unique_id,
     migrate_entry_identity_namespace,
+    migrate_legacy_device_identifier,
     migrate_legacy_unique_ids,
     resolve_entry_identity,
 )
@@ -137,6 +138,59 @@ async def test_migrate_entry_identity_namespace_skips_shared_device(
     untouched_device = dev_reg.async_get(shared_device.id)
     assert untouched_device is not None
     assert untouched_device.identifiers == {(DOMAIN, "TrueNAS_tank")}
+
+
+# ---------------------------
+#   migrate_legacy_device_identifier
+# ---------------------------
+async def test_migrate_legacy_device_identifier_renames_existing_record(
+    hass: HomeAssistant,
+) -> None:
+    """The System device's old ``identity_hostname`` identifier must be
+    renamed in place to the new hostname-free format -- otherwise every
+    existing installation would get a second, duplicate System device the
+    next time it starts, orphaning the original (area assignment, history).
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid-123"}
+    )
+    entry.add_to_hass(hass)
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "system-guid-123_truenas.local")},
+    )
+
+    migrate_legacy_device_identifier(hass, entry, "system-guid-123", "truenas.local")
+
+    migrated_device = dev_reg.async_get(device.id)
+    assert migrated_device is not None
+    assert migrated_device.identifiers == {(DOMAIN, "system-guid-123")}
+
+
+async def test_migrate_legacy_device_identifier_noop_when_no_legacy_record(
+    hass: HomeAssistant,
+) -> None:
+    """Nothing to rename when the System device already uses the current
+    (hostname-free) identifier, or doesn't exist yet -- must not raise or
+    create a device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid-123"}
+    )
+    entry.add_to_hass(hass)
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "system-guid-123")},
+    )
+
+    migrate_legacy_device_identifier(hass, entry, "system-guid-123", "truenas.local")
+
+    untouched_device = dev_reg.async_get(device.id)
+    assert untouched_device is not None
+    assert untouched_device.identifiers == {(DOMAIN, "system-guid-123")}
 
 
 # ---------------------------


### PR DESCRIPTION
## Proposed change

Addresses four Copilot findings against core PR #179103's review that were still open in this codebase (flagged in an earlier review round, on code that hadn't changed since):

- `entity.py`/`button.py`: `format_device_identifier()` dropped the appended TrueNAS hostname suffix. It was redundant with the already-stable `identity`, and meant renaming the TrueNAS host (System Settings > General) silently orphaned the System device and created a duplicate. Added `migrate_legacy_device_identifier()`, run once during `async_setup_entry` before `register_system_device`, to rename the existing device in place for current installations.
- `helper.py`: `format_attribute("uuids")` no longer gets humanized to `"Uuids"`, so the emitted state-attribute key matches `strings.json`'s `state_attributes.uuids` translation entry again (was previously a silent miss). Deliberately scoped to just `"uuids"` rather than dropping formatting globally, since strings.json only declares that one translation and switching every other attribute to raw snake_case keys would have degraded their display.
- `api.py`: `connection_test()` now rejects a truthy-but-malformed `system.info` result (e.g. `{}`) instead of only checking for `None` — previously such a result would let setup proceed and then fail on first refresh.
- `apiparser.py`: `parse_api()` now prunes a uid that was present in a previous poll but is missing from an otherwise successful, non-empty response (e.g. a physically removed disk). The existing `None`-vs-`[]` handling only covered a query failing outright or returning nothing at all, not a response that shrinks but stays non-empty.

## Type of change
- [x] Bugfix

## Additional information

Verified against the production Home Assistant instance via a local sync + restart before opening this PR: 14 `truenas_ce` devices with no duplicate System device (identifier migrated cleanly to the hostname-free format), disk/pool/alert sensors intact with valid values, the `uuids` state attribute now keyed correctly, and no `truenas_ce` errors in the log after restart.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix device identity migration, API response validation, attribute translation, and stale-record cleanup.

Bug Fixes:
- Use stable hostname-free device identifiers and migrate existing System devices to prevent duplicates and orphaned devices after hostname changes.
- Restore translation lookup for the `uuids` state attribute.
- Reject malformed connection-test responses that lack the required hostname.
- Remove stale keyed API records when successful non-empty responses no longer include them.

Enhancements:
- Support opting out of API record pruning for callers that process partial data.

Tests:
- Add coverage for device identifier migration, malformed connection responses, API record pruning, and partial-source handling.