### PR TITLE
fix: key certificate entities by common name to survive rotation (#113)

### DIFF
--- a/custom_components/truenas_ce/binary_sensor_types.py
+++ b/custom_components/truenas_ce/binary_sensor_types.py
@@ -242,7 +242,8 @@ SENSOR_TYPES: tuple[TrueNASBinarySensorEntityDescription, ...] = (
         data_is_on="expired",
         data_name="name",
         data_uid=None,
-        data_reference="name",
+        data_reference="identity",
+        data_legacy_reference="name",
     ),
 )
 

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -170,23 +170,37 @@ _CERTIFICATE_VALS: list[ApiValueSpec] = [
 ]
 
 
-def _assign_certificate_identities(certificates: list[Any]) -> None:
+def _assign_certificate_identities(
+    certificates: list[Any], poisoned_commons: set[str]
+) -> None:
     """Set each raw certificate entry's ``_identity`` key in place.
 
-    Uses ``common`` when it is both non-empty and unique across this poll's
-    certificates, else falls back to the always-unique ``name`` -- see
+    Uses ``common`` when it is both non-empty and has never collided across
+    a poll, else falls back to the always-unique ``name`` -- see
     ``get_certificates`` for why a shared ``common`` cannot be used as-is.
+
+    A common shared by more than one certificate in this poll is added to
+    ``poisoned_commons`` (mutated in place) and stays poisoned on every
+    later poll, even once the collision disappears (e.g. one of the
+    certificates is deleted). Without that persistence, the surviving
+    certificate's identity would flip from ``name`` back to ``common`` as
+    soon as it becomes unique again, changing its unique_id and orphaning
+    its own recorder statistics -- the exact failure this migration exists
+    to prevent (Sourcery finding on an earlier version of this fix).
     """
     common_counts: dict[str, int] = {}
     for cert in certificates:
         if isinstance(cert, dict) and cert.get("common"):
             common_counts[cert["common"]] = common_counts.get(cert["common"], 0) + 1
+    poisoned_commons.update(
+        common for common, count in common_counts.items() if count > 1
+    )
     for cert in certificates:
         if not isinstance(cert, dict):
             continue
         common = cert.get("common")
         cert["_identity"] = (
-            common if common and common_counts.get(common) == 1 else cert.get("name")
+            common if common and common not in poisoned_commons else cert.get("name")
         )
 
 
@@ -532,6 +546,11 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._version_major: int = 0
         self._version_minor: int = 0
         self._unknown_system_stat_names: set[str] = set()
+
+        # Common names that have ever been shared by more than one certificate
+        # in a poll -- see ``_assign_certificate_identities`` for why this
+        # must persist across polls instead of being recomputed each time.
+        self._poisoned_certificate_commons: set[str] = set()
 
         # Orphaned recorder statistic_ids (no live entity) detected each poll.
         self.orphaned_statistics: list[str] = []
@@ -2599,7 +2618,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         certificates = await self.api.query("certificate.query")
         if isinstance(certificates, list):
