### PR TITLE
fix: guard migration registry renames against stale duplicates

### DIFF
--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -133,6 +133,50 @@ def _legacy_format_device_identifier(identity: str, hostname: str) -> str:
     return f"{identity}_{hostname}"
 
 
+def _rename_device_identifiers(
+    dev_reg: dr.DeviceRegistry,
+    ent_reg: er.EntityRegistry,
+    device_entry: dr.DeviceEntry,
+    new_identifiers: set[tuple[str, str]],
+) -> None:
+    """Update a device's identifiers, resolving collisions from stale duplicates.
+
+    A duplicate device can exist when an older integration version
+    recreated it under an earlier identifier format (e.g. a
+    downgrade-then-upgrade cycle -- see ``migrate_entry_identity_namespace``
+    and ``migrate_legacy_device_identifier``). If the target identifiers are
+    already owned by a *different* device, that other device is the real
+    one: remove this duplicate if it is now empty, or leave it unmigrated
+    (better a stale leftover than a crashed config entry) when entities are
+    still attached, logging either outcome for follow-up.
+    """
+    colliding_device = dev_reg.async_get_device(identifiers=new_identifiers)
+    if colliding_device is None or colliding_device.id == device_entry.id:
+        dev_reg.async_update_device(device_entry.id, new_identifiers=new_identifiers)
+        return
+    remaining = er.async_entries_for_device(
+        ent_reg, device_entry.id, include_disabled_entities=True
+    )
+    if remaining:
+        _LOGGER.warning(
+            "CE migration: leaving duplicate device %s unmigrated (identifiers "
+            "%s already claimed by %s, still has %d entities attached)",
+            device_entry.id,
+            sorted(new_identifiers),
+            colliding_device.id,
+            len(remaining),
+        )
+        return
+    _LOGGER.warning(
+        "CE migration: removing duplicate device %s (identifiers %s already "
+        "claimed by %s)",
+        device_entry.id,
+        sorted(new_identifiers),
+        colliding_device.id,
+    )
+    dev_reg.async_remove_device(device_entry.id)
+
+
 def migrate_legacy_device_identifier(
     hass: HomeAssistant, identity: str, hostname: str
 ) -> None:
