### PR TITLE
docs: credit @Korkd in 2.10.1 changelog for update-check crash report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
-## [2.10.1] — UPS Sensor Fix
+## [2.10.1] — UPS Sensor & Coordinator Resilience Fixes
 
 ### Fixed
+- **A single failing background job (e.g. the throttled update-check) could take every entity
+  unavailable.** The update-check job ran outside the coordinator's per-job exception isolation,
+  so a middleware hiccup there (e.g. on `update.status`) raised out of the whole coordinator
+  refresh instead of degrading gracefully like every other per-endpoint job. It's now routed
+  through the same isolation, and its 12h throttle only advances on success, so a transient
+  failure retries on the next poll instead of silently suppressing checks for a full 12h. Thanks
+  @Korkd for reporting! (#134)
 - **UPS current sensor could stay `unavailable` forever after a restart.** TrueNAS's netdata
   backend can return a present-but-empty `aggregations` map for an all-zero-valued metric series
   (e.g. a UPS drawing 0 A), which the integration treated as "no usable reading." Combined with


### PR DESCRIPTION
## Proposed change

PR #136 (already merged to master) fixed the coordinator crash reported in #134, but the CHANGELOG's `[2.10.1]` section only documented the UPS sensor fix so far. This adds the missing changelog entry for the coordinator-resilience fix and credits @Korkd for the report, ahead of cutting the v2.10.1 release.

## Type of change

- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information

Docs-only change, no code touched.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update the 2.10.1 changelog to document coordinator resilience improvements and credit the crash report.