-            _assign_certificate_identities(certificates)
+            _assign_certificate_identities(
+                certificates, self._poisoned_certificate_commons
+            )
         self.ds["certificate"] = parse_api(
             data={},
             source=certificates,

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -157,6 +157,7 @@ _JOB_STATUS_VALS: list[ApiValueSpec] = [
 _CERTIFICATE_VALS: list[ApiValueSpec] = [
     {"name": "id", "default": 0},
     {"name": "name", "default": "unknown"},
+    {"name": "identity", "source": "_identity", "default": "unknown"},
     {"name": "cert_type", "default": "unknown"},
     {"name": "common", "default": ""},
     {
@@ -2562,17 +2563,26 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def get_certificates(self) -> None:
         """Get TrueNAS certificates.
 
-        Keyed by ``name`` (DB-unique in TrueNAS) rather than the raw ``id``:
-        replacing a certificate's content (e.g. a manual renewal/reissue, as
-        opposed to TrueNAS's own in-place scheduled auto-renewal) deletes the
-        old database row and creates a new one with a fresh ``id`` but the
-        same ``name``, which otherwise made the sensor look orphaned (#61).
+        Keyed by ``identity`` -- the certificate's subject common name
+        (``common``), falling back to ``name`` when that is empty -- rather
+        than ``name`` itself. ``name`` is DB-unique in TrueNAS and stable
+        across TrueNAS's own in-place scheduled auto-renewal (#61), but tools
+        that rotate certificates via ``certificate.create`` (e.g. the
+        deploy-freenas ACME helper) mint a fresh, timestamped ``name`` on
+        every run, which still orphaned the sensor on every renewal (#113).
+        The common name identifies the underlying domain and stays stable
+        across such rotations.
         """
         certificates = await self.api.query("certificate.query")
+        if isinstance(certificates, list):
+            for cert in certificates:
+                if isinstance(cert, dict):
+                    common = cert.get("common")
+                    cert["_identity"] = common if common else cert.get("name")
         self.ds["certificate"] = parse_api(
             data={},
             source=certificates,
-            key="name",
+            key="_identity",
             vals=_CERTIFICATE_VALS,
         )
         now = dt_util.utcnow()

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -170,6 +170,26 @@ _CERTIFICATE_VALS: list[ApiValueSpec] = [
 ]
 
 
+def _assign_certificate_identities(certificates: list[Any]) -> None:
+    """Set each raw certificate entry's ``_identity`` key in place.
+
+    Uses ``common`` when it is both non-empty and unique across this poll's
+    certificates, else falls back to the always-unique ``name`` -- see
+    ``get_certificates`` for why a shared ``common`` cannot be used as-is.
+    """
+    common_counts: dict[str, int] = {}
+    for cert in certificates:
+        if isinstance(cert, dict) and cert.get("common"):
+            common_counts[cert["common"]] = common_counts.get(cert["common"], 0) + 1
+    for cert in certificates:
+        if not isinstance(cert, dict):
+            continue
+        common = cert.get("common")
+        cert["_identity"] = (
+            common if common and common_counts.get(common) == 1 else cert.get("name")
+        )
+
+
 # ---------------------------
 #   _stat_name_similar
 # ---------------------------
@@ -2564,21 +2584,22 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Get TrueNAS certificates.
 
         Keyed by ``identity`` -- the certificate's subject common name
-        (``common``), falling back to ``name`` when that is empty -- rather
-        than ``name`` itself. ``name`` is DB-unique in TrueNAS and stable
-        across TrueNAS's own in-place scheduled auto-renewal (#61), but tools
-        that rotate certificates via ``certificate.create`` (e.g. the
-        deploy-freenas ACME helper) mint a fresh, timestamped ``name`` on
-        every run, which still orphaned the sensor on every renewal (#113).
-        The common name identifies the underlying domain and stays stable
-        across such rotations.
+        (``common``), falling back to ``name`` when that is empty or shared
+        by more than one certificate in this poll -- rather than ``name``
+        itself. ``name`` is DB-unique in TrueNAS and stable across TrueNAS's
+        own in-place scheduled auto-renewal (#61), but tools that rotate
+        certificates via ``certificate.create`` (e.g. the deploy-freenas ACME
+        helper) mint a fresh, timestamped ``name`` on every run, which still
+        orphaned the sensor on every renewal (#113). The common name
+        identifies the underlying domain and stays stable across such
+        rotations -- unless it collides with another certificate's, in which
+        case keying by it would silently drop one of them (each new entry
+        overwriting the previous one under the same dict key), so those fall
+        back to the always-unique ``name`` instead.
         """
         certificates = await self.api.query("certificate.query")
         if isinstance(certificates, list):
-            for cert in certificates:
-                if isinstance(cert, dict):
-                    common = cert.get("common")
-                    cert["_identity"] = common if common else cert.get("name")
+            _assign_certificate_identities(certificates)
         self.ds["certificate"] = parse_api(
             data={},
             source=certificates,

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -414,12 +414,13 @@ _LEGACY_UNIQUE_ID_FORMATTERS: tuple[_LegacyFormatter, ...] = (
 )
 
 
-def _collect_unique_id_renames(
+def _collect_legacy_formatter_renames(
     identity: str,
     descriptions: Sequence[TrueNASEntityDescription],
     coordinator: TrueNASCoordinator,
-) -> dict[str, str]:
-    """Build the old-to-new unique_id rename map across all descriptions.
+    candidates: dict[str, set[str]],
+) -> None:
+    """Add rename candidates from every format in ``_LEGACY_UNIQUE_ID_FORMATTERS``.
 
     A composite-reference description (``data_composite_references`` set,
     see ``TrueNASEntityDescription.__post_init__``) is valid without a plain
@@ -427,16 +428,10 @@ def _collect_unique_id_renames(
     unset silently left its legacy entries (e.g. per-app network sensors)
     unmigrated (Sourcery finding on an earlier version of this migration).
 
-    Checked against every format in ``_LEGACY_UNIQUE_ID_FORMATTERS``, merged
-    into one candidate map so a legacy id ambiguous under one format still
-    correctly blocks renaming under another (see ``_merge_rename_candidates``).
-
-    A description also carrying ``data_legacy_reference`` additionally
-    contributes the (old-field, new-field) rename pair described in
-    ``_legacy_reference_id_pairs``, merged into the same candidate map so the
-    same collision-safety applies.
+    Merged into ``candidates`` in place so a legacy id ambiguous under one
+    format still correctly blocks renaming under another (see
+    ``_merge_rename_candidates``).
     """
-    candidates: dict[str, set[str]] = {}
     for legacy_formatter in _LEGACY_UNIQUE_ID_FORMATTERS:
         for description in descriptions:
             has_composite = bool(getattr(description, "data_composite_references", ()))
@@ -451,6 +446,20 @@ def _collect_unique_id_renames(
                 else _referenced_id_pairs(identity, description, data, legacy_formatter)
             )
             _merge_rename_candidates(pairs, candidates)
+
+
+def _collect_legacy_reference_renames(
+    identity: str,
+    descriptions: Sequence[TrueNASEntityDescription],
+    coordinator: TrueNASCoordinator,
+    candidates: dict[str, set[str]],
+) -> None:
+    """Add rename candidates for descriptions carrying ``data_legacy_reference``.
+
+    Contributes the (old-field, new-field) rename pair described in
+    ``_legacy_reference_id_pairs``, merged into ``candidates`` in place so the
+    same collision-safety as the legacy-formatter renames applies.
+    """
     for description in descriptions:
         if not getattr(description, "data_legacy_reference", None):
             continue
@@ -460,6 +469,24 @@ def _collect_unique_id_renames(
         _merge_rename_candidates(
             _legacy_reference_id_pairs(identity, description, data), candidates
         )
+
+
+def _collect_unique_id_renames(
+    identity: str,
+    descriptions: Sequence[TrueNASEntityDescription],
+    coordinator: TrueNASCoordinator,
+) -> dict[str, str]:
+    """Build the old-to-new unique_id rename map across all descriptions.
+
+    Combines two independent sources of rename candidates -- legacy
+    formatting changes (``_collect_legacy_formatter_renames``) and reference
+    field moves (``_collect_legacy_reference_renames``) -- into one candidate
+    map before resolving collisions, so an id ambiguous under either source
+    is left unrenamed.
+    """
+    candidates: dict[str, set[str]] = {}
+    _collect_legacy_formatter_renames(identity, descriptions, coordinator, candidates)
+    _collect_legacy_reference_renames(identity, descriptions, coordinator, candidates)
     return _resolve_renames(candidates)
 
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -303,6 +303,42 @@ def _referenced_id_pairs(
     return pairs
 
 
+def _legacy_reference_id_pairs(
+    identity: str,
+    description: TrueNASEntityDescription,
+    data: Mapping[str, Any],
+) -> set[tuple[str, str]]:
+    """Return (old, new) unique_id pairs for a description whose reference field moved.
+
+    Unlike ``_referenced_id_pairs``, both sides run through the *current*
+    ``format_unique_id`` -- only the underlying field differs
+    (``data_legacy_reference`` vs ``data_reference``), not the value
+    formatting the legacy formatters guard against. Used e.g. by the
+    certificate descriptions after #113, which moved from keying on the
+    volatile ``name`` field to the stable ``identity`` (common name) field.
+    """
+    pairs: set[tuple[str, str]] = set()
+    legacy_field = description.data_legacy_reference
+    if not legacy_field:
+        return pairs
+    for uid, vals in data.items():
+        if not isinstance(vals, dict):
+            continue
+        old_ref = vals.get(legacy_field)
+        new_ref = vals.get(description.data_reference)
+        pairs.add(
+            (
+                format_unique_id(
+                    identity, description.key, old_ref if old_ref is not None else uid
+                ),
+                format_unique_id(
+                    identity, description.key, new_ref if new_ref is not None else uid
+                ),
+            )
+        )
+    return pairs
+
+
 def _composite_id_pairs(
     identity: str,
     description: TrueNASEntityDescription,
@@ -394,6 +430,11 @@ def _collect_unique_id_renames(
     Checked against every format in ``_LEGACY_UNIQUE_ID_FORMATTERS``, merged
     into one candidate map so a legacy id ambiguous under one format still
     correctly blocks renaming under another (see ``_merge_rename_candidates``).
+
+    A description also carrying ``data_legacy_reference`` additionally
+    contributes the (old-field, new-field) rename pair described in
+    ``_legacy_reference_id_pairs``, merged into the same candidate map so the
+    same collision-safety applies.
     """
     candidates: dict[str, set[str]] = {}
     for legacy_formatter in _LEGACY_UNIQUE_ID_FORMATTERS:
@@ -410,6 +451,15 @@ def _collect_unique_id_renames(
                 else _referenced_id_pairs(identity, description, data, legacy_formatter)
             )
             _merge_rename_candidates(pairs, candidates)
+    for description in descriptions:
+        if not getattr(description, "data_legacy_reference", None):
+            continue
+        data = coordinator.data.get(description.data_path or "")
+        if not isinstance(data, dict):
+            continue
+        _merge_rename_candidates(
+            _legacy_reference_id_pairs(identity, description, data), candidates
+        )
     return _resolve_renames(candidates)
 
 
@@ -544,6 +594,7 @@ class TrueNASEntityDescription(EntityDescription):
     data_name: str | None = None
     data_uid: str | None = None
     data_reference: str | None = None
+    data_legacy_reference: str | None = None
     data_attributes_list: tuple[str, ...] = ()
     data_dynamic_keys: bool = False
     data_composite_references: tuple[str, ...] = ()

--- a/custom_components/truenas_ce/sensor_types.py
+++ b/custom_components/truenas_ce/sensor_types.py
@@ -790,7 +790,8 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         data_attribute="days_until_expiry",
         data_name="name",
         data_uid=None,
-        data_reference="name",
+        data_reference="identity",
+        data_legacy_reference="name",
         func="TrueNASCertExpirySensor",
     ),
     TrueNASSensorEntityDescription(
@@ -805,7 +806,8 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         data_attribute="until",
         data_name="name",
         data_uid=None,
-        data_reference="name",
+        data_reference="identity",
+        data_legacy_reference="name",
     ),
     TrueNASSensorEntityDescription(
         key="arc_data_hit_percent",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3905,6 +3905,26 @@ async def test_get_certificates_falls_back_to_name_when_common_empty() -> None:
     assert "cert1" in coord.ds["certificate"]
 
 
+async def test_get_certificates_falls_back_to_name_on_shared_common() -> None:
+    """Two certificates sharing a common name must not collapse into one.
+
+    Keying both by the shared ``common`` would make the second entry
+    overwrite the first under the same dict key, silently dropping one
+    certificate's sensors -- see ``_assign_certificate_identities``.
+    """
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"id": 1, "name": "cert-a", "common": "shared.example.com"},
+            {"id": 2, "name": "cert-b", "common": "shared.example.com"},
+        ]
+    )
+    await coord.get_certificates()
+    assert set(coord.ds["certificate"].keys()) == {"cert-a", "cert-b"}
+
+
 async def test_get_certificates_survives_name_rotation_with_stable_common() -> None:
     """A rotating ACME-style tool renaming the cert on every renewal (#113).
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3877,6 +3877,72 @@ async def test_get_certificates_none_expiry_when_until_missing() -> None:
     assert coord.ds["certificate"]["cert1"]["days_until_expiry"] is None
 
 
+async def test_get_certificates_keyed_by_common_name_when_present() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "letsencrypt-2026-08-27-172301",
+                "common": "nas.example.com",
+            }
+        ]
+    )
+    await coord.get_certificates()
+    assert "nas.example.com" in coord.ds["certificate"]
+    assert coord.ds["certificate"]["nas.example.com"]["name"] == (
+        "letsencrypt-2026-08-27-172301"
+    )
+
+
+async def test_get_certificates_falls_back_to_name_when_common_empty() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(return_value=[{"id": 1, "name": "cert1", "common": ""}])
+    await coord.get_certificates()
+    assert "cert1" in coord.ds["certificate"]
+
+
+async def test_get_certificates_survives_name_rotation_with_stable_common() -> None:
+    """A rotating ACME-style tool renaming the cert on every renewal (#113).
+
+    Keeping ``common`` stable across polls must keep the same dict key/entity
+    (rather than orphaning the previous name-keyed entry), even though the
+    underlying ``id``/``name`` change on every run.
+    """
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "letsencrypt-2026-08-27-090000",
+                "common": "nas.example.com",
+            }
+        ]
+    )
+    await coord.get_certificates()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {
+                "id": 2,
+                "name": "letsencrypt-2026-11-27-090000",
+                "common": "nas.example.com",
+            }
+        ]
+    )
+    await coord.get_certificates()
+    assert list(coord.ds["certificate"].keys()) == ["nas.example.com"]
+    assert coord.ds["certificate"]["nas.example.com"]["name"] == (
+        "letsencrypt-2026-11-27-090000"
+    )
+    assert coord.ds["certificate"]["nas.example.com"]["id"] == 2
+
+
 # ---------------------------
 #   get_arc
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3891,10 +3891,9 @@ async def test_get_certificates_keyed_by_common_name_when_present() -> None:
         ]
     )
     await coord.get_certificates()
-    assert "nas.example.com" in coord.ds["certificate"]
-    assert coord.ds["certificate"]["nas.example.com"]["name"] == (
-        "letsencrypt-2026-08-27-172301"
-    )
+    cert = coord.ds["certificate"].get("nas.example.com")
+    assert cert is not None
+    assert cert["name"] == "letsencrypt-2026-08-27-172301"
 
 
 async def test_get_certificates_falls_back_to_name_when_common_empty() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -86,6 +86,7 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord.host = "truenas.local"
     coord._version_major = 0
     coord._version_minor = 0
+    coord._poisoned_certificate_commons = set()
     return coord
 
 
@@ -3923,6 +3924,37 @@ async def test_get_certificates_falls_back_to_name_on_shared_common() -> None:
     )
     await coord.get_certificates()
     assert set(coord.ds["certificate"].keys()) == {"cert-a", "cert-b"}
