### PR TITLE
fix: bump aiotruenas to 1.5.1, package UPS sensor fix as v2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+### Fixed
+- **UPS current sensor could stay `unavailable` forever after a restart.** TrueNAS's netdata
+  backend can return a present-but-empty `aggregations` map for an all-zero-valued metric series
+  (e.g. a UPS drawing 0 A), which the integration treated as "no usable reading." Combined with
+  the in-memory last-known-value cache resetting on every Home Assistant restart, an affected UPS
+  metric could never recover. Bumped to `aiotruenas` 1.5.1, which falls back to averaging the raw
+  netdata samples when `aggregations.mean` is missing or empty.
+
 ## [2.10.0] — TrueNAS 26 Support
 
 **This release makes the integration TrueNAS 26 ready.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.10.1] — UPS Sensor Fix
+
 ### Fixed
 - **UPS current sensor could stay `unavailable` forever after a restart.** TrueNAS's netdata
   backend can return a present-but-empty `aggregations` map for an all-zero-valued metric series

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ mypy                    # strict typing (config in pyproject.toml, scoped to cus
 
 - Ruff's `target-version` stays **py313** (Ruff 0.15.13's `py314` formatter is buggy — it collapses `except (A, B):` into invalid `except A, B:` — so don't bump it until that's fixed upstream). CI itself now runs on **Python 3.14**, because Home Assistant Core requires `>=3.14.2` from release 2026.5.x onward; `homeassistant` is only a test dependency here, but pinning CI below that threshold silently pulled in a stale, pre-3.14 release lacking newer `homeassistant.const` members.
 - CI also runs Home Assistant **hassfest** validation and HACS validation on push/PR.
-- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas>=1.5.0` from PyPI plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
+- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas>=1.5.1` from PyPI plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
 - Bumping the release: `version` in [manifest.json](custom_components/truenas_ce/manifest.json) is the source of truth (`.github/update_version.py` updates it during release).
 - A [.pre-commit-config.yaml](.pre-commit-config.yaml) mirrors the CI Ruff checks locally; run `pre-commit install` once after cloning to enable it.
 

--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ pytest-asyncio = ">=0.24"
 pytest-cov = ">=6.0"
 
 [packages]
