### PR TITLE
fix: bracket IPv6 hosts, parallelize stat-graph fetches, fix stale default keys

### DIFF
--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -573,7 +573,7 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
         ``_async_apply_user_input``) can establish the box's real identity
         and fold a rediscovered host into an existing entry.
         """
-        host = discovery_info.host
+        host = sanitize_host(discovery_info.host)
         self._async_abort_entries_match({CONF_HOST: host})
         await self.async_set_unique_id(host)
         self._abort_if_unique_id_configured()

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -1044,16 +1044,18 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _fetch_stat_graphs(
         self, graph_names: list[str], graph_query: dict[str, Any]
     ) -> list[Any]:
-        """Query each stat graph, returning combined data and tracking failures."""
+        """Query each stat graph concurrently; return combined data, track failures."""
         reporting_path = _NETDATA_GRAPH
+        results = await asyncio.gather(
+            *(
+                self.api.query(reporting_path, params=[graph_name, graph_query])
+                for graph_name in graph_names
+            )
+        )
+
         tmp_graph: list[Any] = []
         failed_graphs: list[str] = []
-
-        for graph_name in graph_names:
-            graph_data = await self.api.query(
-                reporting_path,
-                params=[graph_name, graph_query],
-            )
+        for graph_name, graph_data in zip(graph_names, results, strict=True):
             if isinstance(graph_data, list):
                 tmp_graph.extend(graph_data)
             else:
@@ -1235,12 +1237,8 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _store_stat_defaults(self, t: str, arr: tuple[str, ...]) -> None:
         """Store zeroed defaults when a statistic graph has no aggregations."""
-        info = self.ds["system_info"]
-        for tmp_load in arr:
-            if t == "cpu":
-                info[f"cpu_{tmp_load}"] = 0.0
-            else:
-                info[tmp_load] = 0.0
+        for tmp_var in arr:
+            self._store_stat_value(t, tmp_var, 0.0)
 
     # ---------------------------
     #   get_service

--- a/custom_components/truenas_ce/helper.py
+++ b/custom_components/truenas_ce/helper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from typing import TYPE_CHECKING
 
@@ -39,11 +40,24 @@ def sanitize_host(host: str) -> str:
 
     Lives here (rather than in ``config_flow``) so both ``config_flow`` and
     ``migration`` can depend on it without either importing the other.
+
+    A bare IPv6 literal is bracketed (e.g. "::1" -> "[::1]") so it combines
+    unambiguously with a scheme/port into a valid WebSocket URL.
     """
     host = host.strip()
     host = _SCHEME_RE.sub("", host)  # drop a leading scheme
     host = _HOST_TAIL_RE.split(host, maxsplit=1)[0]  # drop path/query/fragment
-    return host.strip().lower()
+    host = host.strip().lower()
+    return _bracket_ipv6(host)
+
+
+def _bracket_ipv6(host: str) -> str:
+    """Bracket ``host`` if it is a bare (unbracketed) IPv6 literal."""
+    try:
+        ipaddress.IPv6Address(host)
+    except ValueError:
+        return host
+    return f"[{host}]"
 
 
 # Data-size display tiers as (threshold_in_bytes, unit, precision). The first

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -283,6 +283,28 @@ async def test_zeroconf_flow_confirms_and_creates_entry(hass: HomeAssistant) -> 
     assert result["data"][CONF_HOST] == "192.168.1.50"
 
 
+async def test_zeroconf_flow_brackets_ipv6_host(hass: HomeAssistant) -> None:
+    """A bare IPv6 discovery address is bracketed before being probed.
+
+    Regression test: ``ZeroconfServiceInfo.host`` is the raw, unbracketed
+    IPv6 literal; passing it straight through would build a malformed
+    WebSocket URL (see ``helper.sanitize_host``).
+    """
+    with patch.object(
+        config_flow.TrueNASConfigFlow,
+        "_probe_is_truenas",
+        AsyncMock(return_value="[2001:db8::1]"),
+    ) as mock_probe:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info("2001:db8::1"),
+        )
+    assert mock_probe.call_args.args[0] == "[2001:db8::1]"
+    assert result["type"] is FlowResultType.FORM
+    assert result["description_placeholders"] == {CONF_HOST: "[2001:db8::1]"}
+
+
 async def test_zeroconf_flow_keeps_advertised_port(hass: HomeAssistant) -> None:
     """A box found only on its advertised port is configured with that port."""
     with patch.object(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -350,6 +350,21 @@ def test_systemstats_process_falls_back_to_defaults_without_aggregations() -> No
     assert coord.ds["system_info"]["cpu_cpu"] == pytest.approx(0.0)
 
 
+def test_systemstats_process_defaults_use_dedicated_keys() -> None:
+    """Defaults for a malformed graph land under the same key as a real value.
+
+    Regression test for a bug where defaults bypassed the type-specific key
+    mapping in _store_stat_value and were written under the bare var name
+    instead, leaving the actually-exposed sensor keys stale.
+    """
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}}
+    coord._systemstats_process("size", {}, "arcsize")
+    assert coord.ds["system_info"]["cache_size-arc_value"] == 0.0
+    coord._systemstats_process("available", {}, "memory")
+    assert coord.ds["system_info"]["memory-free_value"] == 0
+
+
 def test_systemstats_process_skips_legend_var_not_in_arr() -> None:
     coord = _bare_coordinator()
     coord.ds = {"system_info": {}}
