### PR TITLE
fix: isolate get_updatecheck failures from coordinator refresh

### DIFF
--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -334,6 +334,12 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # get_systemstats()/TrueNASState.systemstats_stale_graphs.
         self._systemstats_stale_graphs_logged: frozenset[str] = frozenset()
 
+        # Job names (see _run_job) currently failing, deduped so a
+        # persistently-failing job (e.g. an endpoint unsupported on the
+        # user's TrueNAS version) logs one ERROR traceback instead of one
+        # every 60s poll -- see issue #134.
+        self._job_failing: set[str] = set()
+
         # Orphaned recorder statistic_ids (no live entity) detected each poll.
         self.orphaned_statistics: list[str] = []
 
@@ -453,6 +459,39 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Error connecting to TrueNAS: {self.api.error}")
 
     # ---------------------------
+    #   _run_job
+    # ---------------------------
+    async def _run_job(self, job: Callable[[], Awaitable[None]]) -> bool:
+        """Run one coordinator job, isolating its failure from the rest of the poll.
+
+        Every per-endpoint job (and, since #134, the throttled update check)
+        is routed through here so a single failing endpoint degrades to a
+        stale/missing value instead of failing the whole coordinator refresh.
+        Logs a full ERROR traceback only the first time a given job starts
+        failing (deduped via ``self._job_failing``) and an INFO line once it
+        recovers, rather than a traceback on every 60s poll for a
+        persistently-failing job -- mirrors ``_log_systemstats_staleness``.
+        Returns True if the job completed without raising, False otherwise,
+        so callers with their own success-gated bookkeeping (e.g. the
+        update-check throttle) can tell the two apart.
+        """
+        name = getattr(job, "__name__", str(job))
+        try:
+            await job()
+        except Exception as err:
+            if name in self._job_failing:
+                _LOGGER.debug("TrueNAS job %s still failing: %s", name, err)
+            else:
+                _LOGGER.exception("Error running TrueNAS job %s: %s", name, err)
+                self._job_failing.add(name)
+            return False
+        else:
+            if name in self._job_failing:
+                _LOGGER.info("TrueNAS job %s recovered", name)
+                self._job_failing.discard(name)
+            return True
+
+    # ---------------------------
     #   _async_update_data
     # ---------------------------
     async def _async_update_data(self) -> dict[str, Any]:
@@ -484,17 +523,6 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ]
 
         if self.api.connected():
-
-            async def _run_job(job: Callable[[], Awaitable[None]]) -> None:
-                try:
-                    await job()
-                except Exception as err:
-                    _LOGGER.exception(
-                        "Error running TrueNAS job %s: %s",
-                        getattr(job, "__name__", job),
-                        err,
-                    )
-
             # get_interface (not get_systeminfo) now populates ds["interface"],
             # and virtualization detection now lives inside TrueNASState itself
             # rather than a local self._is_virtual. get_systemstats still needs
@@ -503,7 +531,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # so both are run before the concurrent jobs -- otherwise the first
             # cycle would skip the interface graph, leaving RX/TX at 0 until
             # the next poll.
-            await _run_job(self.get_systeminfo)
+            await self._run_job(self.get_systeminfo)
 
             # A middleware error leaves ds["system_info"] at its empty initial
             # value (query() returns None on failure without dropping the
@@ -529,22 +557,30 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     " or invalid in the response from TrueNAS"
                 )
 
-            await _run_job(self.get_interface)
+            await self._run_job(self.get_interface)
 
-            await asyncio.gather(*(_run_job(job) for job in jobs))
+            await asyncio.gather(*(self._run_job(job) for job in jobs))
 
             # get_pool computes pool + dataset capacity internally via
             # TrueNASState now, so it no longer depends on get_dataset()
             # having already run; kept after gather() anyway to avoid
             # reordering the job list for this migration step.
             if self.api.connected():
