### PR TITLE
docs: populate Unreleased changelog for the 2.8.0->2.9.0 diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,35 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+### Fixed
+- **Entity identity, unique IDs and device identifiers reworked to prevent silent
+  collisions:** two TrueNAS servers sharing the same display name, or two dataset/app
+  references differing only in case or `-`/`_` (e.g. `tank/Data` vs `tank/data`),
+  previously collided onto the same `unique_id` and silently dropped one entity.
+  Renaming your TrueNAS host also used to orphan the System device. All of this is now
+  keyed off a stable identity instead of the editable name/hostname, and every existing
+  entity/device is **renamed in place on upgrade** (not recreated), so `entity_id`s,
+  history and long-term statistics are preserved — a dedicated test proves the
+  2.8.0 → 2.9.0 upgrade path orphans nothing. If you still see an "orphaned statistics"
+  Repairs card after upgrading, please open an issue. (#103, #107, #108, #109, #110, #111)
+- **VM stop now defaults to a graceful ACPI shutdown** instead of an immediate force
+  power-off, matching the TrueNAS UI's own "Stop" button; opt back into the old behavior
+  with the new `force` field on `vm_stop`. Thanks @Chouffy for reporting! (#112, #114)
+- **Certificates now keyed by common name, surviving external rotation tools** (e.g. ACME
+  renewal scripts) that mint a fresh internal `name` on every run — no more orphaned-
+  statistics prompts on every renewal. Thanks @janusn for reporting! (#113, #115)
+- **Query errors no longer masked as empty/zero state:** a transient API error now
+  preserves the last known good data instead of wiping it. (#106)
+- **Legacy config secrets redacted in migration backup snapshots.** (#104)
+
+### Changed
+- **Coordinator delegates normalization to `aiotruenas`'s new `TrueNASState` domain
+  layer** for 19 endpoints instead of doing it inline — no user-facing behavior change.
+  (#116)
+
+### Notes
+- Bumps `aiotruenas` to `>=1.4.0` (required for the `TrueNASState` domain layer).
+
 ## [2.8.0] — Live Push Updates & Migration/Security Hardening
 
 ### Added


### PR DESCRIPTION
## Proposed change

Populates CHANGELOG.md's empty `[Unreleased]` section with the full diff since
v2.8.0 (#103-#116), currently out as prerelease v2.9.0-rc1.

Gives the entity-identity/unique-id rework (#103, #107, #108, #109, #110, #111)
prominent, explicit coverage: it changes how existing entities are keyed on
upgrade, and while the migration renames in place (transparent, no orphaned
statistics per #110's dedicated test), that's exactly the kind of change that
deserves an explicit heads-up rather than a one-line summary.

## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information

Matches the v2.9.0-rc1 GitHub release notes (already updated with the same
entity-ID callout under Requirements & Notes).

## Checklist

- [x] The code change is tested and works locally.
- [ ] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

## Summary by Sourcery

Populate the Unreleased changelog with the v2.9.0 changes, including entity identity migration and upgrade-impact notes.

Bug Fixes:
- Document fixes for entity and device identity collisions, preserving existing entity IDs, history, and long-term statistics during upgrades.
- Document graceful VM shutdown as the new default, configurable force shutdown behavior, resilient certificate identity across rotations, preservation of last-known-good state after query errors, and redaction of legacy secrets in migration backups.

Enhancements:
- Document the coordinator's migration to the aiotruenas TrueNASState domain layer.

Documentation:
- Populate the Unreleased changelog with the changes and upgrade notes for the v2.8.0-to-v2.9.0 release range.

Chores:
- Record the aiotruenas >=1.4.0 dependency requirement.