### PR TITLE
docs: condense _schedule_suffix docstring to the non-obvious constraint

### DIFF
--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -859,31 +859,15 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
         return schema[matches[-1].end() :].strip("-_ ") or None
 
     def _schedule_suffix(self) -> str | None:
-        """Return a best-effort Hourly/Daily/Weekly/Monthly label.
+        """Return a best-effort Hourly/Daily/Weekly/Monthly label, or None.
 
-        Derived from the task's cron `schedule` dict (minute/hour/dom/month/
-        dow) using TrueNAS's known periodic-snapshot-task presets, which pin
-        exactly one of dom/dow/hour to a single fixed number, pin `minute`
-        to a single fixed number too (the run time within that hour/day),
-        and leave `month` plus the remaining fields at "*". If any field is
-        neither wildcarded nor a single fixed number -- a step ("*/2" on
-        `minute` or `hour`), range ("1-5") or list ("1,15") -- or if `month`
-        is pinned (which never occurs in any of the four presets), the
-        schedule doesn't match a known preset at all, so it's left
-        unclassified rather than guessed at from whichever field happens to
-        still look pinned. `minute` itself never distinguishes between
-        presets (every preset pins it), so it's only used for this shape
-        check, not for the dom -> dow -> hour classification below, which
-        means a schedule that (contrary to any known preset) has both dom
-        and dow pinned is labeled Monthly. An empty `schedule` dict (no
-        fields at all) is rejected up front rather than falling through to
-        "every field is missing, so every field is wildcard" -> Hourly, and
-        a fully wildcard schedule (minute included) is likewise left
-        unclassified rather than labeled Hourly, since a genuine Hourly
-        preset always pins `minute` to the run time within the hour --
-        minute *also* being "*" would mean "every minute", not hourly.
-        Tasks matching no preset keep the plain dataset-only name rather
-        than risk a misleading guess.
+        TrueNAS's periodic-snapshot-task presets each pin exactly one of
+        dom/dow/hour plus `minute` to a single fixed number, leaving `month`
+        and the rest wildcarded. A step/range/list value on any field, a
+        pinned `month`, or an all-wildcard schedule (minute included -- a
+        genuine Hourly preset always pins minute to its run time) falls
+        outside every known preset and is left unclassified rather than
+        guessed at.
         """
         schedule = self._data.get("schedule") if self._data else None
         if not isinstance(schedule, dict) or not schedule:

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -861,13 +861,14 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
     def _schedule_suffix(self) -> str | None:
         """Return a best-effort Hourly/Daily/Weekly/Monthly label, or None.
 
-        TrueNAS's periodic-snapshot-task presets each pin exactly one of
-        dom/dow/hour plus `minute` to a single fixed number, leaving `month`
-        and the rest wildcarded. A step/range/list value on any field, a
-        pinned `month`, or an all-wildcard schedule (minute included -- a
-        genuine Hourly preset always pins minute to its run time) falls
-        outside every known preset and is left unclassified rather than
-        guessed at.
+        TrueNAS's Daily/Weekly/Monthly periodic-snapshot-task presets each
+        pin exactly one of dom/dow/hour plus `minute` to a single fixed
+        number, leaving `month` and the rest wildcarded. The Hourly preset
+        pins only `minute`; `dom`, `dow`, and `hour` remain wildcarded. A
+        step/range/list value on any field, a pinned `month`, or an
+        all-wildcard schedule (minute included -- a genuine Hourly preset
+        always pins minute to its run time) falls outside every known preset
+        and is left unclassified rather than guessed at.
         """
         schedule = self._data.get("schedule") if self._data else None
         if not isinstance(schedule, dict) or not schedule:


### PR DESCRIPTION
## Proposed change

Condenses `TrueNASSnapshotTaskSensor._schedule_suffix`'s 25-line
branch-by-branch docstring down to the one non-obvious constraint
(presets pin exactly one of dom/dow/hour plus minute; an all-wildcard
schedule is not Hourly). No behavior change.

Mirrors a Copilot review finding on `home-assistant/core#179103` (the
`ha-core` fork carries an identical copy of this method).

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or fixes part of issue: n/a
- Link to documentation pull request: n/a

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Condense the `_schedule_suffix` docstring to clearly document the supported TrueNAS schedule constraints and unclassified cases without changing behavior.