### PR TITLE
fix: move CONF_DATA_UNIT from config-entry data to options

### DIFF
--- a/custom_components/truenas_ce/config_flow.py
+++ b/custom_components/truenas_ce/config_flow.py
@@ -540,10 +540,22 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Save instance
         if not errors:
+            # The data-unit display preference isn't needed to connect, so it
+            # belongs in options (mutable later via the options flow) rather
+            # than the connection data. truenas_config[CONF_DATA_UNIT] already
+            # reflects the right precedence -- prefilled from the legacy
+            # entry's options/data by async_step_migrate_import, then
+            # overridden by whatever the user actually submitted -- so it
+            # always wins over the legacy entry's other, unrelated options.
+            data = {k: v for k, v in truenas_config.items() if k != CONF_DATA_UNIT}
+            options = dict(self._legacy_options)
+            options[CONF_DATA_UNIT] = truenas_config.get(
+                CONF_DATA_UNIT, DEFAULT_DATA_UNIT
+            )
             return self.async_create_entry(
                 title=truenas_config[CONF_NAME],
-                data=truenas_config,
-                options=self._legacy_options or None,
+                data=data,
+                options=options,
             )
         return None
 
@@ -670,7 +682,10 @@ class TrueNASConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_CRONJOB_SKIP_DISABLED: legacy.data.get(
                         CONF_CRONJOB_SKIP_DISABLED, DEFAULT_CRONJOB_SKIP_DISABLED
                     ),
-                    CONF_DATA_UNIT: legacy.data.get(CONF_DATA_UNIT, DEFAULT_DATA_UNIT),
+                    CONF_DATA_UNIT: legacy.options.get(
+                        CONF_DATA_UNIT,
+                        legacy.data.get(CONF_DATA_UNIT, DEFAULT_DATA_UNIT),
+                    ),
                 }
             )
             self._legacy_options = dict(legacy.options)
@@ -847,7 +862,16 @@ class TrueNASOptionsFlow(OptionsFlowWithReload):
         if user_input is not None:
             return self.async_create_entry(data=user_input)
 
+        # A pre-existing entry may still carry CONF_DATA_UNIT only in .data
+        # (from before it moved to .options); fall back to it here so the
+        # form shows the entry's actual current preference instead of
+        # silently reverting it to DEFAULT_DATA_UNIT on the next save.
+        options = dict(self.config_entry.options)
+        options.setdefault(
+            CONF_DATA_UNIT,
+            self.config_entry.data.get(CONF_DATA_UNIT, DEFAULT_DATA_UNIT),
+        )
         return self.async_show_form(
             step_id="init",
-            data_schema=_options_schema(self.config_entry.options),
+            data_schema=_options_schema(options),
         )

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -127,6 +127,11 @@ async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "TrueNAS"
     assert result["data"][CONF_HOST] == "truenas.example.com"
+    # The data-unit display preference isn't needed to connect, so it belongs
+    # in options (mutable later via the options flow) rather than the
+    # immutable connection data.
+    assert CONF_DATA_UNIT not in result["data"]
+    assert result["options"][CONF_DATA_UNIT] == DEFAULT_DATA_UNIT
 
 
 async def test_user_flow_creates_entry_with_system_id_as_unique_id(
@@ -662,7 +667,49 @@ async def test_migrate_import_prefills_and_creates_entry(hass: HomeAssistant) ->
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == "legacy.example.com"
-    assert result["options"] == {CONF_POLL_INTERVAL: "30"}
+    # The legacy entry never had CONF_DATA_UNIT in its own options, so the
+    # value just submitted through the migration form is carried over there.
+    assert CONF_DATA_UNIT not in result["data"]
+    assert result["options"] == {CONF_POLL_INTERVAL: "30", CONF_DATA_UNIT: "GB"}
+
+
+@pytest.mark.usefixtures("_mock_connection_ok")
+async def test_migrate_import_defaults_data_unit_from_legacy_options(
+    hass: HomeAssistant,
+) -> None:
+    """The migration form's data-unit default reflects a value already
+    customized via the legacy entry's own options flow, not the (possibly
+    stale) value in its connection data -- and an explicit choice made
+    during migration always wins over whatever the legacy entry had stored.
+    """
+    MockConfigEntry(
+        domain=LEGACY_DOMAIN,
+        data=_legacy_entry().data,  # CONF_DATA_UNIT: "GB" here
+        options={CONF_POLL_INTERVAL: "30", CONF_DATA_UNIT: "GiB"},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "migrate_import"}
+    )
+    defaults = result["data_schema"]({})
+    assert defaults[CONF_DATA_UNIT] == "GiB"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "TrueNAS",
+            CONF_HOST: "legacy.example.com",
+            CONF_API_KEY: "old-key",
+            CONF_VERIFY_SSL: True,
+            CONF_CRONJOB_SKIP_DISABLED: False,
+            CONF_DATA_UNIT: "GB",
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["options"][CONF_DATA_UNIT] == "GB"
 
 
 @pytest.mark.usefixtures("_mock_connection_ok")
@@ -916,3 +963,22 @@ async def test_options_flow_updates_entry(hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == new_options
+
+
+async def test_options_flow_defaults_data_unit_from_legacy_data(
+    hass: HomeAssistant,
+) -> None:
+    """A pre-existing entry with CONF_DATA_UNIT only in .data (from before it
+    moved to .options) still shows its actual current preference in the
+    options form, instead of silently reverting to DEFAULT_DATA_UNIT the
+    moment the user saves any other, unrelated option.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=_user_input(**{CONF_DATA_UNIT: "GB"}), options={}
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    defaults = result["data_schema"]({})
+    assert defaults[CONF_DATA_UNIT] == "GB"


### PR DESCRIPTION
## Proposed change

The data-unit display preference (`CONF_DATA_UNIT`, GB vs GiB) isn't needed to establish the TrueNAS connection, so it belongs in the config entry's `options` (mutable later via the options flow) rather than the immutable connection `data`.

This applies the same `options.get(..., data.get(..., DEFAULT))` fallback precedence consistently across three places:
- Initial entry creation (`async_step_...` final step): now writes `CONF_DATA_UNIT` into `options` instead of `data`.
- The legacy-import migration step: prefers the legacy entry's `options` value over its `data` value when prefilling.
- The options-flow form default: falls back to a pre-existing entry's `data` value if `options` doesn't have it yet, so entries created before this fix keep showing their actual current preference instead of silently reverting to the default on next save.

This mirrors the identical fix already staged for the `ha-core` fork's Home Assistant Core PR #179103 review (Copilot Finding #6), keeping this repo and the `ha-core` fork aligned rather than reintroducing a divergence that was already cleaned up once.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Verified end-to-end on a live HA test instance before opening this PR: synced the changed integration code, restarted Home Assistant via MCP, waited for it to come back up, then confirmed via `error_log`/`system` logs (zero errors/tracebacks), `ha_get_integration` (config entry `state: loaded`, `options.data_unit == "GiB"` correctly resolved from a pre-existing entry), and a spot-check of live `sensor.truenas_*` entity states (all valid, non-`unknown`).

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Move the data-unit display preference to config-entry options while preserving existing users’ settings across migration and options flows.

Bug Fixes:
- Store the TrueNAS data-unit display preference in mutable config-entry options instead of connection data.
- Preserve data-unit preferences during legacy imports and options-flow updates, including entries created before the preference moved to options.

Tests:
- Add config-flow coverage for new-entry storage, legacy-option precedence, migration overrides, and backward-compatible options defaults.