### PR TITLE
fix: harden hostname sentinel check, entity availability, and cron dom/dow OR-semantics

### DIFF
--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -525,8 +525,8 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hostname = self.ds["system_info"].get("hostname", "unknown")
             if not isinstance(hostname, str) or not hostname or hostname == "unknown":
                 raise UpdateFailed(
-                    "Essential system information (hostname) was not received"
-                    " from TrueNAS"
+                    "Essential system information (hostname) was missing, empty,"
+                    " or invalid in the response from TrueNAS"
                 )
 
             await _run_job(self.get_interface)

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -513,14 +513,17 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # retried setup instead of a crash. Checking mere key-presence is
             # not enough: TrueNASState.get_systeminfo() runs its raw response
             # through parse_api's ensure_vals, which backfills a "hostname":
-            # "unknown" default whenever TrueNAS returns a dict-shaped but
-            # incomplete response -- so the key is always present after any
-            # dict-shaped reply, successful or not. Checking the sentinel
-            # value itself catches that case too. Accepted residual risk: a
-            # host actually named "unknown" would collide with the sentinel
-            # and fail every poll -- judged not worth a second-field check
-            # for a name TrueNAS itself never assigns by default.
-            if self.ds["system_info"].get("hostname", "unknown") == "unknown":
+            # "unknown" default -- but only when the key is absent entirely;
+            # a dict-shaped reply that explicitly sends "hostname": null or ""
+            # keeps that literal value instead of being backfilled, so the
+            # sentinel check alone would miss it. Rejecting any falsy/non-str
+            # value (not just the sentinel) catches both cases. Accepted
+            # residual risk: a host actually named "unknown" would collide
+            # with the sentinel and fail every poll -- judged not worth a
+            # second-field check for a name TrueNAS itself never assigns by
+            # default.
+            hostname = self.ds["system_info"].get("hostname", "unknown")
+            if not isinstance(hostname, str) or not hostname or hostname == "unknown":
                 raise UpdateFailed(
                     "Essential system information (hostname) was not received"
                     " from TrueNAS"

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -510,8 +510,17 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # socket). register_system_device() indexes "hostname" out of it
             # right after the first refresh, so failing fast here -- instead of
             # returning ds with that key missing -- is what turns this into a
-            # retried setup instead of a crash.
-            if "hostname" not in self.ds["system_info"]:
+            # retried setup instead of a crash. Checking mere key-presence is
+            # not enough: TrueNASState.get_systeminfo() runs its raw response
+            # through parse_api's ensure_vals, which backfills a "hostname":
+            # "unknown" default whenever TrueNAS returns a dict-shaped but
+            # incomplete response -- so the key is always present after any
+            # dict-shaped reply, successful or not. Checking the sentinel
+            # value itself catches that case too. Accepted residual risk: a
+            # host actually named "unknown" would collide with the sentinel
+            # and fail every poll -- judged not worth a second-field check
+            # for a name TrueNAS itself never assigns by default.
+            if self.ds["system_info"].get("hostname", "unknown") == "unknown":
                 raise UpdateFailed(
                     "Essential system information (hostname) was not received"
                     " from TrueNAS"

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -982,10 +982,10 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         """Refresh cached data from the coordinator for this entity."""
         data = self.coordinator.data.get(self.entity_description.data_path or "", {})
         self._data: dict[str, Any] = data.get(self._uid, {}) if self._uid else data
-        if self._uid and not self._data:
+        if not self._data:
             _LOGGER.debug(
-                "Data for UID %s is missing or empty in %s",
-                self._uid,
+                "Data for %s is missing or empty in %s",
+                self._uid if self._uid else "keyless entity",
                 self.entity_description.data_path,
             )
 

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -996,28 +996,32 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
 
     @property
     def available(self) -> bool:
-        """Return False once this entity's referenced object is gone.
+        """Return False once this entity's backing data is gone or empty.
 
-        ``_refresh_data`` falls back to an empty dict when a referenced
-        ``self._uid`` no longer has a matching entry in the coordinator's
-        data -- e.g. the disk/dataset/VM/container/pool was deleted, the
-        whole ``data_path`` came back empty on a transient fetch, or (for
-        the event-pushed ``app_stats`` domain) the first stats push for a
-        just-discovered app hasn't arrived yet. The base
-        ``CoordinatorEntity.available`` only checks ``last_update_success``,
-        so without this override such an entity would keep reporting
-        available with stale/empty state. ``_cleanup_orphaned_entities`` runs
-        in this same refresh cycle (it's the first statement of the
-        dispatcher callback that update_controller registers), but only
-        removes entities outright once their uid stops being referenced at
-        all -- this override is what makes a still-registered-but-currently-
-        gone entity report unavailable immediately rather than waiting on
-        that removal. Subclasses that already override ``available`` for a
-        more specific reason (e.g. the app network sensor's "stale" check)
-        still chain through ``super()``, so this applies underneath those
-        too.
+        ``_refresh_data`` falls back to an empty dict both for a referenced
+        ``self._uid`` that no longer has a matching entry in the
+        coordinator's data (e.g. the disk/dataset/VM/container/pool was
+        deleted, or -- for the event-pushed ``app_stats`` domain -- the
+        first stats push for a just-discovered app hasn't arrived yet) and,
+        for a keyless entity, when the whole ``data_path`` came back empty
+        on a transient fetch failure. Checking ``self._data`` alone (instead
+        of only when ``self._uid`` is set) covers both: for a uid'd entity
+        ``self._data`` is that uid's own sub-dict, for a keyless one it's
+        the entire data_path dict, so emptiness means the same thing in
+        both cases. The base ``CoordinatorEntity.available`` only checks
+        ``last_update_success``, so without this override such an entity
+        would keep reporting available with stale/empty state.
+        ``_cleanup_orphaned_entities`` runs in this same refresh cycle (it's
+        the first statement of the dispatcher callback that
+        update_controller registers), but only removes entities outright
+        once their uid stops being referenced at all -- this override is
+        what makes a still-registered-but-currently-gone entity report
+        unavailable immediately rather than waiting on that removal.
+        Subclasses that already override ``available`` for a more specific
+        reason (e.g. the app network sensor's "stale" check) still chain
+        through ``super()``, so this applies underneath those too.
         """
-        return super().available and not (self._uid and not self._data)
+        return super().available and bool(self._data)
 
     def _core_name_translation_key(self) -> str | None:
         """Return Entity._name_translation_key, degrading gracefully.

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -994,6 +994,31 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
         self._refresh_data()
         super()._handle_coordinator_update()
 
+    @property
+    def available(self) -> bool:
+        """Return False once this entity's referenced object is gone.
+
+        ``_refresh_data`` falls back to an empty dict when a referenced
+        ``self._uid`` no longer has a matching entry in the coordinator's
+        data -- e.g. the disk/dataset/VM/container/pool was deleted, the
+        whole ``data_path`` came back empty on a transient fetch, or (for
+        the event-pushed ``app_stats`` domain) the first stats push for a
+        just-discovered app hasn't arrived yet. The base
+        ``CoordinatorEntity.available`` only checks ``last_update_success``,
+        so without this override such an entity would keep reporting
+        available with stale/empty state. ``_cleanup_orphaned_entities`` runs
+        in this same refresh cycle (it's the first statement of the
+        dispatcher callback that update_controller registers), but only
+        removes entities outright once their uid stops being referenced at
+        all -- this override is what makes a still-registered-but-currently-
+        gone entity report unavailable immediately rather than waiting on
+        that removal. Subclasses that already override ``available`` for a
+        more specific reason (e.g. the app network sensor's "stale" check)
+        still chain through ``super()``, so this applies underneath those
+        too.
+        """
+        return super().available and not (self._uid and not self._data)
+
     def _core_name_translation_key(self) -> str | None:
         """Return Entity._name_translation_key, degrading gracefully.
 

--- a/custom_components/truenas_ce/sensor.py
+++ b/custom_components/truenas_ce/sensor.py
@@ -868,7 +868,11 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
         step/range/list value on any field, a pinned `month`, or an
         all-wildcard schedule (minute included -- a genuine Hourly preset
         always pins minute to its run time) falls outside every known preset
-        and is left unclassified rather than guessed at.
+        and is left unclassified rather than guessed at. Standard cron
+        OR-semantics also apply when `dom` and `dow` are pinned at the same
+        time: the job then runs on either match, not just monthly on the
+        `dom` days, so that combination isn't a real preset either and is
+        left unclassified rather than mislabeled "Monthly".
         """
         schedule = self._data.get("schedule") if self._data else None
         if not isinstance(schedule, dict) or not schedule:
@@ -884,9 +888,13 @@ class TrueNASSnapshotTaskSensor(TrueNASSensor):
             return None
         if _is_pinned_schedule_field(month):
             return None
-        if _is_pinned_schedule_field(dom):
+        dom_pinned = _is_pinned_schedule_field(dom)
+        dow_pinned = _is_pinned_schedule_field(dow)
+        if dom_pinned and dow_pinned:
+            return None
+        if dom_pinned:
             return _SCHEDULE_LABEL_MONTHLY
-        if _is_pinned_schedule_field(dow):
+        if dow_pinned:
             return _SCHEDULE_LABEL_WEEKLY
         if _is_pinned_schedule_field(hour):
             return _SCHEDULE_LABEL_DAILY

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1449,6 +1449,28 @@ async def test_async_update_data_raises_when_hostname_is_unknown_sentinel() -> N
     coord.get_pool.assert_not_awaited()
 
 
+async def test_async_update_data_raises_when_hostname_is_none_or_empty() -> None:
+    """A dict-shaped reply that explicitly sends "hostname": null/"" keeps that
+    literal value instead of being backfilled by ensure_vals (which only
+    fills in a default when the key is absent entirely) -- so it must be
+    rejected on top of the "unknown" sentinel, not just equality-checked.
+    """
+    for bad_hostname in (None, ""):
+        coord = _bare_coordinator()
+        coord.api = MagicMock()
+        coord.api.connected = MagicMock(return_value=True)
+        coord._async_ensure_connected = AsyncMock()
+        _stub_all_jobs(coord)
+        coord.ds = {"system_info": {"hostname": bad_hostname}}
+
+        with pytest.raises(coordinator_module.UpdateFailed):
+            await coord._async_update_data()
+
+        coord.get_systeminfo.assert_awaited_once()
+        coord.get_interface.assert_not_awaited()
+        coord.get_pool.assert_not_awaited()
+
+
 # ---------------------------
 #   Orphaned statistics / migration rollback lifecycle
 # ---------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1425,6 +1425,30 @@ async def test_async_update_data_raises_when_system_info_missing() -> None:
     coord.get_pool.assert_not_awaited()
 
 
+async def test_async_update_data_raises_when_hostname_is_unknown_sentinel() -> None:
+    """A backfilled "unknown" hostname (ensure_vals default) must fail too.
+
+    Distinct from test_async_update_data_raises_when_system_info_missing:
+    here the "hostname" key is present -- as it always is after any
+    dict-shaped reply, thanks to parse_api's ensure_vals default -- but
+    carries the sentinel value that means the field was never actually
+    populated by TrueNAS.
+    """
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord._async_ensure_connected = AsyncMock()
+    _stub_all_jobs(coord)
+    coord.ds = {"system_info": {"hostname": "unknown"}}
+
+    with pytest.raises(coordinator_module.UpdateFailed):
+        await coord._async_update_data()
+
+    coord.get_systeminfo.assert_awaited_once()
+    coord.get_interface.assert_not_awaited()
+    coord.get_pool.assert_not_awaited()
+
+
 # ---------------------------
 #   Orphaned statistics / migration rollback lifecycle
 # ---------------------------

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -366,6 +366,27 @@ def _make_entity(
     return TrueNASEntity(coord, desc, uid)
 
 
+def test_available_keyless_entity_empty_data_path_is_unavailable() -> None:
+    """A keyless entity (no uid) whose whole data_path came back empty on a
+    transient fetch failure must go unavailable too, not just a uid'd one --
+    Sourcery-flagged gap: the old ``self._uid and not self._data`` check
+    short-circuited to True (available) whenever ``self._uid`` was falsy.
+
+    Uses "arc" rather than "system_info" as data_path: ``make_coordinator``
+    always seeds ``ds["system_info"]`` with defaults, so it can never be
+    genuinely empty here.
+    """
+    desc = TrueNASEntityDescription(key="arc_ratio", name="ARC Ratio", data_path="arc")
+    entity = _make_entity(data={}, description=desc)
+    assert entity.available is False
+
+
+def test_available_keyless_entity_populated_data_path_is_available() -> None:
+    desc = TrueNASEntityDescription(key="arc_ratio", name="ARC Ratio", data_path="arc")
+    entity = _make_entity(data={"arc": {"hit_ratio": 0.9}}, description=desc)
+    assert entity.available is True
+
+
 def test_name_static_description_no_uid() -> None:
     entity = _make_entity()
     assert entity.name == "Uptime"

--- a/tests/test_entity_setup.py
+++ b/tests/test_entity_setup.py
@@ -745,7 +745,7 @@ async def test_cleanup_keeps_entities_when_dynamic_domain_is_empty(
 #   async_add_entities (via a real platform-setup pass)
 # ---------------------------
 def _fake_api(extra_responses: dict[str, Any] | None = None) -> SimpleNamespace:
-    """A fake TrueNASAPI returning an empty (but present) system.info payload.
+    """A fake TrueNASAPI returning a minimal but valid system.info payload.
 
     Every other query returns None -- matching the coordinator's normal
     handling of a not-yet-responding TrueNAS -- unless ``extra_responses``
@@ -754,6 +754,12 @@ def _fake_api(extra_responses: dict[str, Any] | None = None) -> SimpleNamespace:
     unconditionally every update regardless of monitored groups, so a caller
     only needs to override the one query it actually cares about; this keeps
     the platform-forward pass real while avoiding any actual network I/O.
+
+    system.info must carry a real "hostname" -- the coordinator's
+    essential-hostname check (see ``TrueNASCoordinator._async_update_data``)
+    treats a dict-shaped reply without one as a failed poll and aborts setup,
+    so an empty payload here would fail these tests before they reach the
+    entity-creation behaviour they actually exercise.
 
     ``Any`` mirrors ``TrueNASAPI.query()``'s own return type -- per-method
     structural types aren't modelled here because production code (see
@@ -765,7 +771,7 @@ def _fake_api(extra_responses: dict[str, Any] | None = None) -> SimpleNamespace:
     async def _query(method: str, *args: object, **kwargs: object) -> Any:
         if method in responses:
             return responses[method]
-        return {} if method == "system.info" else None
+        return {"hostname": "truenas.local"} if method == "system.info" else None
 
     # ``TrueNASState`` (aiotruenas's domain layer) calls ``client.call(...)``
     # directly for migrated endpoints instead of going through

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -514,10 +514,11 @@ def test_snapshottask_name_uses_naming_schema_suffix(
             "tank/data Monthly",
         ),
         (
-            # Contrary to any known TrueNAS preset (both dom and dow pinned);
-            # dom is checked first, so this resolves to Monthly.
+            # Standard cron OR-semantics: dom and dow both pinned means
+            # "either match", not "Monthly on that dom day" -- left
+            # unclassified.
             {"minute": "0", "hour": "0", "dom": "1", "month": "*", "dow": "1"},
-            "tank/data Monthly",
+            "tank/data",
         ),
         (
             # No known preset matches (custom "every 2 hours" schedule) ->


### PR DESCRIPTION
## Proposed change

Three fixes identified by Copilot's automated review on the Home Assistant Core PR (kayl-codes/core#179103), addressing real bugs surfaced during the Bronze-quality-scale downgrade review:

- **`coordinator.py`**: the essential-hostname check only verified the `"hostname"` key was present, not that it held a real value. `parse_api`'s `ensure_vals` always backfills `"hostname": "unknown"` on any dict-shaped-but-incomplete response, so the key is present even when TrueNAS never actually returned a hostname — the old check silently accepted this and let a broken poll cycle proceed. Now checks the sentinel value itself.
- **`entity.py`**: added an `available` override so an entity whose referenced object is gone reports unavailable instead of continuing to show stale/empty state. Covers three cases: the underlying disk/dataset/VM/container/pool was deleted, a `data_path` fetch came back transiently empty, or (for the event-pushed `app_stats` domain) the first stats push for a just-discovered app hasn't arrived yet.
- **`sensor.py`**: `TrueNASSnapshotTaskSensor`'s schedule-preset classification mislabeled a schedule with both `dom` and `dow` pinned as "Monthly". Standard cron OR-semantics treat that combination as "either match", not "run only on that day-of-month" — the combination isn't a real preset and is now left unclassified rather than mislabeled.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Validated locally on a live Home Assistant instance after sync + restart: integration loads cleanly (`state: loaded`), no error-log entries for `truenas_ce`, and the affected sensors (snapshot-task schedule labels, system/ARC sensors) report correct values.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden TrueNAS polling, entity availability, and snapshot-task schedule classification against invalid or ambiguous data.

Bug Fixes:
- Reject incomplete or invalid TrueNAS hostname responses so failed coordinator polls are retried instead of proceeding with unusable system information.
- Report entities as unavailable when their backing data is missing or temporarily empty.
- Avoid labeling cron schedules with both day-of-month and day-of-week constraints as Monthly, respecting cron OR-semantics.

Tests:
- Add coverage for invalid hostname responses, empty keyless entity data, and cron schedules with both DOM and DOW pinned.