-                await _run_job(self.get_pool)
+                await self._run_job(self.get_pool)
 
         now = datetime.now(UTC).replace(microsecond=0)
         delta = now - self.last_updatecheck_update
         if self.api.connected() and delta.total_seconds() > 60 * 60 * 12:
-            await self.get_updatecheck()
-            self.last_updatecheck_update = now
+            # Routed through _run_job (like every other job above) so a
+            # failure here -- e.g. a middleware hiccup on "update.status" --
+            # only skips this poll's update check instead of failing the
+            # entire coordinator refresh and taking every entity
+            # unavailable with it (#134). The throttle is only advanced on
+            # success: advancing it unconditionally would let a single
+            # transient failure silently suppress update checks for a full
+            # 12h instead of retrying on the next poll.
+            if await self._run_job(self.get_updatecheck):
+                self.last_updatecheck_update = now
 
         if not self.api.connected():
             raise UpdateFailed("TrueNAS disconnected")

--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -464,10 +464,12 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _run_job(self, job: Callable[[], Awaitable[None]]) -> bool:
         """Run one coordinator job, isolating its failure from the rest of the poll.
 
-        Every per-endpoint job (and, since #134, the throttled update check)
-        is routed through here so a single failing endpoint degrades to a
-        stale/missing value instead of failing the whole coordinator refresh.
-        Logs a full ERROR traceback only the first time a given job starts
+        Per-endpoint jobs whose callers do not perform mandatory postconditions
+        (and, since #134, the throttled update check) are routed through here so
+        a single failing endpoint degrades to a stale/missing value instead of
+        failing the whole coordinator refresh. ``get_systeminfo`` is a
+        deliberate fail-fast exception because its hostname is required by the
+        caller. Logs a full ERROR traceback only the first time a given job starts
         failing (deduped via ``self._job_failing``) and an INFO line once it
         recovers, rather than a traceback on every 60s poll for a
         persistently-failing job -- mirrors ``_log_systemstats_staleness``.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -78,6 +78,7 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._version_minor = 0
     coord._poisoned_certificate_commons = set()
     coord._systemstats_stale_graphs_logged = frozenset()
+    coord._job_failing = set()
     return coord
 
 
@@ -1353,7 +1354,99 @@ def _stub_all_jobs(coord: TrueNASCoordinator) -> None:
         "get_pool",
         "get_updatecheck",
     ):
-        setattr(coord, name, AsyncMock())
+        # __name__ set explicitly (AsyncMock's constructor doesn't honor a
+        # __name__ kwarg): AsyncMock() alone reports "AsyncMock" for every
+        # instance, which would collide all jobs onto one _job_failing dedup
+        # key instead of the distinct bound-method names used in prod.
+        job = AsyncMock()
+        job.__name__ = name
+        setattr(coord, name, job)
+
+
+async def test_run_job_logs_error_once_then_debug_then_recovers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """First failure logs an ERROR traceback, repeat failures only log at
+    DEBUG (no spam every poll), and recovery logs one INFO line -- see #134.
+    """
+    coord = _bare_coordinator()
+    job = AsyncMock(side_effect=Exception("boom"))
+    job.__name__ = "get_directoryservices"
+
+    with caplog.at_level("DEBUG", logger=coordinator_module.__name__):
+        assert await coord._run_job(job) is False
+        assert any(
+            r.levelname == "ERROR" and "get_directoryservices" in r.message
+            for r in caplog.records
+        )
+        assert "get_directoryservices" in coord._job_failing
+
+        caplog.clear()
+        assert await coord._run_job(job) is False
+        assert not any(r.levelname == "ERROR" for r in caplog.records)
+        assert any(
+            r.levelname == "DEBUG" and "get_directoryservices" in r.message
+            for r in caplog.records
+        )
+        assert "get_directoryservices" in coord._job_failing
+
+        caplog.clear()
+        job.side_effect = None
+        assert await coord._run_job(job) is True
+        assert any(
+            r.levelname == "INFO" and "recovered" in r.message for r in caplog.records
+        )
+        assert "get_directoryservices" not in coord._job_failing
+
+
+async def test_async_update_data_get_updatecheck_failure_does_not_crash() -> None:
+    """The throttled update-check call is routed through _run_job too, so a
+    failure there degrades that one value instead of failing the whole
+    coordinator refresh and taking every entity unavailable with it (#134).
+
+    The throttle timestamp must NOT advance on failure: doing so would let a
+    single transient error silently suppress update checks for 12h instead
+    of retrying on the next poll.
+    """
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord._async_ensure_connected = AsyncMock()
+    coord.async_detect_orphaned_statistics = AsyncMock()
+    coord._clear_stale_migration_rollback_issue = MagicMock()
+    coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
+    _stub_all_jobs(coord)
+    coord.get_updatecheck = AsyncMock(side_effect=Exception("boom"))
+    coord.get_updatecheck.__name__ = "get_updatecheck"
+    coord.ds = {"system_info": {"hostname": "truenas"}}
+
+    before = coord.last_updatecheck_update
+    result = await coord._async_update_data()  # must not raise
+
+    assert result is coord.ds
+    coord.get_updatecheck.assert_awaited_once()
+    assert coord.last_updatecheck_update == before
+
+
+async def test_async_update_data_get_updatecheck_success_advances_throttle() -> None:
+    """A successful update check does advance the throttle timestamp, so the
+    next poll waits the full 12h again instead of re-checking immediately.
+    """
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=True)
+    coord._async_ensure_connected = AsyncMock()
+    coord.async_detect_orphaned_statistics = AsyncMock()
+    coord._clear_stale_migration_rollback_issue = MagicMock()
+    coord.last_updatecheck_update = datetime(1970, 1, 1, tzinfo=UTC)
+    _stub_all_jobs(coord)
+    coord.ds = {"system_info": {"hostname": "truenas"}}
+
+    before = coord.last_updatecheck_update
+    await coord._async_update_data()
+
+    coord.get_updatecheck.assert_awaited_once()
+    assert coord.last_updatecheck_update > before
 
 
 async def test_async_update_data_runs_jobs_when_connected() -> None:


### PR DESCRIPTION
## Proposed change

Fixes #134. The throttled update-check job (`get_updatecheck`) ran outside `_run_job`'s per-job exception isolation, so a single failure there (e.g. a middleware hiccup on `update.status`) raised out of `_async_update_data` and failed the whole coordinator refresh, taking every entity unavailable with it.

This PR routes the update-check job through `_run_job` like every other per-endpoint job, so it degrades gracefully instead.

While fixing this, the local review pass (code-reviewer + silent-failure-hunter) caught a second, related bug: `_run_job` always returned `None`, so the caller advanced `last_updatecheck_update` regardless of success or failure. A single transient failure would have silently suppressed update checks for the full 12h throttle window instead of retrying on the next poll. `_run_job` now returns `bool`, and the throttle timestamp only advances on success.

Log-spam handling for `_run_job` follows the existing `_log_systemstats_staleness` pattern already used elsewhere in the coordinator: a full ERROR traceback only the first time a job starts failing, DEBUG while it keeps failing, and an INFO line on recovery — rather than a traceback on every 60s poll for a persistently-failing job.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Verified locally (ruff, ruff format, mypy, bandit, pytest — 873 tests passing) and against a live Home Assistant instance: synced the fix, restarted HA, and confirmed the `truenas_ce` config entry loads cleanly with no new errors in the logs.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent update-check errors from failing coordinator refreshes while preserving retries and reducing repeated failure log noise.

Bug Fixes:
- Isolate throttled update-check failures from coordinator refreshes so endpoint errors no longer make all entities unavailable.
- Advance the update-check throttle only after a successful check, allowing failed checks to retry on the next poll.

Enhancements:
- Deduplicate recurring job failure logs with an ERROR on first failure, DEBUG during continued failure, and INFO on recovery.

Tests:
- Add coverage for job failure logging behavior and update-check failure and success throttle handling.