### PR TITLE
fix: TrueNAS 26 service.control fallback and from_entry null-handling

### DIFF
--- a/custom_components/truenas_ce/apiparser.py
+++ b/custom_components/truenas_ce/apiparser.py
@@ -96,9 +96,16 @@ def from_entry(
     max_len: int | None = 255,
     round_digits: int | None = None,
 ) -> Any:
-    """Validate and return value from an API dict."""
+    """Validate and return value from an API dict.
+
+    A JSON ``null`` for a present key resolves to Python ``None``, which is not
+    ``_MISSING`` -- fall back to ``default`` here too so a declared default is
+    honored instead of leaking the raw ``None`` (TrueNAS sends fields such as
+    ``progress/percent`` on ``core.get_jobs`` as ``null`` before a job starts
+    progressing, where the spec's declared default is ``0``, not ``None``).
+    """
     ret = _resolve_source(entry, param)
-    if ret is _MISSING:
+    if ret is _MISSING or ret is None:
         return default
 
     if isinstance(ret, float) and round_digits is not None:

--- a/custom_components/truenas_ce/binary_sensor.py
+++ b/custom_components/truenas_ce/binary_sensor.py
@@ -257,7 +257,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
             )
             return
 
-        await self.coordinator.api.query("service.start", [self._data["service"]])
+        await self._control_service("START")
         self._raise_if_api_error("start")
 
         await self.coordinator.async_refresh()
@@ -278,7 +278,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
             )
             return
 
-        await self.coordinator.api.query("service.stop", [self._data["service"]])
+        await self._control_service("STOP")
         self._raise_if_api_error("stop")
         await self.coordinator.async_refresh()
 
@@ -298,7 +298,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
             )
             return
 
-        await self.coordinator.api.query("service.restart", [self._data["service"]])
+        await self._control_service("RESTART")
         self._raise_if_api_error("restart")
 
         await self.coordinator.async_refresh()
@@ -319,7 +319,7 @@ class TrueNASServiceBinarySensor(TrueNASBinarySensor):
             )
             return
 
-        await self.coordinator.api.query("service.reload", [self._data["service"]])
+        await self._control_service("RELOAD")
         self._raise_if_api_error("reload")
 
         await self.coordinator.async_refresh()

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -871,6 +871,18 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return (self._version_major, self._version_minor) >= (26, 0)
 
     # ---------------------------
+    #   supports_service_control
+    # ---------------------------
+    def supports_service_control(self) -> bool:
+        """Return True if the "service.control" API method is available.
+
+        TrueNAS 26.0 removed the legacy "service.start"/"service.stop"/
+        "service.restart"/"service.reload" methods entirely, replacing them
+        with a single "service.control"(VERB, service) method.
+        """
+        return (self._version_major, self._version_minor) >= (26, 0)
+
+    # ---------------------------
     #   get_updatecheck
     # ---------------------------
     async def get_updatecheck(self) -> None:

--- a/custom_components/truenas_ce/entity.py
+++ b/custom_components/truenas_ce/entity.py
@@ -1211,6 +1211,21 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
                 },
             )
 
+    async def _control_service(self, verb: str) -> None:
+        """Run a service operation, using service.control on TrueNAS 26+.
+
+        TrueNAS 26 removed the legacy "service.<verb>" methods entirely in
+        favour of a single "service.control"(VERB, service) method.
+        """
+        if self.coordinator.supports_service_control():
+            await self.coordinator.api.query(
+                "service.control", [verb, self._data["service"]]
+            )
+        else:
+            await self.coordinator.api.query(
+                f"service.{verb.lower()}", [self._data["service"]]
+            )
+
     async def start(self) -> None:
         """Run function."""
         self._raise_unsupported("start")

