### PR TITLE
fix: default vm_stop to graceful ACPI shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ TrueNAS object they act on). Each action has a name and description in
 
 | Action | Target entity | What it does |
 | --- | --- | --- |
-| `vm_start` · `vm_stop` · `vm_restart` | VM binary sensor | Start / stop / restart a virtual machine (`vm_start` has an optional `overcommit` field) |
+| `vm_start` · `vm_stop` · `vm_restart` | VM binary sensor | Start / stop / restart a virtual machine (`vm_start` has an optional `overcommit` field; `vm_stop` has an optional `force` field, default `false` for a graceful ACPI shutdown) |
 | `container_start` · `container_stop` · `container_restart` | Container binary sensor | Start / stop / restart a container (Incus instance) |
 | `app_start` · `app_stop` | App binary sensor | Start / stop an app |
 | `service_start` · `service_stop` · `service_restart` · `service_reload` | Service binary sensor | Control a TrueNAS service |

--- a/custom_components/truenas_ce/binary_sensor.py
+++ b/custom_components/truenas_ce/binary_sensor.py
@@ -97,7 +97,7 @@ class TrueNASVMBinarySensor(TrueNASBinarySensor):
         )
         self._raise_if_api_error("start")
 
-    async def stop(self) -> None:
+    async def stop(self, force: bool = False) -> None:
         """Stop a VM."""
         tmp_vm = await self.coordinator.api.query("vm.get_instance", [self._data["id"]])
         self._raise_if_api_error("stop")
@@ -116,7 +116,7 @@ class TrueNASVMBinarySensor(TrueNASBinarySensor):
             return
 
         await self.coordinator.api.query(
-            "vm.stop", [self._data["id"], {"force": True, "force_after_timeout": True}]
+            "vm.stop", [self._data["id"], {"force": force, "force_after_timeout": True}]
         )
         self._raise_if_api_error("stop")
 

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -318,7 +318,10 @@ SCHEMA_SERVICE_VM_START = {
     vol.Optional(SERVICE_VM_START_OVERCOMMIT, default=False): cv.boolean
 }
 SERVICE_VM_STOP = "vm_stop"
-SCHEMA_SERVICE_VM_STOP: VolDictType = {}
+SERVICE_VM_STOP_FORCE = "force"
+SCHEMA_SERVICE_VM_STOP = {
+    vol.Optional(SERVICE_VM_STOP_FORCE, default=False): cv.boolean
+}
 SERVICE_VM_RESTART = "vm_restart"
 SCHEMA_SERVICE_VM_RESTART: VolDictType = {}
 

--- a/custom_components/truenas_ce/services.yaml
+++ b/custom_components/truenas_ce/services.yaml
@@ -135,6 +135,15 @@ vm_start:
 vm_stop:
   name: VM stop
   description: Stop a virtual machine (target the VM binary sensor).
+  fields:
+    force:
+      name: Force
+      description: >-
+        Force an immediate power-off instead of a graceful ACPI shutdown.
+      required: false
+      default: false
+      selector:
+        boolean:
   target:
     entity:
       integration: truenas_ce

