### PR TITLE
ci: add OSV-Scanner dependency-vulnerability scan

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,45 @@
+name: OSV-Scanner
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'Pipfile.lock'
+      - '.github/workflows/osv-scanner.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'Pipfile.lock'
+      - '.github/workflows/osv-scanner.yml'
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  scan-scheduled:
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67" # v2.5.1
+    with:
+      # Pipfile.lock's `develop` section pins ~130 dev/test-only transitive deps
+      # (the full homeassistant chain) that we can't bump without breaking pinned
+      # test tooling. Unlike scan-pr (which diffs old/new and only fails on newly
+      # introduced vulns), this reusable workflow has no baseline to diff against
+      # and would fail on any pre-existing advisory in that tree. Report to the
+      # Security tab instead of failing the build; scan-pr still gates merges.
+      fail-on-vuln: false
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67" # v2.5.1


### PR DESCRIPTION
## Proposed change
Add Google's official OSV-Scanner reusable-workflow dependency-vulnerability scan (`google/osv-scanner-action@v2.5.1`, SHA-pinned) as a new `.github/workflows/osv-scanner.yml`.

Two jobs, wired against the already-committed `Pipfile.lock` (a natively supported OSV-Scanner lockfile format):
- `scan-pr` (`osv-scanner-reusable-pr.yml`), on `pull_request`: diffs old vs. new lockfile state and fails only on newly introduced vulnerabilities. This gates merges.
- `scan-scheduled` (`osv-scanner-reusable.yml`), on `push` to `master` / weekly cron / `workflow_dispatch`: reports all findings to the Security tab. `fail-on-vuln: false` here, since this reusable workflow has no baseline to diff against and would otherwise fail on any pre-existing advisory in `Pipfile.lock`'s `develop` section (~130 dev/test-only transitive deps, the full `homeassistant` chain) that can't always be bumped without breaking pinned test tooling.

Both jobs use least-privilege `permissions:` (`actions: read`, `contents: read`, `security-events: write`), matching this repo's existing CI-hygiene convention.

No changes needed for mypy type-checking — `ci.yml` already runs a blocking, strict mypy job, which exceeds what was being considered.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
- SHA pin (`6e4298ebc4db23e847df9b2e2de2939d6f066c67`) verified against the GitHub API as the correct commit for tag `v2.5.1`.
- Verified live against `api.osv.dev` that the exact locked runtime versions (`aiotruenas==1.4.1`, `websockets==17.1`) have no open advisories, so the first scan should pass cleanly.
- Reviewed with `pr-review-toolkit:code-reviewer` and `pr-review-toolkit:silent-failure-hunter` in parallel; the `fail-on-vuln: false` mitigation above was a real finding from that review, independently verified against the upstream reusable-workflow source before being applied.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add automated OSV-Scanner checks to detect dependency vulnerabilities without blocking builds on pre-existing advisories.

New Features:
- Add OSV-Scanner dependency vulnerability scanning for pull requests, scheduled runs, pushes to master, and manual dispatches.

Enhancements:
- Gate pull requests on newly introduced vulnerabilities while reporting existing findings from scheduled scans to the Security tab.

CI:
- Pin the OSV-Scanner reusable workflows to a verified commit and apply least-privilege permissions.