### PR TITLE
fix: bump aiotruenas to 1.4.1 for send-error deadlock fix

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,4 +15,4 @@ pytest-cov = ">=6.0"
 
 
 [packages]
-aiotruenas = ">=1.4.0"
+aiotruenas = ">=1.4.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7e48cb9ebadb005455ce027c471adbc7ec50699f90c39f1dc8e7e2e8259dbb70"
+            "sha256": "68c670be46439faa568d77b62c8ae3169ee128724d069caa976b1d04ffe50c9c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,12 +16,12 @@
     "default": {
         "aiotruenas": {
             "hashes": [
-                "sha256:94fe79bcfaf276c0012446b553b5f2acd1cc748cb53be38634242a241ca15053",
-                "sha256:95449f83ccd8a951b0138499b005717b11eb551fde01561817054b9a4e1e57d5"
+                "sha256:323707469d1d4ad4be472d4cd7ffc39216a38beae6b1d58534d2f2ed076fa184",
+                "sha256:5de1b1582de9d44e24805e2a9891bb7e84e74daaf372fad6675384dc1bfdf751"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.13'",
-            "version": "==1.4.0"
+            "version": "==1.4.1"
         },
         "websockets": {
             "hashes": [

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -12,7 +12,7 @@
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
     "quality_scale": "platinum",
     "requirements": [
-        "aiotruenas>=1.4.0",
+        "aiotruenas>=1.4.1",
         "websockets>=15.0.1"
     ],
     "version": "2.8.0",


### PR DESCRIPTION
## Proposed change
Bumps the `aiotruenas` dependency pin from `>=1.4.0` to `>=1.4.1`. The new release fixes a non-reentrant-lock deadlock in `TrueNASClient.call()` that could occur on the `ConnectionClosed`/`OSError`/`WebSocketException` send-failure path.

## Type of change
- [x] Bugfix

## Additional information
Upstream fix: kayl-codes/aiotruenas.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent TrueNAS connection send failures from deadlocking by requiring aiotruenas 1.4.1 or newer.

Bug Fixes:
- Update the aiotruenas dependency to version 1.4.1 or newer to include the upstream send-failure deadlock fix.

Build:
- Refresh the locked dependency metadata for the aiotruenas version update.