-aiotruenas = ">=1.5.0"
+aiotruenas = ">=1.5.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f2d749fbd3156abd61cc127cf3560be5e0c83d09591e2cb8384eab69c1d96471"
+            "sha256": "f1d50c2c182a307e8031c4d699c83f118f82d7a7e414316f50fb1a524ad8c199"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,12 +16,12 @@
     "default": {
         "aiotruenas": {
             "hashes": [
-                "sha256:34992275a595e2d7c86ab643a463520f339e635d6775d43c7e767818f3cd0fe6",
-                "sha256:f255cf97179f09e2575c97203ca370e8c6c970218e3d98ce67883dbc6ccf8d99"
+                "sha256:11a97673fe9d541cbb04ff071d6fa1bd4d007d66968d4f2fd539b4d2f0a9ae4a",
+                "sha256:93346aa278dc83d0a6567eb0c4228f2cb2fa0d828acf4bfc026bab13272abe1c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.13'",
-            "version": "==1.5.0"
+            "version": "==1.5.1"
         },
         "websockets": {
             "hashes": [
@@ -426,66 +426,66 @@
         },
         "ast-serialize": {
             "hashes": [
-                "sha256:0103ce489e91b0467cc2bf2fc7eaf80b7b61d5e48aed070a9c3d594e41dffaad",
-                "sha256:0eb4562df6842d900b127c59c2896e8684e2a5eb69518cc79bfa24ec0b6bd808",
-                "sha256:1109077d53b377d022d799bc4b171c32c3a711a716248a918d3e07875b5513cd",
-                "sha256:15bd638e70753e58b3d1f2859dfdeef268bc9ebfd349c5acf477bad01cb97cfc",
-                "sha256:2251086be53a375d256faefaedffe5ccd99187be614788f8279b41dae1c5fdee",
-                "sha256:226535f407b70f22109c5faf777cb5c8e9189bf44f29b2fb4ba87093c2c01743",
-                "sha256:26e6dc5d1f7aa642d9e94b98e4d3e1c81dc6b595f01619658f7e9268379826c0",
-                "sha256:2759bc9e04b13f11b80a23a7aec8da16a27217e0f4bf61019f06ea533511d2ed",
-                "sha256:2afa657d7ce1a1e150dfa4794d1d303441bd17367d69941f9712c15e4d273b3c",
-                "sha256:2eef5883e824ff7d303be13ca1dd1aaeb1975ac9f3da5ceecb3ae43c84a54773",
-                "sha256:354d12c7463266f2ca655af6f0333ee91ea98c875ffc5f47f10f03c7fe8a0667",
-                "sha256:382cb721e2624dd1c2f4f7afd2a9b500930b057d2e24e1078cf6999c5fad1b31",
-                "sha256:3c9715c4379b33740c94819e55afe59e28d6d3f30f69b903b4fcb2ecb5335531",
-                "sha256:40a7f487e2f5523518270600e0b7f2c61beac3106da142d911c3386ed7abbcfa",
-                "sha256:4496c0d20111a243525cb074a3e9a9313bbd7d3fb1d40ddee2ade9ef680b80c6",
-                "sha256:45cfbde7e43a56a386b47f13b415d1fa4421b0a5e07ae0c84a7d883ac9aca4b2",
-                "sha256:4cb6d447b3510e47090b66560e17a466f3d61e42699c475482b505fd80ff8c83",
-                "sha256:4d10d8fb4b82d5bae455ce9f606920d8dcd563b812b43dcd8d6f9b11089cfb23",
-                "sha256:56a28b7567ba17f602a17d5603133a1292d307e957b3b5c3f66538e87548aed3",
-                "sha256:5917460c0f8322755872db1792788fcaa3835d1fb6a3f129c65ace700c7e4663",
-                "sha256:59ef8acc0ba4315024e5000e5fa8ea656a02e375ebb5ce020f3582d308d6153d",
-                "sha256:5c75ed7d94660e3ed4fd3c35672ab16c248c0be51d6b845de3edebbb6cf4526c",
-                "sha256:5cc1e7e5b6db230c980a2916350d07f9b7ad6f08fb1ab6932bd393aa0c6d9220",
-                "sha256:5d17c50e1f6e8d950d79c66a18b863dee16cea3106f597203883131dd9c6ca4f",
-                "sha256:5f72062e17859d9cbf946fcd6b2d7b20d79a4fc5dc51e28198d86c6455cd1ed4",
-                "sha256:6760026ee6903cd63d89e77a0cb9ea4f150fe619ec541b8590bcaacf26dfbb81",
-                "sha256:6c944147c80cff8cfad185835bd4772c690019988331f05095d1d5f393eefe06",
-                "sha256:6e45f7d7a663c28ed44d52b4069e32335edb7a0653a908a43bef2801d8d7c344",
-                "sha256:6ee514e465bd43dddc6b0b1d05b5baf64035b5f945ae558d4f1021b368f1c4c1",
-                "sha256:6f8b8a4c4e02d1bea4e2212727fa6ddf824d8c5926df03452ad491470ce37699",
-                "sha256:719c7a121cc3022d78b7f4f7a9fd159586e521531c0e495a245375d2c4695d4e",
-                "sha256:7272522ca885c0091b4f4165b9403eb54a59e157a248592cc2539098c7ada50b",
-                "sha256:760dce78c6c4d4df30d3df9b80be1c521e0ee1d275ae54906e9a95b150692567",
-                "sha256:7ff5abf0897f54d62bd32a2878bb154d648ceaf77f553ff39b264c1191b0d60f",
-                "sha256:82087a71fe39925ab0068ef2f25444a1c87d1e5f1901f32dcf82f6eddddeac6a",
-                "sha256:8274eebef548a927c3691c7f7c2f4635dde700164ce942273a464cc914241ae9",
-                "sha256:84bac4b6f441824d91e0540362f12c0e0f8820294652521b4ce9d7e7faa56b5b",
-                "sha256:8919e79a4525cdac63d51cd117c57f324936c902c7ecd0fd09d02aa88323b74d",
-                "sha256:8aac958cf0c0b2595a0487c7b5d2ecac88fa5c0221b83b1420ac4bf472f84cb7",
-                "sha256:8c91b2bc42a12252be53966a1f1b14cc5c843dfca82bee3bce38f2e96b327aa6",
-                "sha256:8efb53cf1c439516a563664e014ba9b6b4fd86b4869c180954edce3954a51870",
-                "sha256:93ae740c6d6f5641573122a7dcffa4baa7ef9144109c54584baad5bf827ad388",
-                "sha256:a1c252b746da0ad1883b82502eeff859221eef1d66d3f95dcb2373760a34d440",
-                "sha256:a53a4d528171b8b709b4e7d89654532189bff53947f24ac4db9c465bb10e7cd2",
-                "sha256:b3a52baa4c457d17a5729aa9bd698da8e61731f1670b4fe33923da54daa480e3",
-                "sha256:b910e8c67547efe5a5d5524de7ce80dc50a45debafaaf4b29000fc72b34a8902",
-                "sha256:c07cb3f354c234cfacf81da95194b085186d7f4c1f7ad06c7f04fb49e320ef6d",
-                "sha256:ca5ff9030b426b245cf7897137872cdb6ebe43b2e4c5e04d5812ed24955a91ba",
-                "sha256:cb698ad6625a55d5d618c9d887423fd04d65dc5ad0f3ae5a8cbd96c46cea2438",
-                "sha256:cbcc3542259ae08153e634d50dc220723415fb24510856523052b5eeb10b4950",
-                "sha256:cf2c6cc5a62839869317523e0f74737db0d1759d72fb62cffe57a40e040d6a55",
-                "sha256:d1358ef5d98f9dc96468d171317d78d746f9ef8ca45577298512a737ba9d6514",
-                "sha256:d7621157ac99ae00957196e7094fe279e7547d8b505046a9d5509c4fc740e9fc",
-                "sha256:eb1b20121a62da5937b0c11c8f31667be0102342bf55459bb44a10d8549f8f3f",
-                "sha256:efde0f316f226d4e7b211d62bc0cc17f6b4cd2d057622b889183a38956d0f9ce",
-                "sha256:f1a8508054137a1cc67a64915ba588e75f03f546a9b16424aaf0cc9854b0a2a2",
-                "sha256:f47a26cc7d2605fb645b6e7f6c21cf4fb8d7833d00ea8b48e26f057b14eccd01"
+                "sha256:01d6b2aaa91810a377ea06524388e2e77af3a32dd9e1870e38b3627534f195ce",
+                "sha256:09c38f1aa78fd664028486ad1e8e7567b88a47adf373a9e56cf1395012108edf",
+                "sha256:0cc0c793063fe07e52244c66ceb2b2c5eecaa826dbb250fdeb7f0502e5697782",
+                "sha256:0ecc5e1282b8ce7c73fc204bde4eb3bad500784e1f0e14f0b9ea624124095821",
+                "sha256:1241b3963a07bd474f0a5d53f054bbbda278c805efd1d7b4ce41d0d3c5becc1e",
+                "sha256:18e28f523669d07547795aac3d9a5cf9e7c8d6ddf3dd48fe2090009ab35d0f69",
+                "sha256:1d861d8232f6c1661b805f22c96c3923a76c8feed1a4e504cecc0eaa3cd4077e",
+                "sha256:1e185d0dc0712e8568eb0477bb29583341fb00542eff3246a39d3841ee9a0d9c",
+                "sha256:2110f04937ac932c03839af266a57a8b29fd97b0789d500fa92782bdad70f475",
+                "sha256:2468e68d7f5b6d80fb619f614734f46ab8c2d474437bcba16cf3f63b5e1b3f79",
+                "sha256:2605d538e17e9569643b5c0722da8d39b1d758391e2a1902f44abfe42b8f7f78",
+                "sha256:26803ffd2daac676b4acf6683d527af091ed2fbf1c7eca861216702c3296d408",
+                "sha256:26bd819c06ee10df68dbcf2fb12c8fd2249bcadffe25ba7011f0686cbfd69b94",
+                "sha256:2fc6fcdbf95a358f3be9af5ee8ccad40e0ef61ed6b84b942003e5bd983ac4cc9",
+                "sha256:3e50f6d77d8f619e04625db5a72ab5c5256ab1b13d6de3dadbcaf3547711631d",
+                "sha256:3f552edbf9e7e0fe69b1eda569cf775c2279e5f0b839727d63c39a73adaef966",
+                "sha256:4c4c2df749d1dc6bba9a9e8cc4b5c3dfc39a351fbfe4ce22ca49c2d488c7a7ce",
+                "sha256:5b08b50d364d80dfe49002c683e9753f6e703b6c9e230737fe22fc5272235448",
+                "sha256:60d3fd70362b539318e1149ca09df0d0f9ff03e7ea72b117453003a9d8598ab7",
+                "sha256:635d63498882a5ba3b1170c6eaf1aa1c78026267e40dcbbdf4bc42b6d7babeeb",
+                "sha256:666be7180941373dbef1083b6d5f8b566c8257afa96b21ac521df96272d4e8ef",
+                "sha256:6a5879e45a85c0cce453c1302250a9d644bab59c2d615e6720da03c2d1baffe3",
+                "sha256:6cf3edf38d808e3f26094473f593feb3c05d68d4c53b366c9c3a1c3284438f71",
+                "sha256:75d12e18c8d6691ceda09f514de2effcac628b217c0b3ea17851d217bfdbdab8",
+                "sha256:781657cd74567f5b814ce3529c636bb205824bdb86951e79a05d58190ce2599b",
+                "sha256:79baeca550ad2d2eac4619e8b848a9ebe01c6c72bf90549dbb7935df83db8e29",
+                "sha256:82f67de691ae29aa44afc6fff5d7c77f93bd5218954757a9453ebdbe924cfb12",
+                "sha256:8a2ed2669adf5e92f4d0cfd70a72c8f949c66309657eabb54a2c7a0ba2577f8d",
+                "sha256:8b4b9862436eaf1442d6a16b7e138d4ff6ae558bdb6fde1c4cd87735093d5744",
+                "sha256:8dcae98b677ca0ed9988d09b83394db65385ca6f45b0ee8892e68c90e5d8df74",
+                "sha256:93206e8059d23952475099967174b7a3f573ca7dc19bdcaa59dbfbf86d76e52b",
+                "sha256:9c47daae633c843dec15c5ff5f8ec9c471deecc5257dc1f47156ebb7cc8c5b91",
+                "sha256:9e488e94ba0fe4cef06391702387656e283a3fe77653976a9a95a92a15e6ff39",
+                "sha256:a2fbc5cbff379354d6e07296f0f953955543f60134ffd91fb8f14fc0b4f1aeaa",
+                "sha256:aea29e01c9ef7f9c46da1fccdbed1811cc2a85233d0c0d4ac9c04ffaf3c3352a",
+                "sha256:b19176a6f04aadca38a80ed4e070fef896db47901257df513dceb9c7fc4751ed",
+                "sha256:c077a1c8bb3645e49256f4d31679fa4a3cfe1455cbf99080ddb3bbd40afa2457",
+                "sha256:c345fb4e035ca5db948b781d894f5d98d8a271497ce0fee319f9375d5d358c9b",
+                "sha256:c394f64c4a7aba67173dda8b70087b37c82dc899265dca160a9ccd0d2c9e1ff5",
+                "sha256:c590495b1212d91bf696b3333c31ca1765c1b980d07bf5825f9278030211df67",
+                "sha256:c912d84a7eed20aa51ce864a37e60c275a3c4f972056aab20247ec8d01b8457e",
+                "sha256:cd6b802249a22d0f44cee22452910a653493e4b974a8dbe401f6b85cb4d74219",
+                "sha256:ce307fe34458a9fb87c660730796e55f977acf5c4e9c645a806faf3436d402a9",
+                "sha256:ce35aa812044357c2a2767964def40c06c7b1ecbb94d98c73715b7978a460beb",
+                "sha256:d0ee62b0149144785e2ea158cade30a41d90446cbaeae5745cb996adcee99c68",
+                "sha256:d13a1350eb5767501d4a32bbb31ae63c17ab1c9f13f41c08e7d28150f73ac138",
+                "sha256:d2e3fb7476f2ccc2c2e40155f8e04e6110be98b6f51e52cc5476f3be5b1a1956",
+                "sha256:d475173e59fec5dd1bad84d8351c7f5230119b1d5c68bad93264657589a93043",
+                "sha256:d9c73f6e08778d696f7452f9c61e914b3a0c5ec3f24f9664785550b001bb6bb6",
+                "sha256:dd3c69e27b1be3172880bce2867c359106c28c5909f1ca6154bb7bf89847c419",
+                "sha256:e7523fce1258c810c277799557771e35a851e5c1f132d0a68ca4551675f868b7",
+                "sha256:eb22d9300e7a064fa8c45e2c1e568a4e36c4c91487ea0da5e7f589905365c866",
+                "sha256:ed1a8c44bc0557bdc3dbcf9d38df843b72f9950ef1f92d95db7c45cc8efbf136",
+                "sha256:ee8928ae9305f921484239a97030146dbb674cc10327fdf84124c4a20f73382e",
+                "sha256:f02d0905a1c1b81ead9b277a4b35c62698619a0625a73c114b81b26f75612a2d",
+                "sha256:f504a2c787d22822fcfa4297bbb014cef1dc06962a30d2710c8c1cd5cf8326ec",
+                "sha256:fc0a2fc3335a72a750c84e2a8cf113e4265edc930ac1b64b5f52fb7685070e3a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.0"
+            "version": "==0.11.0"
         },
         "astral": {
             "hashes": [
@@ -761,19 +761,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c28abbe472e9b7cad08807356311aeec51bde5218c18489da827045d2267bfd9",
-                "sha256:fe4190afe63eb562b6ba6a3911cf4427473b35fa047adde093bf696d3ae09fc0"
+                "sha256:4b669742d5b45b8fd20ca50ac414a4e4cf995ebb8f280d21be28676e71c97594",
+                "sha256:aaaa1216d65ddb3dcf86bf9d93cfa436af05cbcd1e1f8b2847f2b83116012186"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.43.89"
+            "version": "==1.43.90"
         },
         "botocore": {
             "hashes": [
-                "sha256:d7211220c815427fe71225acc6909e4ab5dfab3b03770e72fd16cf9eb86b3d1a",
-                "sha256:f0574942970742657b0e0716cf08c2dfe6bef8e6de5fbb7081c3424e262b4cca"
+                "sha256:65f3394ef07314e45c92a90120988531d651136390d464a94938a92f665893f7",
+                "sha256:a139ed601e8b8fb1d730022355fe2b284b8c15cfe9ac0f100254a35d2273e1d3"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.43.89"
+            "version": "==1.43.90"
         },
         "btsocket": {
             "hashes": [
@@ -2641,11 +2641,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d",
-                "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6"
+                "sha256:52f2f181bbfde907966932cc8312d967d02976422d66d537ea16092b8e291081",
+                "sha256:f23abafea7dd4276d1f29104b83598d7dcc567cafd07c9c951e66665645437fc"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.11.7"
+            "version": "==4.11.8"
         },
         "pluggy": {
             "hashes": [

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -12,7 +12,7 @@
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
     "quality_scale": "platinum",
     "requirements": [
-        "aiotruenas>=1.5.0",
+        "aiotruenas>=1.5.1",
         "websockets>=15.0.1"
     ],
     "version": "2.10.0",

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -15,7 +15,7 @@
         "aiotruenas>=1.5.1",
         "websockets>=15.0.1"
     ],
-    "version": "2.10.0",
+    "version": "2.10.1",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change

Bumps the `aiotruenas` runtime dependency from `>=1.5.0` to `>=1.5.1` and packages the fix as release **v2.10.1**.

TrueNAS's netdata backend can return a present-but-empty `aggregations` map for an all-zero-valued metric series (e.g. a UPS drawing 0 A), which `aiotruenas` treated as "no usable reading." Combined with the in-memory last-known-value cache resetting on every Home Assistant restart, an affected UPS metric could never recover and stayed `unavailable` forever.

`aiotruenas` 1.5.1 fixes this by falling back to averaging the raw netdata samples when `aggregations.mean` is missing or empty (kayl-codes/aiotruenas#38).

No `custom_components` source changes beyond the version bump — this is a dependency-only fix plus `Pipfile.lock` regeneration, changelog entry and release packaging.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

- `Pipfile`, `Pipfile.lock`, and `custom_components/truenas_ce/manifest.json` all updated to `aiotruenas>=1.5.1` / `==1.5.1` consistently.
- `CLAUDE.md`'s dependency version note synced as well (this was missed on the previous 1.5.0 bump and flagged by Sourcery on that PR).
- `manifest.json` version bumped `2.10.0` → `2.10.1`; `CHANGELOG.md`'s `[Unreleased]` entry moved under a new `## [2.10.1] — UPS Sensor Fix` section.
- Verified live: synced to a running Home Assistant instance and confirmed via HA logs that `aiotruenas` 1.5.1 installs cleanly and `truenas_ce` sets up without errors.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