+
+
+async def test_get_certificates_keeps_name_fallback_once_common_has_collided() -> None:
+    """A common name that collided once must not flip back to identity later.
+
+    If cert-b (sharing cert-a's common) disappears on the next poll, cert-a's
+    common becomes unique again. Without persisting the collision, cert-a's
+    identity would flip from ``name`` back to ``common``, changing its dict
+    key/unique_id and orphaning its own recorder statistics -- the exact
+    failure this migration exists to prevent (Sourcery finding on an earlier
+    version of ``_assign_certificate_identities``).
+    """
+    coord = _bare_coordinator()
+    coord.ds = {}
+    coord.api = MagicMock()
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"id": 1, "name": "cert-a", "common": "shared.example.com"},
+            {"id": 2, "name": "cert-b", "common": "shared.example.com"},
+        ]
+    )
+    await coord.get_certificates()
+    assert set(coord.ds["certificate"].keys()) == {"cert-a", "cert-b"}
+
+    coord.api.query = AsyncMock(
+        return_value=[
+            {"id": 1, "name": "cert-a", "common": "shared.example.com"},
+        ]
+    )
+    await coord.get_certificates()
+    assert set(coord.ds["certificate"].keys()) == {"cert-a"}
 
 
 async def test_get_certificates_survives_name_rotation_with_stable_common() -> None:

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -454,6 +454,101 @@ async def test_migrate_legacy_unique_ids_leaves_case_collision_unrenamed(
     )
 
 