--- a/custom_components/truenas_ce/strings.json
+++ b/custom_components/truenas_ce/strings.json
@@ -462,7 +462,13 @@
         },
         "vm_stop": {
             "name": "VM stop",
-            "description": "Stop a virtual machine (target the VM binary sensor)."
+            "description": "Stop a virtual machine (target the VM binary sensor).",
+            "fields": {
+                "force": {
+                    "name": "Force",
+                    "description": "Force an immediate power-off instead of a graceful ACPI shutdown."
+                }
+            }
         },
         "vm_restart": {
             "name": "VM restart",

--- a/custom_components/truenas_ce/translations/de.json
+++ b/custom_components/truenas_ce/translations/de.json
@@ -462,7 +462,13 @@
         },
         "vm_stop": {
             "name": "VM stoppen",
-            "description": "Stoppt eine virtuelle Maschine (VM-Binärsensor als Ziel)."
+            "description": "Stoppt eine virtuelle Maschine (VM-Binärsensor als Ziel).",
+            "fields": {
+                "force": {
+                    "name": "Erzwingen",
+                    "description": "Erzwingt ein sofortiges Ausschalten anstelle eines geordneten ACPI-Shutdowns."
+                }
+            }
         },
         "vm_restart": {
             "name": "VM neu starten",

--- a/custom_components/truenas_ce/translations/en.json
+++ b/custom_components/truenas_ce/translations/en.json
@@ -462,7 +462,13 @@
         },
         "vm_stop": {
             "name": "VM stop",
-            "description": "Stop a virtual machine (target the VM binary sensor)."
+            "description": "Stop a virtual machine (target the VM binary sensor).",
+            "fields": {
+                "force": {
+                    "name": "Force",
+                    "description": "Force an immediate power-off instead of a graceful ACPI shutdown."
+                }
+            }
         },
         "vm_restart": {
             "name": "VM restart",

--- a/custom_components/truenas_ce/translations/es.json
+++ b/custom_components/truenas_ce/translations/es.json
@@ -462,7 +462,13 @@
         },
         "vm_stop": {
             "name": "VM stop",
-            "description": "Stop a virtual machine (target the VM binary sensor)."
+            "description": "Stop a virtual machine (target the VM binary sensor).",
+            "fields": {
+                "force": {
+                    "name": "Force",
+                    "description": "Force an immediate power-off instead of a graceful ACPI shutdown."
+                }
+            }
         },
         "vm_restart": {
             "name": "VM restart",

--- a/custom_components/truenas_ce/translations/pt_BR.json
+++ b/custom_components/truenas_ce/translations/pt_BR.json
@@ -462,7 +462,13 @@
         },
         "vm_stop": {
             "name": "VM stop",
-            "description": "Stop a virtual machine (target the VM binary sensor)."
+            "description": "Stop a virtual machine (target the VM binary sensor).",
+            "fields": {
+                "force": {
+                    "name": "Force",
+                    "description": "Force an immediate power-off instead of a graceful ACPI shutdown."
+                }
+            }
         },
         "vm_restart": {
             "name": "VM restart",

--- a/custom_components/truenas_ce/translations/ru.json
+++ b/custom_components/truenas_ce/translations/ru.json
@@ -462,7 +462,13 @@
         },
         "vm_stop": {
             "name": "VM stop",
-            "description": "Stop a virtual machine (target the VM binary sensor)."
+            "description": "Stop a virtual machine (target the VM binary sensor).",
+            "fields": {
+                "force": {
+                    "name": "Force",
+                    "description": "Force an immediate power-off instead of a graceful ACPI shutdown."
+                }
+            }
         },
         "vm_restart": {
             "name": "VM restart",

--- a/custom_components/truenas_ce/translations/sk.json
+++ b/custom_components/truenas_ce/translations/sk.json
@@ -462,7 +462,13 @@
         },
         "vm_stop": {
             "name": "VM stop",
-            "description": "Stop a virtual machine (target the VM binary sensor)."
+            "description": "Stop a virtual machine (target the VM binary sensor).",
+            "fields": {
+                "force": {
+                    "name": "Force",
+                    "description": "Force an immediate power-off instead of a graceful ACPI shutdown."
+                }
+            }
         },
         "vm_restart": {
             "name": "VM restart",

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -98,6 +98,15 @@ async def test_vm_stop_success() -> None:
     vm.coordinator.api.query.side_effect = [{"status": {"state": "RUNNING"}}, None]
     await vm.stop()
     vm.coordinator.api.query.assert_awaited_with(
+        "vm.stop", [1, {"force": False, "force_after_timeout": True}]
+    )
+
+
+async def test_vm_stop_force() -> None:
+    vm = _make_vm({})
+    vm.coordinator.api.query.side_effect = [{"status": {"state": "RUNNING"}}, None]
+    await vm.stop(force=True)
+    vm.coordinator.api.query.assert_awaited_with(
         "vm.stop", [1, {"force": True, "force_after_timeout": True}]
     )
 


### PR DESCRIPTION
## Proposed change
`truenas_ce.vm_stop` always sent `force=True` to TrueNAS's `vm.stop` API, immediately powering off the VM instead of allowing a graceful ACPI shutdown like the TrueNAS UI's own "Stop" button does. This adds an optional `force` field (default `false`) to `vm_stop`, mirroring the existing `overcommit` field on `vm_start`. With the default, a VM now gets a graceful ACPI shutdown request; `force: true` keeps the previous immediate power-off behavior for anyone who relies on it.

Verified live: calling `vm_stop` without `force` against a running Windows Server VM resulted in a clean OS shutdown sequence instead of an abrupt power-off, with no errors in the Home Assistant logs.

Fixes #112

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Containers already default to a graceful stop (`CONTAINER_STOP_OPTIONS = {"force": False, "force_after_timeout": True}`), so this issue was VM-specific.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Default VM stop actions to graceful ACPI shutdowns while allowing users to request an immediate forced power-off.

Bug Fixes:
- Make VM stops graceful by default while preserving an opt-in forceful power-off mode.

Documentation:
- Document the optional `force` field for the `vm_stop` action and its graceful-shutdown default.

Tests:
- Add coverage for both graceful and forced VM stop behavior.