### PR TITLE
fix: delegate systemstats polling to aiotruenas TrueNASState

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,5 @@ pytest = ">=8.0"
 pytest-asyncio = ">=0.24"
 pytest-cov = ">=6.0"
 
-
 [packages]
-aiotruenas = ">=1.4.1"
+aiotruenas = ">=1.4.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "68c670be46439faa568d77b62c8ae3169ee128724d069caa976b1d04ffe50c9c"
+            "sha256": "50973fd8aec00b247f7ee5940684e5c23ef7c69e4c3c578b17e83a2b87611512"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,12 +16,12 @@
     "default": {
         "aiotruenas": {
             "hashes": [
-                "sha256:323707469d1d4ad4be472d4cd7ffc39216a38beae6b1d58534d2f2ed076fa184",
-                "sha256:5de1b1582de9d44e24805e2a9891bb7e84e74daaf372fad6675384dc1bfdf751"
+                "sha256:012bc1c1e77a10b48f6f8197777a5de3f4d21f7f79f532732ef878c2b37d2a4f",
+                "sha256:7773dafb47a173a3b1f138854aafede0daadd3118e428c821291321552845aac"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.13'",
-            "version": "==1.4.1"
+            "version": "==1.4.2"
         },
         "websockets": {
             "hashes": [

--- a/custom_components/truenas_ce/const.py
+++ b/custom_components/truenas_ce/const.py
@@ -28,17 +28,9 @@ ATTRIBUTION = "Data provided by TrueNAS CE integration"
 SIGNAL_UPDATE_SENSORS = f"{DOMAIN}_update_sensors"
 
 # TrueNAS interface link states (from interface.query -> state/link_state).
-LINK_STATE_UP = "LINK_STATE_UP"
 LINK_STATE_DOWN = "LINK_STATE_DOWN"
 
 DEFAULT_HOST = "trueas.local"
-
-# Conversion factor: kilobits per second to kibibytes per second
-# (1000 / 8192 = ~0.12207)
-KILOBITS_TO_KIBIBYTES_FACTOR = 0.12207
-
-# Tolerance in seconds to prevent Uptime sensor fluctuations
-UPTIME_EPOCH_TOLERANCE_SECONDS = 300
 
 # Default per-query timeout in seconds
 QUERY_TIMEOUT: float = 30.0

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -329,6 +329,11 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # must persist across polls instead of being recomputed each time.
         self._poisoned_certificate_commons: set[str] = set()
 
+        # Netdata graph names already warned about as stale (deduped so a
+        # persistently-failing graph doesn't re-log every 60s poll) -- see
+        # get_systemstats()/TrueNASState.systemstats_stale_graphs.
+        self._systemstats_stale_graphs_logged: frozenset[str] = frozenset()
+
         # Orphaned recorder statistic_ids (no live entity) detected each poll.
         self.orphaned_statistics: list[str] = []
 
@@ -733,9 +738,13 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         Carries forward the update-job and SMB-connection-count fields that
         ``TrueNASState.get_systeminfo()`` intentionally does not own (see
-        ``get_updatecheck``/the SMB merge) -- otherwise every poll would reset
-        an in-progress system-update job's tracking state to defaults, exactly
-        the bug already fixed for per-app upgrade jobs in ``_refresh_app``.
+        ``get_updatecheck``/the SMB merge). In practice ``TrueNASState`` keeps
+        returning the same dict object it mutates in place, so these fields
+        already survive between polls on their own; this loop is a defensive
+        safety net against relying on that object-identity detail, which is
+        an implementation detail of ``TrueNASState``, not a documented
+        contract -- exactly the bug already fixed for per-app upgrade jobs
+        in ``_refresh_app``.
         """
         previous = self.ds["system_info"]
         self.ds["system_info"] = await self.state.get_systeminfo()
@@ -884,6 +893,27 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         needed here.
         """
         await self.state.get_systemstats()
+        self._log_systemstats_staleness()
+
+    def _log_systemstats_staleness(self) -> None:
+        """Warn once per netdata graph that starts/stays failing, and note
+        recovery, so a stuck graph (stale field values every poll) is
+        visible in the log instead of silently never refreshing.
+        """
+        stale = self.state.systemstats_stale_graphs
+        newly_stale = stale - self._systemstats_stale_graphs_logged
+        if newly_stale:
+            _LOGGER.warning(
+                "TrueNAS system stats graph(s) failed, values may be stale: %s",
+                ", ".join(sorted(newly_stale)),
+            )
+        recovered = self._systemstats_stale_graphs_logged - stale
+        if recovered:
+            _LOGGER.info(
+                "TrueNAS system stats graph(s) recovered: %s",
+                ", ".join(sorted(recovered)),
+            )
+        self._systemstats_stale_graphs_logged = stale
 
     # ---------------------------
     #   get_service

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -896,9 +896,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._log_systemstats_staleness()
 
     def _log_systemstats_staleness(self) -> None:
-        """Warn once per netdata graph that starts/stays failing, and note
-        recovery, so a stuck graph (stale field values every poll) is
-        visible in the log instead of silently never refreshing.
+        """Warn once when a netdata graph starts failing (staying silent
+        while it keeps failing), and log once when it recovers, so a stuck
+        graph (stale field values every poll) is visible in the log instead
+        of silently never refreshing.
         """
         stale = self.state.systemstats_stale_graphs
         newly_stale = stale - self._systemstats_stale_graphs_logged

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -45,9 +45,7 @@ from .const import (
     ERR_INVALID_KEY,
     ISSUE_MIGRATION_ROLLBACK,
     ISSUE_STATISTICS_ORPHANED,
-    KILOBITS_TO_KIBIBYTES_FACTOR,
     LEGACY_DOMAIN,
-    LINK_STATE_UP,
     MIGRATION_LEGACY_ENTRY_ID,
     MIGRATION_RECORDS,
     MONITOR_GROUP_CLOUDSYNC,
@@ -60,15 +58,10 @@ from .const import (
     MONITOR_GROUP_SNAPSHOTS,
     MONITOR_GROUP_UPS,
     MONITOR_GROUP_VMS,
-    UPTIME_EPOCH_TOLERANCE_SECONDS,
 )
 from .event_push import SubscriptionCircuitBreaker, SubscriptionPushConsumer
 
 _LOGGER = logging.getLogger(__name__)
-
-# TrueNAS reporting (netdata) API method names.
-_NETDATA_GRAPH = "reporting.netdata_graph"
-_NETDATA_GRAPHS = "reporting.netdata_graphs"
 
 # Job-progress fields shared by the cloudsync, replication and rsync queries.
 _JOB_PROGRESS_VALS: list[ApiValueSpec] = [
@@ -149,26 +142,6 @@ def _assign_certificate_identities(
         cert["_identity"] = (
             common if common and common not in poisoned_commons else cert.get("name")
         )
-
-
-# ---------------------------
-#   _stat_name_similar
-# ---------------------------
-def _stat_name_similar(a: str, b: str) -> bool:
-    """Return True if two stat graph names look like near-misses of each other."""
-    a_l, b_l = a.lower(), b.lower()
-    if a_l == b_l:
-        return False
-    if a_l.replace("_", "") == b_l.replace("_", ""):
-        return True
-    if (
-        a_l.startswith(b_l)
-        or a_l.endswith(b_l)
-        or b_l.startswith(a_l)
-        or b_l.endswith(a_l)
-    ):
-        return True
-    return abs(len(a_l) - len(b_l)) <= 2 and a_l[:3] == b_l[:3]
 
 
 # ---------------------------
@@ -345,15 +318,11 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # self.ds[...] entries directly below.
         self.state = TrueNASState(self.api.client)
 
-        self._systemstats_errored: dict[str, datetime] = {}
-        self._systemstats_error_cooldown = timedelta(minutes=10)
         self.datasets_hass_device_id = None
         self.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
 
-        self._is_virtual = False
         self._version_major: int = 0
         self._version_minor: int = 0
-        self._unknown_system_stat_names: set[str] = set()
 
         # Common names that have ever been shared by more than one certificate
         # in a poll -- see ``_assign_certificate_identities`` for why this
@@ -521,11 +490,14 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         err,
                     )
 
-            # get_systeminfo populates ds["interface"] and _is_virtual, which
-            # get_systemstats reads to decide whether to fetch the interface
-            # graph (and to skip cputemp on VMs). Run it before the concurrent
-            # jobs so the first cycle does not skip the interface graph, which
-            # would leave RX/TX at 0 until the next poll.
+            # get_interface (not get_systeminfo) now populates ds["interface"],
+            # and virtualization detection now lives inside TrueNASState itself
+            # rather than a local self._is_virtual. get_systemstats still needs
+            # both ds["system_info"] and a populated ds["interface"] before it
+            # runs (its rx/tx enrichment is a no-op on an empty interface map),
+            # so both are run before the concurrent jobs -- otherwise the first
+            # cycle would skip the interface graph, leaving RX/TX at 0 until
+            # the next poll.
             await _run_job(self.get_systeminfo)
 
             # A middleware error leaves ds["system_info"] at its empty initial
@@ -539,6 +511,8 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "Essential system information (hostname) was not received"
                     " from TrueNAS"
                 )
+
+            await _run_job(self.get_interface)
 
             await asyncio.gather(*(_run_job(job) for job in jobs))
 
@@ -737,46 +711,37 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ---------------------------
     #   get_systeminfo
     # ---------------------------
-    async def get_systeminfo(self) -> None:
-        """Get system info from TrueNAS."""
-        raw_system_info = await self.api.query("system.info")
+    _SYSTEM_INFO_CARRY_FIELDS = (
+        "update_available",
+        "update_progress",
+        "update_jobid",
+        "update_state",
+        "update_version",
+        "smb_connections",
+    )
+    _SYSTEM_INFO_CARRY_DEFAULTS: dict[str, Any] = {
+        "update_available": False,
+        "update_progress": 0,
+        "update_jobid": 0,
+        "update_state": "unknown",
+        "update_version": "unknown",
+        "smb_connections": 0,
+    }
 
-        if isinstance(raw_system_info, dict):
-            self.ds["system_info"] = parse_api(
-                data=self.ds["system_info"],
-                source=raw_system_info,
-                vals=[
-                    {"name": "version", "default": "unknown"},
-                    {"name": "hostname", "default": "unknown"},
-                    {"name": "uptime_seconds", "default": 0},
-                    {"name": "system_serial", "default": "unknown"},
-                    {"name": "system_product", "default": "unknown"},
-                    {"name": "system_manufacturer", "default": "unknown"},
-                    {"name": "physmem", "default": 0},
-                ],
-                ensure_vals=[
-                    {"name": "uptimeEpoch", "default": 0},
-                    {"name": "cpu_temperature", "default": None},
-                    {"name": "load_shortterm", "default": 0.0},
-                    {"name": "load_midterm", "default": 0.0},
-                    {"name": "load_longterm", "default": 0.0},
-                    {"name": "cpu_usage", "default": 0.0},
-                    {"name": "cache_size-arc_value", "default": 0.0},
-                    {"name": "memory-free_value", "default": 0.0},
-                    {"name": "memory-total_value", "default": 0.0},
-                    {"name": "memory-usage_percent", "default": 0},
-                    {"name": "update_available", "type": "bool", "default": False},
-                    {"name": "update_progress", "default": 0},
-                    {"name": "update_jobid", "default": 0},
-                    {"name": "update_state", "default": "unknown"},
-                    {"name": "update_version", "default": "unknown"},
-                    {"name": "smb_connections", "default": 0},
-                ],
-            )
-        else:
-            _LOGGER.debug(
-                "Skipping system_info update due to invalid/empty API response: %r",
-                raw_system_info,
+    async def get_systeminfo(self) -> None:
+        """Get system info via the aiotruenas domain layer.
+
+        Carries forward the update-job and SMB-connection-count fields that
+        ``TrueNASState.get_systeminfo()`` intentionally does not own (see
+        ``get_updatecheck``/the SMB merge) -- otherwise every poll would reset
+        an in-progress system-update job's tracking state to defaults, exactly
+        the bug already fixed for per-app upgrade jobs in ``_refresh_app``.
+        """
+        previous = self.ds["system_info"]
+        self.ds["system_info"] = await self.state.get_systeminfo()
+        for field in self._SYSTEM_INFO_CARRY_FIELDS:
+            self.ds["system_info"][field] = previous.get(
+                field, self._SYSTEM_INFO_CARRY_DEFAULTS[field]
             )
 
         if not self.api.connected():
@@ -793,9 +758,13 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
 
         self._parse_version()
-        self._detect_virtualization()
-        self._update_uptime()
-        await self._query_interfaces()
+
+    # ---------------------------
+    #   get_interface
+    # ---------------------------
+    async def get_interface(self) -> None:
+        """Get network interfaces via the aiotruenas domain layer."""
+        self.ds["interface"] = _as_str_keyed(await self.state.get_interface())
 
     # ---------------------------
     #   _handle_update_job
@@ -881,88 +850,6 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return (self._version_major, self._version_minor) >= (26, 0)
 
     # ---------------------------
-    #   _detect_virtualization
-    # ---------------------------
-    def _detect_virtualization(self) -> None:
-        """Detect whether TrueNAS is running virtualized."""
-        self._is_virtual = self.ds["system_info"].get("system_manufacturer") in [
-            "QEMU",
-            "VMware, Inc.",
-            "Microsoft Corporation",
-            "Xen",
-        ] or self.ds["system_info"].get("system_product") in [
-            "VirtualBox",
-            "Virtual Machine",
-        ]
-
-    # ---------------------------
-    #   _update_uptime
-    # ---------------------------
-    def _update_uptime(self) -> None:
-        """Update the uptime epoch, using a tolerance to avoid sensor jitter."""
-        uptime_seconds = self.ds["system_info"].get("uptime_seconds", 0)
-        if uptime_seconds <= 0:
-            return
-
-        now = datetime.now(UTC).replace(microsecond=0)
-        now_epoch = int(now.timestamp())
-        new_uptime_epoch = now_epoch - int(uptime_seconds)
-
-        old_uptime_epoch = self.ds["system_info"].get("uptimeEpoch", 0)
-        if (
-            old_uptime_epoch == 0
-            or abs(new_uptime_epoch - old_uptime_epoch) > UPTIME_EPOCH_TOLERANCE_SECONDS
-        ):
-            self.ds["system_info"]["uptimeEpoch"] = new_uptime_epoch
-        else:
-            self.ds["system_info"]["uptimeEpoch"] = old_uptime_epoch
-
-    # ---------------------------
-    #   _query_interfaces
-    # ---------------------------
-    async def _query_interfaces(self) -> None:
-        """Query network interfaces from TrueNAS."""
-        self.ds["interface"] = parse_api(
-            data=self.ds["interface"],
-            source=await self.api.query("interface.query"),
-            key="id",
-            vals=[
-                {"name": "id", "default": "unknown"},
-                {"name": "name", "default": "unknown"},
-                {"name": "description", "default": "unknown"},
-                {"name": "mtu", "default": "unknown"},
-                {
-                    "name": "link_state",
-                    "source": "state/link_state",
-                    "default": "unknown",
-                },
-                {
-                    "name": "active_media_type",
-                    "source": "state/active_media_type",
-                    "default": "unknown",
-                },
-                {
-                    "name": "active_media_subtype",
-                    "source": "state/active_media_subtype",
-                    "default": "unknown",
-                },
-                {
-                    "name": "link_address",
-                    "source": "state/link_address",
-                    "default": "unknown",
-                },
-            ],
-            ensure_vals=[
-                {"name": "rx", "default": 0},
-                {"name": "tx", "default": 0},
-            ],
-        )
-
-        # Derive a boolean link state for the connectivity binary sensor.
-        for interface in self.ds["interface"].values():
-            interface["link_up"] = interface.get("link_state") == LINK_STATE_UP
-
-    # ---------------------------
     #   get_updatecheck
     # ---------------------------
     async def get_updatecheck(self) -> None:
@@ -989,256 +876,14 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     #   get_systemstats
     # ---------------------------
     async def get_systemstats(self) -> None:
-        """Get system statistics."""
-        report_epoch = int(datetime.now(UTC).replace(microsecond=0).timestamp())
-        graph_names = self._select_stat_graph_names()
-        if not graph_names:
-            return
+        """Get system statistics via the aiotruenas domain layer.
 
-        # Use a window matching the poll interval so interface RX/TX values
-        # reflect current traffic rather than a fixed 60-second average.
-        # A minimum of 5 s keeps the window sane at the shortest poll setting.
-        poll = int(
-            self.config_entry.options.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
-        )
-        window = max(poll, 5)
-        graph_query = {
-            "start": report_epoch - window - 2,
-            "end": report_epoch - 2,
-            "aggregate": True,
-        }
-        tmp_graph = await self._fetch_stat_graphs(graph_names, graph_query)
-        if not tmp_graph:
-            return
-
-        for item in tmp_graph:
-            if isinstance(item, dict):
-                self._process_system_stat(item)
-
-    def _select_stat_graph_names(self) -> list[str]:
-        """Build the list of stat graphs to query, honoring the error cooldown."""
-        graph_names = ["load", "cputemp", "cpu", "arcsize", "memory"]
-
-        if self.ds["interface"]:
-            graph_names.append("interface")
-
-        # 2DO: Consider making this a config option. Many hypervisors do not
-        # pass through CPU temperatures, causing API errors. However, some do,
-        # so users might want to explicitly enable 'cputemp' polling even for VMs.
-        if self._is_virtual and "cputemp" in graph_names:
-            graph_names.remove("cputemp")
-
-        now = datetime.now(UTC)
-        self._systemstats_errored = {
-            name: ts
-            for name, ts in self._systemstats_errored.items()
-            if now - ts < self._systemstats_error_cooldown
-        }
-
-        return [
-            graph_name
-            for graph_name in graph_names
-            if graph_name not in self._systemstats_errored
-        ]
-
-    async def _fetch_stat_graphs(
-        self, graph_names: list[str], graph_query: dict[str, Any]
-    ) -> list[Any]:
-        """Query each stat graph concurrently; return combined data, track failures."""
-        reporting_path = _NETDATA_GRAPH
-        results = await asyncio.gather(
-            *(
-                self.api.query(reporting_path, params=[graph_name, graph_query])
-                for graph_name in graph_names
-            )
-        )
-
-        tmp_graph: list[Any] = []
-        failed_graphs: list[str] = []
-        for graph_name, graph_data in zip(graph_names, results, strict=True):
-            if isinstance(graph_data, list):
-                tmp_graph.extend(graph_data)
-            else:
-                failed_graphs.append(graph_name)
-
-        self._record_failed_graphs(failed_graphs)
-        return tmp_graph
-
-    def _record_failed_graphs(self, failed_graphs: list[str]) -> None:
-        """Record failed graphs, logging only newly failed ones to avoid spam."""
-        if not failed_graphs:
-            return
-
-        # Only log when a graph transitions into a failed state (i.e. was not
-        # already in _systemstats_errored), to avoid spamming the log on every
-        # coordinator update while the graph remains broken.
-        newly_failed_graphs: list[str] = []
-        now = datetime.now(UTC)
-        for graph_name in failed_graphs:
-            if graph_name not in self._systemstats_errored:
-                newly_failed_graphs.append(graph_name)
-            self._systemstats_errored[graph_name] = now
-
-        if newly_failed_graphs:
-            _LOGGER.warning(
-                "TrueNAS %s failed to fetch graphs: %s",
-                self.host,
-                newly_failed_graphs,
-            )
-
-    def _process_system_stat(self, item: dict[str, Any]) -> None:
-        """Process a single system statistic item."""
-        name = item.get("name")
-        if not name:
-            return
-
-        if name == "cputemp":
-            self._process_cputemp(item)
-        elif name == "load":
-            self._systemstats_process(
-                ("shortterm", "midterm", "longterm"), item, "load"
-            )
-        elif name == "cpu":
-            self._systemstats_process("cpu", item, "cpu")
-            cpu_cpu = self.ds["system_info"].get("cpu_cpu", 0.0)
-            self.ds["system_info"]["cpu_usage"] = round(cpu_cpu, 2)
-        elif name == "interface":
-            tmp_etc = item["identifier"]
-            if tmp_etc in self.ds["interface"]:
-                self._process_system_stat_interface(item, tmp_etc)
-        elif name == "memory":
-            self._process_memory_stat(item)
-        elif name == "arcsize":
-            # netdata exposes the ARC value under the "size" series, not "arc_size".
-            self._systemstats_process("size", item, "arcsize")
-        else:
-            self._handle_unknown_stat(name)
-
-    def _process_cputemp(self, item: dict[str, Any]) -> None:
-        """Store the CPU temperature from a cputemp graph item."""
-        mean_vals = item.get("aggregations", {}).get("mean", {})
-        valid_means = [v for v in mean_vals.values() if isinstance(v, (int, float))]
-        self.ds["system_info"]["cpu_temperature"] = (
-            round(max(valid_means), 2) if valid_means else None
-        )
-
-    def _process_memory_stat(self, item: dict[str, Any]) -> None:
-        """Store memory totals and usage percentage from a memory graph item."""
-        self.ds["system_info"]["memory-total_value"] = round(
-            self.ds["system_info"].get("physmem", 0)
-        )
-
-        self._systemstats_process("available", item, "memory")
-        total_mem = self.ds["system_info"].get("memory-total_value", 0.0)
-        free_mem = self.ds["system_info"].get("memory-free_value", 0.0)
-        if total_mem > 0:
-            self.ds["system_info"]["memory-usage_percent"] = round(
-                100 * (float(total_mem) - float(free_mem)) / float(total_mem)
-            )
-
-    def _handle_unknown_stat(self, name: str) -> None:
-        """Log an unknown stat graph name once to surface potential API changes."""
-        if name in self._unknown_system_stat_names:
-            return
-
-        self._unknown_system_stat_names.add(name)
-        _LOGGER.warning(
-            "TrueNAS %s returned unknown system stat graph name '%s'; "
-            "this may indicate a TrueNAS API change or misconfiguration",
-            self.host,
-            name,
-        )
-
-        known_names = {"cputemp", "load", "cpu", "interface", "memory", "arcsize"}
-        if near_misses := [k for k in known_names if _stat_name_similar(name, k)]:
-            _LOGGER.debug(
-                "Unknown system stat graph name '%s' from TrueNAS %s "
-                "is similar to known names: %s",
-                name,
-                self.host,
-                ", ".join(sorted(near_misses)),
-            )
-
-    def _process_system_stat_interface(
-        self, item: dict[str, Any], tmp_etc: str
-    ) -> None:
-        """Process interface system statistics."""
-        tmp_arr = ("rx", "tx")
-        legend = item.get("legend")
-        if not isinstance(legend, list):
-            for tmp_load in tmp_arr:
-                self.ds["interface"][tmp_etc][tmp_load] = 0.0
-            return
-
-        item["legend"] = [
-            tmp.replace("received", "rx").replace("sent", "tx")
-            for tmp in legend
-            if isinstance(tmp, str)
-        ]
-
-        aggregations = item.get("aggregations")
-        if isinstance(aggregations, dict) and isinstance(
-            aggregations.get("mean"), dict
-        ):
-            aggregations["mean"] = {
-                k.replace("received", "rx").replace("sent", "tx"): v
-                for k, v in aggregations["mean"].items()
-                if isinstance(k, str)
-            }
-
-            for tmp_var in item["legend"]:
-                if tmp_var in tmp_arr:
-                    tmp_val = aggregations["mean"].get(tmp_var) or 0.0
-                    self.ds["interface"][tmp_etc][tmp_var] = round(
-                        (tmp_val * KILOBITS_TO_KIBIBYTES_FACTOR), 2
-                    )
-
-        else:
-            for tmp_load in tmp_arr:
-                self.ds["interface"][tmp_etc][tmp_load] = 0.0
-
-    # ---------------------------
-    #   _systemstats_process
-    # ---------------------------
-    def _systemstats_process(
-        self, arr: str | tuple[str, ...], graph: dict[str, Any], t: str
-    ) -> None:
-        arr = (arr,) if isinstance(arr, str) else tuple(arr)
-        aggregations = graph.get("aggregations")
-        legend = graph.get("legend")
-
-        if not (isinstance(aggregations, dict) and isinstance(legend, list)):
-            self._store_stat_defaults(t, arr)
-            return
-
-        mean_data = aggregations.get("mean")
-        for tmp_var in legend:
-            if tmp_var not in arr:
-                continue
-            tmp_val = (
-                mean_data.get(tmp_var) if isinstance(mean_data, dict) else 0.0
-            ) or 0.0
-            self._store_stat_value(t, tmp_var, tmp_val)
-
-    def _store_stat_value(self, t: str, tmp_var: str, tmp_val: float) -> None:
-        """Store a single processed statistic value under the right key."""
-        info = self.ds["system_info"]
-        if t == "arcsize":
-            info["cache_size-arc_value"] = round(tmp_val, 2)
-        elif t == "cpu":
-            info[f"cpu_{tmp_var}"] = round(tmp_val, 2)
-        elif t == "load":
-            info[f"load_{tmp_var}"] = round(tmp_val, 2)
-        elif t == "memory":
-            if tmp_var == "available":
-                info["memory-free_value"] = round(tmp_val)
-        else:
-            info[tmp_var] = round(tmp_val, 2)
-
-    def _store_stat_defaults(self, t: str, arr: tuple[str, ...]) -> None:
-        """Store zeroed defaults when a statistic graph has no aggregations."""
-        for tmp_var in arr:
-            self._store_stat_value(t, tmp_var, 0.0)
+        Mutates the same dict objects already assigned to
+        ``ds["system_info"]``/``ds["interface"]`` in place (CPU/load/
+        memory/ARC stats, interface rx/tx), so no explicit re-sync is
+        needed here.
+        """
+        await self.state.get_systemstats()
 
     # ---------------------------
     #   get_service

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -12,7 +12,7 @@
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
     "quality_scale": "platinum",
     "requirements": [
-        "aiotruenas>=1.4.1",
+        "aiotruenas>=1.4.2",
         "websockets>=15.0.1"
     ],
     "version": "2.8.0",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1943,16 +1943,48 @@ async def test_get_systemstats_delegates_to_state() -> None:
 
     coord.state = MagicMock()
     coord.state.get_systemstats = AsyncMock(side_effect=_mutate_in_place)
+    coord.state.systemstats_stale_graphs = frozenset()
     await coord.get_systemstats()
     coord.state.get_systemstats.assert_awaited_once()
-    # get_systemstats() has no coordinator-side logic of its own, so the only
-    # thing worth locking in here is that it doesn't clobber ds["system_info"]/
-    # ds["interface"] with its own return value -- the mutate-in-place contract
-    # from TrueNASState is what actually updates them.
+    # get_systemstats() doesn't clobber ds["system_info"]/ds["interface"] with
+    # its own return value -- the mutate-in-place contract from TrueNASState is
+    # what actually updates them. Staleness logging (_log_systemstats_staleness)
+    # is exercised separately below.
     assert coord.ds["system_info"] is system_info
     assert coord.ds["interface"] is interface
     assert system_info["cpu_usage"] == 42
     assert interface["eth0"]["rx"] == 123
+
+
+async def test_log_systemstats_staleness_warns_once_then_silent_then_recovers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """New-stale graphs warn once, stay silent while still stale, then log an
+    info once recovered -- and warn again if they go stale a second time."""
+    coord = _bare_coordinator()
+    coord.state = MagicMock()
+
+    with caplog.at_level("DEBUG", logger=coordinator_module.__name__):
+        coord.state.systemstats_stale_graphs = frozenset({"cpu"})
+        coord._log_systemstats_staleness()
+        assert "cpu" in caplog.text
+        assert "failed" in caplog.text
+
+        caplog.clear()
+        coord._log_systemstats_staleness()
+        assert caplog.text == ""
+
+        caplog.clear()
+        coord.state.systemstats_stale_graphs = frozenset()
+        coord._log_systemstats_staleness()
+        assert "cpu" in caplog.text
+        assert "recovered" in caplog.text
+
+        caplog.clear()
+        coord.state.systemstats_stale_graphs = frozenset({"cpu"})
+        coord._log_systemstats_staleness()
+        assert "cpu" in caplog.text
+        assert "failed" in caplog.text
 
 
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -77,6 +77,7 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._version_major = 0
     coord._version_minor = 0
     coord._poisoned_certificate_commons = set()
+    coord._systemstats_stale_graphs_logged = frozenset()
     return coord
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -52,7 +52,6 @@ from custom_components.truenas_ce.coordinator import (
     _count_statistics_with_data,
     _is_truenas_sensor_id,
     _PushSourceState,
-    _stat_name_similar,
 )
 
 
@@ -79,24 +78,6 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._version_minor = 0
     coord._poisoned_certificate_commons = set()
     return coord
-
-
-# ---------------------------
-#   _stat_name_similar
-# ---------------------------
-@pytest.mark.parametrize(
-    ("a", "b", "expected"),
-    [
-        ("cpu", "cpu", False),
-        ("arc_size", "arcsize", True),
-        ("cputemp", "cpu", True),
-        ("cpu", "cputemp", True),
-        ("memroy", "memory", True),
-        ("load", "interface", False),
-    ],
-)
-def test_stat_name_similar(a: str, b: str, expected: bool) -> None:
-    assert _stat_name_similar(a, b) == expected
 
 
 # ---------------------------
@@ -257,154 +238,6 @@ def test_parse_version_leaves_unset_on_no_match() -> None:
     coord._parse_version()
     assert coord._version_major == 0
     assert coord._version_minor == 0
-
-
-# ---------------------------
-#   _detect_virtualization
-# ---------------------------
-def test_detect_virtualization_true_for_known_manufacturer() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {"system_manufacturer": "QEMU", "system_product": ""}}
-    coord._detect_virtualization()
-    assert coord._is_virtual is True
-
-
-def test_detect_virtualization_true_for_known_product() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {
-        "system_info": {"system_manufacturer": "", "system_product": "VirtualBox"}
-    }
-    coord._detect_virtualization()
-    assert coord._is_virtual is True
-
-
-def test_detect_virtualization_false_for_physical_hardware() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {
-        "system_info": {"system_manufacturer": "Dell Inc.", "system_product": "R730"}
-    }
-    coord._detect_virtualization()
-    assert coord._is_virtual is False
-
-
-# ---------------------------
-#   _update_uptime
-# ---------------------------
-def test_update_uptime_sets_epoch_on_first_run() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {"uptime_seconds": 3600, "uptimeEpoch": 0}}
-    coord._update_uptime()
-    assert coord.ds["system_info"]["uptimeEpoch"] > 0
-
-
-def test_update_uptime_keeps_old_epoch_within_tolerance() -> None:
-    coord = _bare_coordinator()
-    now_epoch = int(datetime.now(UTC).timestamp())
-    old_epoch = now_epoch - 3600 + 5  # within the 300s tolerance of a fresh reading
-    coord.ds = {"system_info": {"uptime_seconds": 3600, "uptimeEpoch": old_epoch}}
-    coord._update_uptime()
-    assert coord.ds["system_info"]["uptimeEpoch"] == old_epoch
-
-
-def test_update_uptime_replaces_stale_epoch_outside_tolerance() -> None:
-    coord = _bare_coordinator()
-    now_epoch = int(datetime.now(UTC).timestamp())
-    old_epoch = now_epoch - 3600 - 600  # 600s drift, well beyond the 300s tolerance
-    coord.ds = {"system_info": {"uptime_seconds": 3600, "uptimeEpoch": old_epoch}}
-    coord._update_uptime()
-    new_epoch = coord.ds["system_info"]["uptimeEpoch"]
-    assert new_epoch != old_epoch
-    # Replaced by a freshly computed epoch (now - uptime_seconds).
-    assert abs(new_epoch - (now_epoch - 3600)) <= 5
-
-
-def test_update_uptime_skips_when_uptime_not_positive() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {"uptime_seconds": 0, "uptimeEpoch": 123}}
-    coord._update_uptime()
-    assert coord.ds["system_info"]["uptimeEpoch"] == 123
-
-
-# ---------------------------
-#   _systemstats_process / _store_stat_value / _store_stat_defaults
-# ---------------------------
-def test_systemstats_process_stores_matching_legend_values() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    graph = {
-        "legend": ["shortterm", "midterm", "longterm"],
-        "aggregations": {"mean": {"shortterm": 1.234, "midterm": 2.0}},
-    }
-    coord._systemstats_process(("shortterm", "midterm", "longterm"), graph, "load")
-    assert coord.ds["system_info"]["load_shortterm"] == pytest.approx(1.23)
-    assert coord.ds["system_info"]["load_midterm"] == pytest.approx(2.0)
-    # "longterm" is in the legend but missing from the mean dict, so it falls
-    # back to 0.0 rather than being skipped.
-    assert coord.ds["system_info"]["load_longterm"] == pytest.approx(0.0)
-
-
-def test_systemstats_process_falls_back_to_defaults_without_aggregations() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._systemstats_process("cpu", {}, "cpu")
-    assert coord.ds["system_info"]["cpu_cpu"] == pytest.approx(0.0)
-
-
-def test_systemstats_process_defaults_use_dedicated_keys() -> None:
-    """Defaults for a malformed graph land under the same key as a real value.
-
-    Regression test for a bug where defaults bypassed the type-specific key
-    mapping in _store_stat_value and were written under the bare var name
-    instead, leaving the actually-exposed sensor keys stale.
-    """
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._systemstats_process("size", {}, "arcsize")
-    assert coord.ds["system_info"]["cache_size-arc_value"] == 0.0
-    coord._systemstats_process("available", {}, "memory")
-    assert coord.ds["system_info"]["memory-free_value"] == 0
-
-
-def test_systemstats_process_skips_legend_var_not_in_arr() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    graph = {
-        "legend": ["shortterm", "other"],
-        "aggregations": {"mean": {"shortterm": 1.0, "other": 99.0}},
-    }
-    coord._systemstats_process(("shortterm",), graph, "load")
-    assert coord.ds["system_info"]["load_shortterm"] == pytest.approx(1.0)
-    assert "load_other" not in coord.ds["system_info"]
-
-
-def test_store_stat_value_arcsize_uses_dedicated_key() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._store_stat_value("arcsize", "size", 12.345)
-    assert coord.ds["system_info"]["cache_size-arc_value"] == pytest.approx(12.35)
-
-
-def test_store_stat_value_cpu_uses_prefixed_key() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._store_stat_value("cpu", "cpu", 12.345)
-    assert coord.ds["system_info"]["cpu_cpu"] == pytest.approx(12.35)
-
-
-def test_store_stat_value_memory_only_stores_available() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._store_stat_value("memory", "available", 100.0)
-    assert coord.ds["system_info"]["memory-free_value"] == 100
-    coord._store_stat_value("memory", "used", 50.0)
-    assert "memory-used" not in coord.ds["system_info"]
-
-
-def test_store_stat_value_unknown_type_stores_raw_key() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._store_stat_value("diskstats", "reads", 12.345)
-    assert coord.ds["system_info"]["reads"] == pytest.approx(12.35)
 
 
 # ---------------------------
@@ -1495,6 +1328,7 @@ def _stub_all_jobs(coord: TrueNASCoordinator) -> None:
     """Patch every job invoked by ``_async_update_data`` with a no-op AsyncMock."""
     for name in (
         "get_systeminfo",
+        "get_interface",
         "get_systemstats",
         "get_service",
         "get_disk",
@@ -1535,6 +1369,7 @@ async def test_async_update_data_runs_jobs_when_connected() -> None:
     result = await coord._async_update_data()
 
     coord.get_systeminfo.assert_awaited_once()
+    coord.get_interface.assert_awaited_once()
     coord.get_pool.assert_awaited_once()
     coord.get_updatecheck.assert_awaited_once()
     assert result is coord.ds
@@ -1585,6 +1420,7 @@ async def test_async_update_data_raises_when_system_info_missing() -> None:
         await coord._async_update_data()
 
     coord.get_systeminfo.assert_awaited_once()
+    coord.get_interface.assert_not_awaited()
     coord.get_pool.assert_not_awaited()
 
 
@@ -1898,19 +1734,26 @@ async def test_async_clear_orphaned_statistics_clears_and_refreshes() -> None:
 
 
 # ---------------------------
-#   get_systeminfo / _handle_update_job / _query_interfaces
+#   get_systeminfo / _handle_update_job
 # ---------------------------
-async def test_get_systeminfo_parses_valid_response_and_runs_pipeline() -> None:
+# The system.info parsing, uptime-epoch derivation and virtualization
+# detection these tests used to exercise directly now live in and are tested
+# by aiotruenas's own TrueNASState.get_systeminfo() (see
+# tests/test_domain_state.py in that repo). get_systeminfo just delegates,
+# carries forward the update-job/SMB fields TrueNASState intentionally
+# doesn't own, and drives the update-job/version-parsing pipeline, so this
+# only needs to lock in that plumbing.
+async def test_get_systeminfo_delegates_and_runs_pipeline() -> None:
     coord = _bare_coordinator()
     coord.ds = {"system_info": {}, "interface": {}}
     coord.api = MagicMock()
     coord.api.connected = MagicMock(return_value=True)
-    coord.api.query = AsyncMock(
+    coord.state = MagicMock()
+    coord.state.get_systeminfo = AsyncMock(
         return_value={
             "version": "TrueNAS-SCALE-25.04.1",
             "hostname": "nas1",
             "uptime_seconds": 100,
-            "physmem": 1000,
         }
     )
     coord._handle_update_job = AsyncMock()
@@ -1923,17 +1766,58 @@ async def test_get_systeminfo_parses_valid_response_and_runs_pipeline() -> None:
     coord._handle_update_job.assert_awaited_once()
 
 
-async def test_get_systeminfo_skips_parse_on_invalid_response() -> None:
+async def test_get_systeminfo_carries_forward_update_and_smb_fields() -> None:
+    """An in-progress system-update job's tracking state (and the SMB
+    connection count) must survive across a poll, even though
+    TrueNASState.get_systeminfo() returns a freshly-built dict that never
+    carries these HA-specific fields (the same #101-style regression already
+    fixed for per-app upgrade jobs in ``_refresh_app``)."""
     coord = _bare_coordinator()
-    coord.ds = {"system_info": {}, "interface": {}}
+    coord.ds = {
+        "system_info": {
+            "update_available": True,
+            "update_progress": 42,
+            "update_jobid": 5,
+            "update_state": "RUNNING",
+            "update_version": "25.04.2",
+            "smb_connections": 3,
+        },
+        "interface": {},
+    }
     coord.api = MagicMock()
     coord.api.connected = MagicMock(return_value=True)
-    coord.api.query = AsyncMock(return_value=None)
+    coord.state = MagicMock()
+    coord.state.get_systeminfo = AsyncMock(
+        return_value={"version": "TrueNAS-SCALE-25.04.1", "hostname": "nas1"}
+    )
     coord._handle_update_job = AsyncMock()
 
     await coord.get_systeminfo()
 
-    coord._handle_update_job.assert_awaited_once()
+    assert coord.ds["system_info"]["update_available"] is True
+    assert coord.ds["system_info"]["update_progress"] == 42
+    assert coord.ds["system_info"]["update_jobid"] == 5
+    assert coord.ds["system_info"]["update_state"] == "RUNNING"
+    assert coord.ds["system_info"]["update_version"] == "25.04.2"
+    assert coord.ds["system_info"]["smb_connections"] == 3
+
+
+async def test_get_systeminfo_defaults_carried_fields_on_first_run() -> None:
+    coord = _bare_coordinator()
+    coord.ds = {"system_info": {}, "interface": {}}
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord.state = MagicMock()
+    coord.state.get_systeminfo = AsyncMock(
+        return_value={"version": "25.04.1", "hostname": "nas1"}
+    )
+    coord._handle_update_job = AsyncMock()
+
+    await coord.get_systeminfo()
+
+    assert coord.ds["system_info"]["update_available"] is False
+    assert coord.ds["system_info"]["update_jobid"] == 0
+    assert coord.ds["system_info"]["smb_connections"] == 0
 
 
 async def test_get_systeminfo_returns_early_when_disconnected_after_parse() -> None:
@@ -1941,7 +1825,8 @@ async def test_get_systeminfo_returns_early_when_disconnected_after_parse() -> N
     coord.ds = {"system_info": {}, "interface": {}}
     coord.api = MagicMock()
     coord.api.connected = MagicMock(return_value=False)
-    coord.api.query = AsyncMock(return_value={"version": "25.04.1"})
+    coord.state = MagicMock()
+    coord.state.get_systeminfo = AsyncMock(return_value={"version": "25.04.1"})
     coord._handle_update_job = AsyncMock()
 
     await coord.get_systeminfo()
@@ -1955,7 +1840,8 @@ async def test_get_systeminfo_returns_early_disconnected_after_update_job() -> N
     coord.api = MagicMock()
     # Connected for the pre-update-job check, disconnected right after.
     coord.api.connected = MagicMock(side_effect=[True, False])
-    coord.api.query = AsyncMock(return_value={"version": "25.04.1"})
+    coord.state = MagicMock()
+    coord.state.get_systeminfo = AsyncMock(return_value={"version": "25.04.1"})
     coord._handle_update_job = AsyncMock()
     coord._parse_version = MagicMock()
 
@@ -2017,280 +1903,38 @@ async def test_handle_update_job_returns_early_when_disconnected() -> None:
     assert coord.ds["system_info"]["update_jobid"] == 5
 
 
-async def test_query_interfaces_derives_link_up() -> None:
+# ---------------------------
+#   get_interface
+# ---------------------------
+# The interface.query parsing/link_up derivation these tests used to
+# exercise directly now lives in and is tested by aiotruenas's own
+# TrueNASState.get_interface(). get_interface just delegates and assigns
+# the result, so this only needs to lock in that plumbing.
+async def test_get_interface_delegates_to_state() -> None:
     coord = _bare_coordinator()
     coord.ds = {"interface": {}}
-    coord.api = MagicMock()
-    coord.api.query = AsyncMock(
-        return_value=[
-            {"id": "eth0", "name": "eth0", "state": {"link_state": "LINK_STATE_UP"}},
-            {"id": "eth1", "name": "eth1", "state": {"link_state": "LINK_STATE_DOWN"}},
-        ]
+    coord.state = MagicMock()
+    coord.state.get_interface = AsyncMock(
+        return_value={"eth0": {"name": "eth0", "link_up": True}}
     )
-    await coord._query_interfaces()
+    await coord.get_interface()
     assert coord.ds["interface"]["eth0"]["link_up"] is True
-    assert coord.ds["interface"]["eth1"]["link_up"] is False
 
 
 # ---------------------------
-#   get_systemstats family
+#   get_systemstats
 # ---------------------------
-def test_select_stat_graph_names_includes_interface_when_present() -> None:
+# The netdata-graph fetching/parsing these tests used to exercise directly
+# now lives in and is tested by aiotruenas's own TrueNASState.get_systemstats(),
+# which mutates ds["system_info"]/ds["interface"] in place as a documented
+# side effect. get_systemstats just delegates, so this only needs to lock in
+# that plumbing.
+async def test_get_systemstats_delegates_to_state() -> None:
     coord = _bare_coordinator()
-    coord.ds = {"interface": {"eth0": {}}}
-    coord._is_virtual = False
-    coord._systemstats_errored = {}
-    names = coord._select_stat_graph_names()
-    assert "interface" in names
-    assert "cputemp" in names
-
-
-def test_select_stat_graph_names_removes_cputemp_for_virtual() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {}}
-    coord._is_virtual = True
-    coord._systemstats_errored = {}
-    names = coord._select_stat_graph_names()
-    assert "cputemp" not in names
-    assert "interface" not in names
-
-
-def test_select_stat_graph_names_filters_cooldown_graphs() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {}}
-    coord._is_virtual = False
-    coord._systemstats_errored = {"cpu": datetime.now(UTC)}
-    coord._systemstats_error_cooldown = timedelta(minutes=10)
-    names = coord._select_stat_graph_names()
-    assert "cpu" not in names
-
-
-async def test_fetch_stat_graphs_collects_and_records_failures() -> None:
-    coord = _bare_coordinator()
-    coord.host = "truenas.local"
-    coord._systemstats_errored = {}
-    coord.api = MagicMock()
-    coord.api.query = AsyncMock(side_effect=[[{"name": "load"}], None])
-    result = await coord._fetch_stat_graphs(["load", "cpu"], {"start": 0, "end": 1})
-    assert result == [{"name": "load"}]
-    assert "cpu" in coord._systemstats_errored
-
-
-def test_record_failed_graphs_logs_only_new_failures(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    coord = _bare_coordinator()
-    coord.host = "truenas.local"
-    coord._systemstats_errored = {"cpu": datetime.now(UTC)}
-    with caplog.at_level("WARNING"):
-        coord._record_failed_graphs(["cpu", "memory"])
-    assert "memory" in caplog.text
-    assert coord._systemstats_errored.keys() == {"cpu", "memory"}
-
-
-def test_record_failed_graphs_noop_for_empty_list() -> None:
-    coord = _bare_coordinator()
-    coord._systemstats_errored = {}
-    coord._record_failed_graphs([])
-    assert coord._systemstats_errored == {}
-
-
-def test_process_system_stat_dispatches_by_name() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}, "interface": {}}
-    # Missing "aggregations"/"legend" fails the isinstance guard in
-    # _systemstats_process, so it falls back to _store_stat_defaults, which
-    # routes through _store_stat_value the same as a successful value would.
-    coord._process_system_stat({"name": "load"})
-    assert coord.ds["system_info"]["load_shortterm"] == 0.0
-
-
-def test_process_system_stat_ignores_missing_name() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._process_system_stat({})  # must not raise
-
-
-def test_process_system_stat_dispatches_cputemp() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    item = {"name": "cputemp", "aggregations": {"mean": {"core0": 40.0}}}
-    with patch.object(coord, "_process_cputemp") as mock:
-        coord._process_system_stat(item)
-    mock.assert_called_once_with(item)
-
-
-def test_process_system_stat_dispatches_cpu_and_rounds_usage() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._process_system_stat({"name": "cpu"})
-    # No aggregations/legend -> _store_stat_defaults zeroes cpu_cpu, which then
-    # feeds cpu_usage.
-    assert coord.ds["system_info"]["cpu_usage"] == pytest.approx(0.0)
-
-
-def test_process_system_stat_dispatches_interface_for_known_identifier() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}, "interface": {"eth0": {}}}
-    coord._process_system_stat(
-        {"name": "interface", "identifier": "eth0", "legend": "not-a-list"}
-    )
-    assert coord.ds["interface"]["eth0"]["rx"] == 0.0
-    assert coord.ds["interface"]["eth0"]["tx"] == 0.0
-
-
-def test_process_system_stat_ignores_interface_for_unknown_identifier() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}, "interface": {}}
-    coord._process_system_stat({"name": "interface", "identifier": "eth99"})
-    assert coord.ds["interface"] == {}
-
-
-def test_process_system_stat_dispatches_memory() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {"physmem": 1000}}
-    coord._process_system_stat(
-        {
-            "name": "memory",
-            "legend": ["available"],
-            "aggregations": {"mean": {"available": 250.0}},
-        }
-    )
-    assert coord.ds["system_info"]["memory-free_value"] == 250
-
-
-def test_process_system_stat_dispatches_arcsize() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._process_system_stat(
-        {
-            "name": "arcsize",
-            "legend": ["size"],
-            "aggregations": {"mean": {"size": 12.345}},
-        }
-    )
-    assert coord.ds["system_info"]["cache_size-arc_value"] == pytest.approx(12.35)
-
-
-def test_process_system_stat_dispatches_unknown_name() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord.host = "truenas.local"
-    coord._unknown_system_stat_names = set()
-    coord._process_system_stat({"name": "weird_stat"})
-    assert "weird_stat" in coord._unknown_system_stat_names
-
-
-def test_process_cputemp_stores_max_mean() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._process_cputemp({"aggregations": {"mean": {"core0": 40.0, "core1": 45.0}}})
-    assert coord.ds["system_info"]["cpu_temperature"] == 45.0
-
-
-def test_process_cputemp_none_when_no_valid_means() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {}}
-    coord._process_cputemp({"aggregations": {"mean": {}}})
-    assert coord.ds["system_info"]["cpu_temperature"] is None
-
-
-def test_process_memory_stat_computes_usage_percent() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"system_info": {"physmem": 1000}}
-    coord._process_memory_stat(
-        {"legend": ["available"], "aggregations": {"mean": {"available": 250.0}}}
-    )
-    assert coord.ds["system_info"]["memory-total_value"] == 1000
-    assert coord.ds["system_info"]["memory-free_value"] == 250
-    assert coord.ds["system_info"]["memory-usage_percent"] == 75
-
-
-def test_handle_unknown_stat_logs_once_and_detects_near_miss(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    coord = _bare_coordinator()
-    coord.host = "truenas.local"
-    coord._unknown_system_stat_names = set()
-    with caplog.at_level("DEBUG"):
-        coord._handle_unknown_stat("cpu_usage")
-        coord._handle_unknown_stat("cpu_usage")
-    assert caplog.text.count("unknown system stat graph name") == 1
-
-
-def test_process_system_stat_interface_updates_rx_tx() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {"eth0": {}}}
-    item = {
-        "legend": ["received", "sent"],
-        "aggregations": {"mean": {"received": 100.0, "sent": 50.0}},
-    }
-    coord._process_system_stat_interface(item, "eth0")
-    assert coord.ds["interface"]["eth0"]["rx"] > 0
-    assert coord.ds["interface"]["eth0"]["tx"] > 0
-
-
-def test_process_system_stat_interface_zeroes_on_invalid_legend() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {"eth0": {}}}
-    coord._process_system_stat_interface({"legend": "not-a-list"}, "eth0")
-    assert coord.ds["interface"]["eth0"]["rx"] == 0.0
-    assert coord.ds["interface"]["eth0"]["tx"] == 0.0
-
-
-def test_process_system_stat_interface_zeroes_when_mean_not_dict() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {"eth0": {}}}
-    item = {
-        "legend": ["received", "sent"],
-        "aggregations": {"mean": "not-a-dict"},
-    }
-    coord._process_system_stat_interface(item, "eth0")
-    assert coord.ds["interface"]["eth0"]["rx"] == 0.0
-    assert coord.ds["interface"]["eth0"]["tx"] == 0.0
-
-
-async def test_get_systemstats_returns_early_without_graph_names() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {}}
-    coord._is_virtual = True
-    coord._systemstats_errored = {
-        name: datetime.now(UTC) for name in ("load", "cpu", "arcsize", "memory")
-    }
-    coord._systemstats_error_cooldown = timedelta(minutes=10)
-    coord.config_entry = MagicMock()
-    coord.config_entry.options = {}
-    coord.api = MagicMock()
-    coord.api.query = AsyncMock()
+    coord.state = MagicMock()
+    coord.state.get_systemstats = AsyncMock(return_value={})
     await coord.get_systemstats()
-    coord.api.query.assert_not_awaited()
-
-
-async def test_get_systemstats_returns_when_fetch_yields_no_graphs() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {}, "system_info": {}}
-    coord._is_virtual = True
-    coord._systemstats_errored = {}
-    coord.host = "truenas.local"
-    coord.config_entry = MagicMock()
-    coord.config_entry.options = {}
-    coord.api = MagicMock()
-    coord.api.query = AsyncMock(return_value=None)
-    await coord.get_systemstats()
-    assert coord.ds["system_info"] == {}
-
-
-async def test_get_systemstats_processes_returned_graphs() -> None:
-    coord = _bare_coordinator()
-    coord.ds = {"interface": {}, "system_info": {}}
-    coord._is_virtual = True
-    coord._systemstats_errored = {}
-    coord.config_entry = MagicMock()
-    coord.config_entry.options = {}
-    coord.api = MagicMock()
-    coord.api.query = AsyncMock(return_value=[{"name": "load"}])
-    await coord.get_systemstats()
-    assert coord.ds["system_info"]["load_shortterm"] == 0.0
+    coord.state.get_systemstats.assert_awaited_once()
 
 
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1931,10 +1931,27 @@ async def test_get_interface_delegates_to_state() -> None:
 # that plumbing.
 async def test_get_systemstats_delegates_to_state() -> None:
     coord = _bare_coordinator()
+    system_info = {"cpu_usage": 0}
+    interface = {"eth0": {"rx": 0}}
+    coord.ds = {"system_info": system_info, "interface": interface}
+
+    def _mutate_in_place() -> dict[str, object]:
+        system_info["cpu_usage"] = 42
+        interface["eth0"]["rx"] = 123
+        return {}
+
     coord.state = MagicMock()
-    coord.state.get_systemstats = AsyncMock(return_value={})
+    coord.state.get_systemstats = AsyncMock(side_effect=_mutate_in_place)
     await coord.get_systemstats()
     coord.state.get_systemstats.assert_awaited_once()
+    # get_systemstats() has no coordinator-side logic of its own, so the only
+    # thing worth locking in here is that it doesn't clobber ds["system_info"]/
+    # ds["interface"] with its own return value -- the mutate-in-place contract
+    # from TrueNASState is what actually updates them.
+    assert coord.ds["system_info"] is system_info
+    assert coord.ds["interface"] is interface
+    assert system_info["cpu_usage"] == 42
+    assert interface["eth0"]["rx"] == 123
 
 
 # ---------------------------


### PR DESCRIPTION
## Proposed change
Batch 5 of the interface/systeminfo/systemstats migration to aiotruenas's `TrueNASState` domain layer: `coordinator.get_systemstats()` now delegates entirely to `self.state.get_systemstats()` instead of running its own local `_fetch_stat_graphs`/`_store_stat_value` parallel-fetch implementation (the PR #118 fix). That logic now lives in and is tested by aiotruenas itself.

This requires bumping `aiotruenas` to `>=1.4.2`, which fixes a regression where 1.4.1's `TrueNASState.get_systemstats()` fetched stat graphs serially instead of in parallel.

## Type of change
- [x] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Verified live against a real TrueNAS instance: after deploying and restarting Home Assistant, `truenas_ce` set up cleanly with no errors in the log, and CPU/load sensors continued updating correctly on the normal 60s poll interval.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

## Summary by Sourcery

Migrate system information, interface, and statistics polling to aiotruenas’s TrueNASState domain layer while preserving coordinator-specific state and diagnostics.

Bug Fixes:
- Delegate system statistics collection to aiotruenas’s TrueNASState layer, preserving parallel polling and improving stale-graph visibility through the updated dependency.

Enhancements:
- Move system information and interface retrieval, parsing, virtualization detection, uptime handling, and statistics processing into aiotruenas while retaining coordinator-owned update and SMB state.

Build:
- Bump the aiotruenas dependency requirement to version 1.4.2 or newer.

Tests:
- Update coordinator tests to cover delegation, state preservation, interface initialization, and stale-statistics warning and recovery behavior.