@@ -2085,9 +2100,9 @@ def test_process_system_stat_dispatches_by_name() -> None:
     coord.ds = {"system_info": {}, "interface": {}}
     # Missing "aggregations"/"legend" fails the isinstance guard in
     # _systemstats_process, so it falls back to _store_stat_defaults, which
-    # (for t != "cpu") stores the bare arr name, not a "load_"-prefixed one.
+    # routes through _store_stat_value the same as a successful value would.
     coord._process_system_stat({"name": "load"})
-    assert coord.ds["system_info"]["shortterm"] == 0.0
+    assert coord.ds["system_info"]["load_shortterm"] == 0.0
 
 
 def test_process_system_stat_ignores_missing_name() -> None:
@@ -2275,7 +2290,7 @@ async def test_get_systemstats_processes_returned_graphs() -> None:
     coord.api = MagicMock()
     coord.api.query = AsyncMock(return_value=[{"name": "load"}])
     await coord.get_systemstats()
-    assert coord.ds["system_info"]["shortterm"] == 0.0
+    assert coord.ds["system_info"]["load_shortterm"] == 0.0
 
 
 # ---------------------------

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -26,6 +26,11 @@ from custom_components.truenas_ce.helper import sanitize_host
         ("https://nas.example.com:8443/", "nas.example.com:8443"),
         ("NAS.Local", "nas.local"),
         ("HTTPS://NAS.Example.COM:8443/UI", "nas.example.com:8443"),
+        ("2001:db8::1", "[2001:db8::1]"),
+        ("2001:DB8::1", "[2001:db8::1]"),
+        ("::1", "[::1]"),
+        ("[2001:db8::1]", "[2001:db8::1]"),
+        ("[2001:db8::1]:8443", "[2001:db8::1]:8443"),
     ],
 )
 def test_sanitize_host(raw: str, expected: str) -> None:


### PR DESCRIPTION
## Proposed change
Mirrors two review findings from home-assistant/core#179103 (Copilot) into
this repo, since both bugs live in code shared with the Core PR:

1. **IPv6 hosts were never bracketed.** `sanitize_host()` left a bare IPv6
   literal (e.g. `2001:db8::1`) unbracketed, and zeroconf discovery passed
   `ZeroconfServiceInfo.host` straight through without running it through
   `sanitize_host` at all. Either produces a malformed
   `wss://<host>/api/current` URL, since the literal's colons are ambiguous
   with a port separator once unbracketed.
2. **`_fetch_stat_graphs` queried graphs serially** instead of concurrently,
   so one slow/unresponsive TrueNAS could hold a nominal poll for several
   minutes. **`_store_stat_defaults` bypassed `_store_stat_value`'s
   type-specific key mapping**, so a malformed `arcsize`/`memory` graph left
   the actually-exposed `cache_size-arc_value`/`memory-free_value` sensors
   stale instead of zeroed on failure.

## Type of change
- [X] Bugfix

## Additional information
Verified against a live TrueNAS instance (synced to HA, restarted, checked
logs + sensor states — CPU load/ARC size/memory-free sensors all report
fresh non-zero values, no errors).

## Checklist
- [X] The code change is tested and works locally.
- [X] The code has been formatted and linted using Ruff.
- [X] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [X] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix IPv6 host handling and statistic polling so connections remain valid and sensor values stay current when graph requests fail.

Bug Fixes:
- Handle IPv6 addresses consistently in discovered and configured hosts so generated connection URLs remain valid.
- Fetch statistic graphs concurrently to prevent slow requests from blocking the polling cycle.
- Store fallback statistic values under the same mapped keys as successful values so exposed sensors do not retain stale data.

Tests:
- Add regression coverage for IPv6 zeroconf discovery, mapped statistic defaults, and IPv6 host sanitization.