+_CERT_DESC = TrueNASSensorEntityDescription(
+    key="certificate_expiry",
+    name="Certificate expiry",
+    data_path="certificate",
+    data_reference="identity",
+    data_legacy_reference="name",
+    func="TrueNASEntity",
+)
+
+
+async def test_migrate_legacy_unique_ids_renames_moved_reference_field(
+    hass: HomeAssistant,
+) -> None:
+    """A description whose reference field moved (#113: certificates keyed by
+    ``name`` moved to the stable ``identity``/common-name field) must rename
+    the registry entry built from the old field to the new field's value --
+    otherwise every certificate rotated by an external ACME tool would keep
+    orphaning its sensor on every renewal, even after the fix ships.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(
+        data={
+            "certificate": {
+                "nas.example.com": {
+                    "name": "letsencrypt-2026-11-27-090000",
+                    "identity": "nas.example.com",
+                }
+            }
+        }
+    )
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        format_unique_id(
+            "system-guid", "certificate_expiry", "letsencrypt-2026-08-27-090000"
+        ),
+        config_entry=entry,
+    )
+
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_CERT_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == format_unique_id(
+        "system-guid", "certificate_expiry", "nas.example.com"
+    )
+
+
+async def test_migrate_legacy_unique_ids_leaves_moved_reference_collision_unrenamed(
+    hass: HomeAssistant,
+) -> None:
+    """Two certificates whose *old* name happens to equal another's must not
+    be guessed at -- same collision-safety as the lossy-reference migration.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = SimpleNamespace(
+        data={
+            "certificate": {
+                "nas.example.com": {
+                    "name": "shared-name",
+                    "identity": "nas.example.com",
+                },
+                "other.example.com": {
+                    "name": "shared-name",
+                    "identity": "other.example.com",
+                },
+            }
+        }
+    )
+
+    ent_reg = er.async_get(hass)
+    entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        format_unique_id("system-guid", "certificate_expiry", "shared-name"),
+        config_entry=entry,
+    )
+
+    migrate_legacy_unique_ids(hass, entry, coordinator, [_CERT_DESC])
+
+    migrated = ent_reg.async_get(entity.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == format_unique_id(
+        "system-guid", "certificate_expiry", "shared-name"
+    )
+
+
 async def test_migrate_covers_every_reference_bearing_description_in_prod(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -477,11 +477,17 @@ async def test_migrate_legacy_unique_ids_renames_moved_reference_field(
         domain=DOMAIN, data={CONF_NAME: "TrueNAS", CONF_SYSTEM_ID: "system-guid"}
     )
     entry.add_to_hass(hass)
+    # The current poll's "name" must match what the not-yet-migrated live
+    # entity's unique_id was built from -- migration runs right after
+    # upgrading, using the current data, so it can only reverse-map a
+    # reference that is still present in this same poll (see the
+    # module docstring on ``migrate_legacy_unique_ids`` for the equivalent
+    # tradeoff on a reference that already vanished before the upgrade).
     coordinator = SimpleNamespace(
         data={
             "certificate": {
                 "nas.example.com": {
-                    "name": "letsencrypt-2026-11-27-090000",
+                    "name": "letsencrypt-2026-08-27-090000",
                     "identity": "nas.example.com",
                 }
             }


### PR DESCRIPTION
## Proposed change

Certificates were keyed by `name` (fixed in #63/#61), which stays stable across TrueNAS's own in-place scheduled auto-renewal but not across external tools that rotate certificates via `certificate.create` with a fresh, timestamped `name` on every run (e.g. the [deploy-freenas](https://github.com/danb35/deploy-freenas) ACME helper referenced in #113) -- every renewal still orphaned the certificate sensors' recorder statistics.

This keys certificates by the certificate's subject common name (`common`) instead, falling back to `name` when `common` is empty. The common name identifies the underlying domain and stays stable across such rotations, so the same entity keeps updating instead of a new one being created on every renewal.

Existing installations are migrated in place: `TrueNASEntityDescription` gains a new `data_legacy_reference` field, generalizing the unique_id migration registry (introduced in #107-#110) to also cover a reference *field* move -- not just a formatting change -- so upgrading users don't see a fresh orphaned-statistics prompt for their certificates.

Fixes #113.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

- `coordinator.py::get_certificates` now computes a per-entry `_identity` (common name, falling back to name) before handing the list to `parse_api`, which uses it as the dict key.
- `entity.py` adds `_legacy_reference_id_pairs` + wiring into `_collect_unique_id_renames`, reusing the existing collision-safety (`_merge_rename_candidates`/`_resolve_renames`) so an ambiguous old id is left unrenamed rather than guessed at.
- The three certificate entity descriptions (`certificate_expiry`, `certificate_expiration_time`, `certificate_expired`) now set `data_reference="identity"` + `data_legacy_reference="name"`.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Preserve certificate entity identities and recorder statistics across certificate renewals and rotations.

Bug Fixes:
- Keep certificate entities stable across external certificate rotations by keying them by subject common name when available, while safely falling back to unique certificate names for empty or conflicting common names.

Enhancements:
- Add in-place unique ID migration for certificate entities whose reference field changes from certificate name to stable identity.
- Preserve name-based fallbacks after common-name collisions to prevent identity changes and recorder-statistics orphaning.

Tests:
- Add coverage for common-name identity selection, fallback behavior, collision persistence, certificate name rotation, and unique ID migration safety.