@@ -150,8 +194,9 @@ def migrate_legacy_device_identifier(
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_device(identifiers={(DOMAIN, legacy_identifier)})
     if device is not None:
-        dev_reg.async_update_device(
-            device.id, new_identifiers={(DOMAIN, format_device_identifier(identity))}
+        ent_reg = er.async_get(hass)
+        _rename_device_identifiers(
+            dev_reg, ent_reg, device, {(DOMAIN, format_device_identifier(identity))}
         )
 
 
@@ -181,12 +226,30 @@ def migrate_entry_identity_namespace(
     for entity_entry in er.async_entries_for_config_entry(
         ent_reg, config_entry.entry_id
     ):
-        if entity_entry.unique_id.startswith(old_uid_prefix):
-            ent_reg.async_update_entity(
+        if not entity_entry.unique_id.startswith(old_uid_prefix):
+            continue
+        new_unique_id = new_uid_prefix + entity_entry.unique_id[len(old_uid_prefix) :]
+        colliding_entity_id = ent_reg.async_get_entity_id(
+            entity_entry.domain, DOMAIN, new_unique_id
+        )
+        if colliding_entity_id not in (None, entity_entry.entity_id):
+            # A duplicate left behind by an older integration version (e.g. a
+            # downgrade-then-upgrade cycle where that version never learned
+            # the identity-based unique_id scheme and recreated this entity
+            # under the old name-based one). The real entity already owns
+            # the target unique_id, so this one is redundant -- drop it
+            # instead of letting async_update_entity raise ValueError and
+            # abort the whole config entry setup.
+            _LOGGER.warning(
+                "CE migration: removing duplicate entity %s (unique_id %s "
+                "already claimed by %s)",
                 entity_entry.entity_id,
-                new_unique_id=new_uid_prefix
-                + entity_entry.unique_id[len(old_uid_prefix) :],
+                new_unique_id,
+                colliding_entity_id,
             )
+            ent_reg.async_remove(entity_entry.entity_id)
+            continue
+        ent_reg.async_update_entity(entity_entry.entity_id, new_unique_id=new_unique_id)
 
     old_dev_prefix = f"{old_name}_"
     new_dev_prefix = f"{identity}_"
@@ -212,9 +275,7 @@ def migrate_entry_identity_namespace(
             for domain, value in device_entry.identifiers
         }
         if new_identifiers != device_entry.identifiers:
-            dev_reg.async_update_device(
-                device_entry.id, new_identifiers=new_identifiers
-            )
+            _rename_device_identifiers(dev_reg, ent_reg, device_entry, new_identifiers)
 
 
 _LegacyFormatter = Callable[[str, str, object], str]
@@ -393,8 +454,25 @@ def migrate_legacy_unique_ids(
         ent_reg, config_entry.entry_id
     ):
         new_id = renames.get(entity_entry.unique_id)
-        if new_id is not None:
-            ent_reg.async_update_entity(entity_entry.entity_id, new_unique_id=new_id)
+        if new_id is None:
+            continue
+        colliding_entity_id = ent_reg.async_get_entity_id(
+            entity_entry.domain, DOMAIN, new_id
+        )
+        if colliding_entity_id not in (None, entity_entry.entity_id):
+            # Same duplicate-from-an-older-version situation as
+            # migrate_entry_identity_namespace: the real entity already owns
+            # the target unique_id, so this one is redundant.
+            _LOGGER.warning(
+                "CE migration: removing duplicate entity %s (unique_id %s "
+                "already claimed by %s)",
+                entity_entry.entity_id,
+                new_id,
+                colliding_entity_id,
+            )
+            ent_reg.async_remove(entity_entry.entity_id)
+            continue
+        ent_reg.async_update_entity(entity_entry.entity_id, new_unique_id=new_id)
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -487,6 +487,8 @@ async def test_migrate_covers_every_reference_bearing_description_in_prod(
     # entity_id -> (old unique_id it was created with, new unique_id it must
     # carry after both migration passes)
     expected: dict[str, tuple[str, str]] = {}
+    scalar_count = 0
+    composite_count = 0
 
     for description in init_module._ALL_DESCRIPTIONS:
         if not description.data_path:
@@ -498,11 +500,13 @@ async def test_migrate_covers_every_reference_bearing_description_in_prod(
                 container_key: [{leaf_key: "Test-Ref"}]
             }
             reference: str = f"{uid}::Test-Ref"
+            composite_count += 1
         elif description.data_reference:
             reference = f"Test-Ref-{description.key}"
             data.setdefault(description.data_path, {})[uid] = {
                 description.data_reference: reference
             }
+            scalar_count += 1
         else:
             continue
 
@@ -513,9 +517,11 @@ async def test_migrate_covers_every_reference_bearing_description_in_prod(
         )
         expected[registry_entry.entity_id] = (old_uid, new_uid)
 
-    # Sanity check the fixture actually exercised a meaningful cross-section
-    # of the codebase (scalar *and* composite descriptions), not zero.
-    assert len(expected) > 10
+    # Sanity check the fixture actually exercised both reference categories,
+    # not just a nonzero total -- a fixed size threshold on the combined
+    # count would silently pass even if one category dropped to zero.
+    assert scalar_count > 0
+    assert composite_count > 0
 
     coordinator = SimpleNamespace(data=data)
     migrate_entry_identity_namespace(hass, entry)


### PR DESCRIPTION
## Proposed change
A downgrade-then-upgrade cycle (e.g. reinstalling 2.8.0, which predates the identity-based unique_id/device-identifier scheme from #107-#109, then upgrading back to master) lets the older version recreate entities/devices under the pre-2.9 name-based format. On the next upgrade, `migrate_entry_identity_namespace`, `migrate_legacy_unique_ids` and `migrate_legacy_device_identifier` all tried to rename those stale duplicates onto unique_ids/identifiers already owned by the real, already-migrated records, raising `ValueError`/`DeviceIdentifierCollisionError` and aborting the whole config entry setup.

Each rename now checks for a collision first: an empty duplicate is removed, one that still has entities attached is left unmigrated (logged for follow-up) instead of crashing setup. The two device-collision call sites share one `_rename_device_identifiers()` helper.

Also fixes the Sourcery nitpick left open on #110 (merged before it was addressed): the migration-coverage test's `len(expected) > 10` sanity check is replaced with separate nonzero assertions for scalar and composite reference counts, so it can't silently pass if one category drops to zero.

## Type of change
- [x] Bugfix
- [x] Code quality improvements to existing code or addition of tests

## Additional information
Verified live against a real dev instance rather than only via unit tests: downgraded to 2.8.0, synced master back, and iterated through each collision this surfaced (entity unique_id, device identifier, legacy device identifier) until setup completed cleanly with no orphaned statistics left behind (confirmed via the integration's own orphan-detection Repair + cleanup button).

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Make registry migrations resilient to stale duplicates created by downgrade-and-upgrade cycles.

Bug Fixes:
- Prevent migration failures when stale duplicate entities or devices already own the target unique IDs or identifiers.
- Remove empty duplicate devices and preserve devices with attached entities for follow-up instead of aborting config entry setup.

Enhancements:
- Consolidate device identifier collision handling across migrations and improve migration logging.

Tests:
- Strengthen migration coverage checks by independently requiring scalar and composite reference cases.