### PR TITLE
chore: bump version to 2.9.0, add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.9.0] — Entity Identity Rework & Core-Review Hardening
+
 ### Fixed
 - **Entity identity, unique IDs and device identifiers reworked to prevent silent
   collisions:** two TrueNAS servers sharing the same display name, or two dataset/app
@@ -34,14 +36,48 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 - **Query errors no longer masked as empty/zero state:** a transient API error now
   preserves the last known good data instead of wiping it. (#106)
 - **Legacy config secrets redacted in migration backup snapshots.** (#104)
+- **State attribute keys are now stable, machine-readable snake_case identifiers**
+  (e.g. `model`, `cpu`) instead of humanized display labels (e.g. `"Model"`,
+  `"CPU"`) — matching Home Assistant's own attribute convention. **This is a
+  breaking change** for any template/automation reading these attributes by name
+  (e.g. `state_attr('sensor.xyz', 'Model')`); switch to the lowercase key
+  (`state_attr('sensor.xyz', 'model')`). (#120)
+- **IPv6 hosts are now correctly bracketed** in the WebSocket connection URL (both
+  manual entry and zeroconf discovery), fixing setup failures against bare IPv6
+  literals. Stat-graph fetches are also now parallelized instead of serial, and a
+  malformed stat-graph response no longer bypasses the type-specific defaulting,
+  leaving the actual sensor stale instead of zeroed. (#118)
+- **The GB/GiB data-unit preference now lives in config-entry options** instead of
+  immutable connection data, so it can actually be changed later via the options
+  flow, and existing entries keep showing their real current preference instead of
+  silently reverting to the default. (#124)
+- **Hardening surfaced during the Home Assistant Core Bronze-quality-scale review:**
+  a broken poll could silently proceed past the essential-hostname check because
+  the sentinel default value ("unknown") was mistaken for a real hostname; entities
+  now correctly report unavailable when their referenced disk/dataset/VM/
+  container/pool/app is gone instead of showing stale or empty state; and a
+  snapshot-task schedule pinning both day-of-month and day-of-week is no longer
+  mislabeled "Monthly" (cron OR-semantics treat that combination as "either
+  match"). (#126)
+- **The TrueNAS API connection is now closed if the very first refresh fails**,
+  preventing a leaked open WebSocket on every setup retry. (#127)
+- **Config-flow timeouts now report a specific "timeout" error** instead of a
+  generic "Unknown error occurred," and malformed non-string date values are
+  normalized consistently with other timestamp fields. (#128)
+- **A TrueNAS API response made up entirely of malformed entries no longer wipes
+  the previous snapshot** — matches the existing "query failed" safety behavior
+  instead of being treated as proof everything was removed. (#129)
 
 ### Changed
 - **Coordinator delegates normalization to `aiotruenas`'s new `TrueNASState` domain
   layer** for 19 endpoints instead of doing it inline — no user-facing behavior change.
   (#116)
+- **System-stats polling also migrated to the TrueNASState domain layer**,
+  completing the interface/system-info/system-stats migration. (#123)
 
 ### Notes
-- Bumps `aiotruenas` to `>=1.4.0` (required for the `TrueNASState` domain layer).
+- Bumps `aiotruenas` to `>=1.4.2` (required for the `TrueNASState` domain layer,
+  plus two follow-up fixes: a send-error deadlock and a parallel-fetch regression).
 
 ## [2.8.0] — Live Push Updates & Migration/Security Hardening
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,12 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 - **Query errors no longer masked as empty/zero state:** a transient API error now
   preserves the last known good data instead of wiping it. (#106)
 - **Legacy config secrets redacted in migration backup snapshots.** (#104)
-- **State attribute keys are now stable, machine-readable snake_case identifiers**
-  (e.g. `model`, `cpu`) instead of humanized display labels (e.g. `"Model"`,
-  `"CPU"`) — matching Home Assistant's own attribute convention. **This is a
-  breaking change** for any template/automation reading these attributes by name
-  (e.g. `state_attr('sensor.xyz', 'Model')`); switch to the lowercase key
-  (`state_attr('sensor.xyz', 'model')`). (#120)
+- **State attribute keys are now generally stable raw API names** (e.g. `model`,
+  `cpu`), with some source keys retaining characters such as hyphens (e.g.
+  `memory-free_value`), instead of humanized display labels (e.g. `"Model"`,
+  `"CPU"`). **This is a breaking change** for any template/automation reading
+  these attributes by name (e.g. `state_attr('sensor.xyz', 'Model')`); use the
+  raw API key (`state_attr('sensor.xyz', 'model')`). (#120)
 - **IPv6 hosts are now correctly bracketed** in the WebSocket connection URL (both
   manual entry and zeroconf discovery), fixing setup failures against bare IPv6
   literals. Stat-graph fetches are also now parallelized instead of serial, and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ mypy                    # strict typing (config in pyproject.toml, scoped to cus
 
 - Ruff's `target-version` stays **py313** (Ruff 0.15.13's `py314` formatter is buggy — it collapses `except (A, B):` into invalid `except A, B:` — so don't bump it until that's fixed upstream). CI itself now runs on **Python 3.14**, because Home Assistant Core requires `>=3.14.2` from release 2026.5.x onward; `homeassistant` is only a test dependency here, but pinning CI below that threshold silently pulled in a stale, pre-3.14 release lacking newer `homeassistant.const` members.
 - CI also runs Home Assistant **hassfest** validation and HACS validation on push/PR.
-- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas>=1.0.0` from PyPI plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
+- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas>=1.4.2` from PyPI plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
 - Bumping the release: `version` in [manifest.json](custom_components/truenas_ce/manifest.json) is the source of truth (`.github/update_version.py` updates it during release).
 - A [.pre-commit-config.yaml](.pre-commit-config.yaml) mirrors the CI Ruff checks locally; run `pre-commit install` once after cloning to enable it.
 

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,7 +15,7 @@
         "aiotruenas>=1.4.2",
         "websockets>=15.0.1"
     ],
-    "version": "2.8.0",
+    "version": "2.9.0",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change
Prepares the v2.9.0 release: bumps `manifest.json`'s version and fills in the `CHANGELOG.md` entries for everything merged since v2.8.0 that wasn't yet documented (entity-identity rework, VM graceful stop, certificate common-name keying, and the hardening picked up during the Home Assistant Core Bronze-quality-scale review — hostname-sentinel check, entity availability, snapshot-task cron semantics, connection cleanup on first-refresh failure, config-flow timeout reporting, and malformed-response handling), and corrects the `aiotruenas` requirement note to `>=1.4.2` (two follow-up bumps landed after the initial `>=1.4.0` entry: a send-error deadlock fix and a parallel stat-fetch regression fix).

No functional/runtime code changes — docs and version metadata only.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information
Follows the same structure as the previous release-prep commit (#102). No README changes were needed for this diff — checked for `aiotruenas`/`data_unit`/options-flow/version references and found nothing outdated.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

Generated with Claude Code

## Summary by Sourcery

Prepare the v2.9.0 release with updated version metadata, dependency requirements, and comprehensive release notes.

Enhancements:
- Document the v2.9.0 entity-identity improvements, API state handling, IPv6 support, data-unit options, and Home Assistant Core hardening updates.

Documentation:
- Add the v2.9.0 changelog covering the entity identity rework, reliability fixes, configuration-flow improvements, and compatibility changes.

Chores:
- Update the integration version to 2.9.0 and require aiotruenas 1.4.2 or newer.