### PR TITLE
fix: keep previous snapshot when API source is entirely malformed entries

### DIFF
--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -188,7 +188,10 @@ def parse_api(
     the underlying object (disk, pool, task, app, interface, ...) no longer
     exists, so keeping it would leave a stale entity behind indefinitely.
     See ``_empty_source_result`` for the None-source (query failed) and
-    empty-list-source (nothing left at all) cases.
+    empty-list-source (nothing left at all) cases. A non-empty source made
+    up entirely of malformed (non-dict) entries is treated the same as a
+    None source: it's a parsing failure, not evidence everything was
+    removed, so the previous snapshot is kept instead of pruned.
 
     ``prune=False`` opts out of that dropping for callers that intentionally
     pass a partial ``source`` covering only a subset of ``data`` (e.g. adding
@@ -207,8 +210,70 @@ def parse_api(
         return _empty_source_result(data, key, key_search, vals, source is None)
 
     keymap = generate_keymap(data, key_search)
+    data, seen_uids, any_valid_entry, malformed_count = _apply_source_entries(
+        data,
+        source,
+        key,
+        key_secondary,
+        key_search,
+        keymap,
+        vals,
+        ensure_vals,
+        val_proc,
+        only,
+        skip,
+    )
+    _finalize_prune(
+        data,
+        key,
+        key_search,
+        seen_uids,
+        prune,
+        any_valid_entry,
+        malformed_count,
+        len(source),
+    )
+    return data
+
+
+# ---------------------------
+#   _apply_source_entries
+# ---------------------------
+def _apply_source_entries(
+    data: dict[str, Any],
+    source: list[Any],
+    key: str | None,
+    key_secondary: str | None,
+    key_search: str | None,
+    keymap: dict[Hashable, str] | None,
+    vals: list[ApiValueSpec] | None,
+    ensure_vals: list[ApiValueSpec] | None,
+    val_proc: list[list[dict[str, Any]]] | None,
+    only: list[dict[str, Any]] | None,
+    skip: list[dict[str, Any]] | None,
+) -> tuple[dict[str, Any], set[str], bool, int]:
+    """Apply each source entry to data.
+
+    Returns ``(data, seen_uids, any_valid_entry, malformed_count)``. A
+    malformed (non-dict) entry can't be matched or parsed, so it's skipped
+    before it reaches the only/skip filters or key lookups -- both of which
+    assume a dict and would raise on anything else.
+    """
     seen_uids: set[str] = set()
+    any_valid_entry = False
+    malformed_count = 0
     for entry in source:
+        if not isinstance(entry, dict):
+            malformed_count += 1
+            _LOGGER.debug(
+                "Skipping malformed (non-dict) source entry for key=%r/"
+                "key_search=%r: %r",
+                key,
+                key_search,
+                entry,
+            )
+            continue
+        any_valid_entry = True
         if _should_skip_entry(entry, only, skip):
             continue
 
@@ -222,10 +287,54 @@ def parse_api(
 
         data = _apply_entry(data, entry, uid, vals, ensure_vals, val_proc)
 
-    if prune:
-        _prune_stale_uids(data, key, key_search, seen_uids)
+    return data, seen_uids, any_valid_entry, malformed_count
 
-    return data
+
+# ---------------------------
+#   _finalize_prune
+# ---------------------------
+def _finalize_prune(
+    data: dict[str, Any],
+    key: str | None,
+    key_search: str | None,
+    seen_uids: set[str],
+    prune: bool,
+    any_valid_entry: bool,
+    malformed_count: int,
+    total_entries: int,
+) -> None:
+    """Prune stale uids, or log why pruning was skipped/risky.
+
+    A non-empty source containing zero valid entries is a parsing failure,
+    not confirmation everything was removed -- pruning is skipped so it
+    behaves like the None-source case instead of wiping the previous
+    snapshot. A source with *some* malformed entries still prunes (one valid
+    entry proves the source parsed), but that can't tell a row that merely
+    failed to parse this cycle apart from one that was genuinely removed, so
+    it's logged as a risk rather than silently trusted.
+    """
+    if not prune:
+        return
+    if not any_valid_entry:
+        _LOGGER.warning(
+            "All %d source entries were malformed for key=%r/key_search=%r; "
+            "keeping previous snapshot instead of pruning",
+            total_entries,
+            key,
+            key_search,
+        )
+        return
+    if malformed_count:
+        _LOGGER.warning(
+            "%d of %d source entries were malformed for key=%r/key_search=%r; "
+            "pruning proceeds but may incorrectly drop entries whose row "
+            "failed to parse this cycle",
+            malformed_count,
+            total_entries,
+            key,
+            key_search,
+        )
+    _prune_stale_uids(data, key, key_search, seen_uids)
 
 
 # ---------------------------

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -312,6 +312,42 @@ def test_parse_api_prune_false_keeps_uids_absent_from_partial_source(
     }
 
 
+def test_parse_api_all_malformed_source_with_key_keeps_data(ap: ModuleType) -> None:
+    """A non-empty but entirely malformed response (e.g. [None, None]) is a
+    parsing failure, not proof every object was removed -- must not wipe the
+    previous snapshot the way a genuinely empty list correctly does."""
+    data = {"1": {"name": "pool0"}, "2": {"name": "pool1"}}
+    result = ap.parse_api(data=data, source=[None, "garbage"], key="id")
+    assert result == {"1": {"name": "pool0"}, "2": {"name": "pool1"}}
+
+
+def test_parse_api_partially_malformed_source_still_prunes(ap: ModuleType) -> None:
+    """One valid entry only proves that row parsed -- it says nothing about
+    the other (malformed) rows, so a uid whose row failed to parse this cycle
+    is indistinguishable from one that was genuinely removed and gets pruned
+    just the same. This is a known limitation (see the malformed-entry
+    warning log in parse_api), not a guarantee that this is safe."""
+    data = {"1": {"name": "pool0"}, "2": {"name": "pool1"}}
+    source = [None, {"id": "2", "name": "pool1"}]
+    result = ap.parse_api(data=data, source=source, key="id", vals=[{"name": "name"}])
+    assert result == {"2": {"name": "pool1"}}
+
+
+def test_parse_api_malformed_entry_skipped_before_only_skip_filters(
+    ap: ModuleType,
+) -> None:
+    """A non-dict entry must never reach the only/skip filters -- matches_only
+    and can_skip call entry.get(...) directly and would raise AttributeError
+    on e.g. None, so parsing the rest of the source must not crash."""
+    source = [None, {"name": "keep", "value": "x"}]
+    result = ap.parse_api(
+        source=source,
+        vals=[{"name": "name"}],
+        skip=[{"name": "value", "value": "drop"}],
+    )
+    assert result == {"name": "keep"}
+
+
 def test_parse_api_keyless_source_does_not_prune(ap: ModuleType) -> None:
     """Keyless (single-object) data has no per-uid identity to prune by."""
     result = ap.parse_api(


### PR DESCRIPTION
## Proposed change

`parse_api()` previously treated any non-empty `source` list as proof that everything not seen should be pruned — even when every entry in that list was malformed (non-dict, e.g. from a partial/garbled API response). That silently wiped the entire previous snapshot instead of preserving it, the way the `None`-source ("query failed") case already correctly does.

This PR:
- Adds an isinstance guard so malformed (non-dict) entries are skipped before they reach the `only`/`skip` filters or key lookups (which assume a dict and would otherwise raise).
- Skips pruning when *all* entries in a non-empty source are malformed, treating it like a parsing failure rather than confirmation everything was removed.
- Logs the failure mode instead of swallowing it silently: `debug` per skipped entry, `warning` when pruning is skipped entirely, and `warning` when pruning proceeds despite some malformed entries (a known residual risk — one valid entry proves the source parsed, but can't tell a row that merely failed to parse this cycle apart from one that was genuinely removed).
- Extracts the entry-application loop (`_apply_source_entries`) and the prune decision (`_finalize_prune`) out of `parse_api` to keep its cognitive complexity within the project's limit.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Local review pre-stage (`code-reviewer` + `silent-failure-hunter`) was run against this diff; all findings (a tautological test assertion, missing logging on the malformed-entry path, and a cognitive-complexity regression) were verified against the source and addressed.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent malformed API responses from silently wiping valid snapshots while retaining pruning behavior for successfully parsed data.

Bug Fixes:
- Preserve the previous API snapshot when a non-empty response contains only malformed entries instead of pruning all existing data.
- Skip malformed source entries safely and handle partially malformed responses without raising errors.

Enhancements:
- Add diagnostic logging for skipped malformed entries and for skipped or potentially unsafe pruning.
- Refactor source-entry processing and pruning decisions into dedicated helpers to keep parsing logic maintainable.

Tests:
- Add coverage for entirely malformed responses, partially malformed responses, and malformed entries encountered with filters.