### PR TITLE
fix: close API connection when first refresh fails with ConfigEntryNotReady

### DIFF
--- a/custom_components/truenas_ce/__init__.py
+++ b/custom_components/truenas_ce/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -567,7 +567,20 @@ async def async_setup_entry(
 ) -> bool:
     """Set up TrueNAS config entry."""
     coordinator = TrueNASCoordinator(hass, config_entry)
-    await coordinator.async_config_entry_first_refresh()
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady:
+        # _async_ensure_connected() opens the websocket before this failure
+        # point, but runtime_data (which async_unload_entry needs to find the
+        # coordinator) is only set below, after first refresh succeeds -- so a
+        # failed first refresh would otherwise leak the open connection on
+        # every retry. Guard close() itself so a teardown hiccup can't mask
+        # the ConfigEntryNotReady HA needs to see in order to schedule a retry.
+        try:
+            await coordinator.api.close()
+        except Exception:
+            _LOGGER.exception("Error closing TrueNAS connection after failed setup")
+        raise
     config_entry.runtime_data = coordinator
     migrate_entry_identity_namespace(hass, config_entry)
     migrate_legacy_unique_ids(hass, config_entry, coordinator, _ALL_DESCRIPTIONS)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_NAME
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 
 import custom_components.truenas_ce as init_module
 from custom_components.truenas_ce import (
@@ -816,6 +816,59 @@ async def test_async_setup_entry_wires_coordinator_and_platforms() -> None:
     notify_mock.assert_called_once()
     register_device_mock.assert_called_once_with(hass, entry, coordinator)
     assert coordinator.system_device_id is register_device_mock.return_value
+
+
+async def test_async_setup_entry_closes_api_on_first_refresh_failure() -> None:
+    """A failed first refresh must close the websocket, not leak it.
+
+    ``runtime_data`` is only set after first refresh succeeds, so
+    ``async_unload_entry`` can't find the coordinator to close it on retry --
+    the setup path itself must close the connection it opened.
+    """
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=ConfigEntryNotReady("unreachable")
+    )
+    coordinator.api = SimpleNamespace(close=AsyncMock())
+
+    with (
+        patch.object(init_module, "TrueNASCoordinator", return_value=coordinator),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, entry)
+
+    coordinator.api.close.assert_awaited_once()
+    assert not hasattr(entry, "runtime_data")
+
+
+async def test_async_setup_entry_first_refresh_failure_survives_close_error() -> None:
+    """A close() failure during cleanup must not mask ConfigEntryNotReady.
+
+    Swallowing the original exception in favor of whatever close() raises
+    would turn a retryable failure into a hard setup error.
+    """
+    hass = MagicMock()
+    entry = _config_entry(entry_id="e1")
+
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=ConfigEntryNotReady("unreachable")
+    )
+    coordinator.api = SimpleNamespace(
+        close=AsyncMock(side_effect=RuntimeError("teardown boom"))
+    )
+
+    with (
+        patch.object(init_module, "TrueNASCoordinator", return_value=coordinator),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, entry)
+
+    coordinator.api.close.assert_awaited_once()
+    assert not hasattr(entry, "runtime_data")
 
 
 async def test_async_setup_entry_refresh_listener_dispatches_update_signal() -> None:


### PR DESCRIPTION
## Proposed change

`_async_ensure_connected()` can open the TrueNAS websocket before `async_config_entry_first_refresh()` fails. Since `config_entry.runtime_data` (which `async_unload_entry` needs to find the coordinator) is only set after first refresh succeeds, a failed first refresh previously left the connection open on every setup retry.

This wraps the first refresh in `try/except ConfigEntryNotReady` and explicitly closes `coordinator.api` before re-raising. The cleanup `close()` call is itself guarded so a teardown failure can't mask the original `ConfigEntryNotReady`, which Home Assistant needs to see in order to schedule an automatic setup retry.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Found while reviewing the ha-core integration counterpart of this code path. Verified against the installed `aiotruenas` client source that an auth failure (`ConfigEntryAuthFailed`) does not leak a connection today (the client closes its own websocket before that exception propagates), so this fix is scoped to the `ConfigEntryNotReady` path only.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure failed initial TrueNAS setup attempts clean up their API connection without masking retryable configuration errors.

Bug Fixes:
- Close the TrueNAS API connection when the initial config-entry refresh fails with ConfigEntryNotReady, preventing websocket leaks across setup retries.
- Preserve the original ConfigEntryNotReady error when connection cleanup also fails so Home Assistant can schedule a retry.

Tests:
- Add coverage for connection cleanup after an initial refresh failure and for preserving the retryable error when cleanup fails.