--- a/custom_components/truenas_ce/switch.py
+++ b/custom_components/truenas_ce/switch.py
@@ -86,12 +86,14 @@ class TrueNASServiceSwitch(_TrueNASSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self.coordinator.api.query("service.start", [self._data["service"]])
+        await self._control_service("START")
+        self._raise_if_api_error("start")
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self.coordinator.api.query("service.stop", [self._data["service"]])
+        await self._control_service("STOP")
+        self._raise_if_api_error("stop")
         await self.coordinator.async_request_refresh()
 
 

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -93,4 +93,5 @@ def make_coordinator(
         raise_migration_rollback_issue=MagicMock(),
         supports_update_run=MagicMock(return_value=False),
         supports_container_api=MagicMock(return_value=False),
+        supports_service_control=MagicMock(return_value=False),
     )

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -58,6 +58,20 @@ def test_from_entry_nested_path_missing_segment(ap: ModuleType) -> None:
     assert ap.from_entry(entry, "scan/start_time/$date", default="none") == "none"
 
 
+def test_from_entry_null_value_returns_default(ap: ModuleType) -> None:
+    """A present key holding JSON ``null`` must fall back to ``default`` just
+    like a missing key -- TrueNAS sends e.g. app ``memory`` as null when the
+    app is stopped, and the raw None must not leak past the declared default."""
+    assert ap.from_entry({"a": None}, "a", default="fallback") == "fallback"
+
+
+@pytest.mark.parametrize("value", [0, "", False, 0.0])
+def test_from_entry_falsy_non_none_values_pass_through(ap: ModuleType, value) -> None:
+    """Only ``None`` triggers the default fallback -- other falsy values are
+    legitimate data and must be returned as-is."""
+    assert ap.from_entry({"a": value}, "a", default="fallback") == value
+
+
 def test_from_entry_truncates_long_strings(ap: ModuleType) -> None:
     entry = {"a": "x" * 300}
     assert ap.from_entry(entry, "a", max_len=10) == "x" * 10

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -266,9 +266,19 @@ async def test_service_start_not_stopped_returns() -> None:
 
 async def test_service_start_success() -> None:
     svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = False
     svc.coordinator.api.query.side_effect = [[{"state": "STOPPED"}], None]
     await svc.start()
     svc.coordinator.api.query.assert_awaited_with("service.start", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_service_start_success_v26_uses_service_control() -> None:
+    svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = True
+    svc.coordinator.api.query.side_effect = [[{"state": "STOPPED"}], None]
+    await svc.start()
+    svc.coordinator.api.query.assert_awaited_with("service.control", ["START", "ssh"])
     svc.coordinator.async_refresh.assert_awaited_once()
 
 
@@ -281,9 +291,19 @@ async def test_service_stop_not_running_returns() -> None:
 
 async def test_service_stop_success() -> None:
     svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = False
     svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
     await svc.stop()
     svc.coordinator.api.query.assert_awaited_with("service.stop", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_service_stop_success_v26_uses_service_control() -> None:
+    svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = True
+    svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
+    await svc.stop()
+    svc.coordinator.api.query.assert_awaited_with("service.control", ["STOP", "ssh"])
     svc.coordinator.async_refresh.assert_awaited_once()
 
 
@@ -296,9 +316,19 @@ async def test_service_restart_stopped_returns() -> None:
 
 async def test_service_restart_success() -> None:
     svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = False
     svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
     await svc.restart()
     svc.coordinator.api.query.assert_awaited_with("service.restart", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_service_restart_success_v26_uses_service_control() -> None:
+    svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = True
+    svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
+    await svc.restart()
+    svc.coordinator.api.query.assert_awaited_with("service.control", ["RESTART", "ssh"])
     svc.coordinator.async_refresh.assert_awaited_once()
 
 
@@ -311,9 +341,19 @@ async def test_service_reload_stopped_returns() -> None:
 
 async def test_service_reload_success() -> None:
     svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = False
     svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
     await svc.reload()
     svc.coordinator.api.query.assert_awaited_with("service.reload", ["ssh"])
+    svc.coordinator.async_refresh.assert_awaited_once()
+
+
+async def test_service_reload_success_v26_uses_service_control() -> None:
+    svc = _make_service()
+    svc.coordinator.supports_service_control.return_value = True
+    svc.coordinator.api.query.side_effect = [[{"state": "RUNNING"}], None]
+    await svc.reload()
+    svc.coordinator.api.query.assert_awaited_with("service.control", ["RELOAD", "ssh"])
     svc.coordinator.async_refresh.assert_awaited_once()
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2716,6 +2716,14 @@ def test_supports_container_api_from_26() -> None:
     assert coord.supports_container_api() is True
 
 
+def test_supports_service_control_from_26() -> None:
+    coord = _bare_coordinator()
+    coord._version_major, coord._version_minor = 25, 10
+    assert coord.supports_service_control() is False
+    coord._version_major, coord._version_minor = 26, 0
+    assert coord.supports_service_control() is True
+
+
 async def test_get_container_empty_when_not_monitored() -> None:
     coord = _bare_coordinator()
     coord.ds = {"container": {"stale": {}}}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -52,6 +52,24 @@ async def test_service_switch_turn_off_calls_service_stop_and_refreshes() -> Non
     coordinator.async_request_refresh.assert_awaited_once()
 
 
+async def test_service_switch_turn_on_v26_uses_service_control() -> None:
+    coordinator = make_coordinator(data={"service": {"s1": {"service": "ssh"}}})
+    coordinator.supports_service_control.return_value = True
+    switch = TrueNASServiceSwitch(coordinator, _SERVICE_DESC, "s1")
+    await switch.async_turn_on()
+    coordinator.api.query.assert_awaited_once_with("service.control", ["START", "ssh"])
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_service_switch_turn_off_v26_uses_service_control() -> None:
+    coordinator = make_coordinator(data={"service": {"s1": {"service": "ssh"}}})
+    coordinator.supports_service_control.return_value = True
+    switch = TrueNASServiceSwitch(coordinator, _SERVICE_DESC, "s1")
+    await switch.async_turn_off()
+    coordinator.api.query.assert_awaited_once_with("service.control", ["STOP", "ssh"])
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
 async def test_cloudsync_switch_turn_on_calls_update_method() -> None:
     coordinator = make_coordinator(data={"cloudsync": {"c1": {"id": 3}}})
     switch = TrueNASCloudsyncSwitch(coordinator, _CLOUDSYNC_DESC, "c1")


### PR DESCRIPTION
## Proposed change
Closes two gaps against upstream TrueNAS 26 support:

1. **`service.control` fallback**: TrueNAS 26 removed the legacy
   `service.start`/`service.stop`/`service.restart`/`service.reload` API
   methods, replacing them with a single `service.control(VERB, service)`
   method. Adds `supports_service_control()` to the coordinator (mirroring
   the existing `supports_container_api()` version-gate pattern) and a
   shared `_control_service()` helper on `TrueNASEntity` that picks the
   right API shape depending on the detected TrueNAS version. Wired into
   the service switch and service binary sensor entities.
2. **`from_entry()` null-handling bug**: a JSON `null` for a present key
   resolved to Python `None` instead of falling back to the field's
   declared default (e.g. `core.get_jobs`' `progress/percent` is `null`
   before a job starts progressing, where the spec declares a `0`
   default). Fixed so `None` is now treated the same as a missing key.

## Type of change
- [x] Bugfix
- [x] Code quality improvements to existing code or addition of tests

## Additional information
Deliberately **not** addressed in this branch (risk accepted): both
`supports_service_control()` and `supports_container_api()` fall back to
`False` (legacy API path) whenever the TrueNAS version can't be parsed,
rather than distinguishing "confirmed pre-26" from "version unknown".
This can only be properly verified against a real TrueNAS 26 instance and
will be picked up separately once one is available.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add TrueNAS 26 service-control compatibility and correct default handling for null API values.

Bug Fixes:
- Support TrueNAS 26 service operations through the replacement `service.control` API while retaining compatibility with legacy service methods.
- Treat JSON `null` values as missing fields so declared API defaults are applied correctly.

Enhancements:
- Centralize service operation handling across service switches and binary sensors with version-aware API selection.

Tests:
- Add coverage for null/default parsing, TrueNAS version capability detection, and legacy versus TrueNAS 26 service control operations.