### PR TITLE
fix: bump aiotruenas to 1.5.2, package disk-temp log-noise fix as v2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ## [Unreleased]
 
+## [2.10.2] — Quieter Disk-Temperature Fallback
+
+### Fixed
+- **NVMe disk-temperature sensors logged a WARNING on every poll cycle even though nothing was
+  wrong.** TrueNAS's netdata `disktemp` graph can legitimately return zero samples for a poll
+  (observed for NVMe drives on SCALE 25.10.x) even though the RPC itself succeeds, and the
+  `disk.temperatures` API fallback already populated the temperature correctly — the warning was
+  pure log noise. Bumped to `aiotruenas` 1.5.2, which demotes this to a DEBUG trace, adds a
+  raw-sample fallback for one more empty-`aggregations` response shape, and still warns (once) on
+  a genuinely malformed netdata payload. Thanks @ErikvO for reporting! (#139)
+
 ## [2.10.1] — UPS Sensor & Coordinator Resilience Fixes
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ mypy                    # strict typing (config in pyproject.toml, scoped to cus
 
 - Ruff's `target-version` stays **py313** (Ruff 0.15.13's `py314` formatter is buggy — it collapses `except (A, B):` into invalid `except A, B:` — so don't bump it until that's fixed upstream). CI itself now runs on **Python 3.14**, because Home Assistant Core requires `>=3.14.2` from release 2026.5.x onward; `homeassistant` is only a test dependency here, but pinning CI below that threshold silently pulled in a stale, pre-3.14 release lacking newer `homeassistant.const` members.
 - CI also runs Home Assistant **hassfest** validation and HACS validation on push/PR.
-- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas>=1.5.1` from PyPI plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
+- Runtime deps come from [manifest.json](custom_components/truenas_ce/manifest.json) (`aiotruenas>=1.5.2` from PyPI plus `websockets>=15.0.1`); dev deps are in the [Pipfile](Pipfile). `.github/generate_requirements.py` regenerates `requirements*.txt` from the Pipfile during CI.
 - Bumping the release: `version` in [manifest.json](custom_components/truenas_ce/manifest.json) is the source of truth (`.github/update_version.py` updates it during release).
 - A [.pre-commit-config.yaml](.pre-commit-config.yaml) mirrors the CI Ruff checks locally; run `pre-commit install` once after cloning to enable it.
 

--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ pytest-asyncio = ">=0.24"
 pytest-cov = ">=6.0"
 
 [packages]
-aiotruenas = ">=1.5.1"
+aiotruenas = ">=1.5.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f1d50c2c182a307e8031c4d699c83f118f82d7a7e414316f50fb1a524ad8c199"
+            "sha256": "544b9f46e73ef46539ac98ccca8f899db7e09958150717ff0bafcb93290f6822"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,12 +16,12 @@
     "default": {
         "aiotruenas": {
             "hashes": [
-                "sha256:11a97673fe9d541cbb04ff071d6fa1bd4d007d66968d4f2fd539b4d2f0a9ae4a",
-                "sha256:93346aa278dc83d0a6567eb0c4228f2cb2fa0d828acf4bfc026bab13272abe1c"
+                "sha256:2fd42ad911022f32b45db847908641cc576a0dc8b827369eb83d832a9b0f83cd",
+                "sha256:e84108308f7d47c26e7e1020b705ca34f820d5c9e4ff9f006f06b369faa246ff"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.13'",
-            "version": "==1.5.1"
+            "version": "==1.5.2"
         },
         "websockets": {
             "hashes": [
@@ -1369,11 +1369,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:142cd9fa77a872c5e78c62329a0d15278fadc686eb89e760017968961a4fd6b2",
-                "sha256:f6a6a28f743f9b95ce19db5abe0f376f75eb56517dff21e1a4751e2657d3e83d"
+                "sha256:3f16ecd0117feae0dfc147e8c62eb5daeccd8bd800378c3ddf416de9b4feb6b1",
+                "sha256:a3f55a18af3652a94d8f47d6055df434f254ca1d02ef2524850c6d249ca2512c"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==3.32.5"
+            "version": "==3.32.6"
         },
         "fnv-hash-fast": {
             "hashes": [
@@ -3550,11 +3550,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:1dc49c790072a9072cb1803f9bd62aa69cd583077cada32390f75505cdc64c9b",
-                "sha256:3040eb3cbf5d32b10ffd57d167e6a162237ad82ba7d8cf1400a1efed593d85ac"
+                "sha256:a7e42d81d779dec8afd7dc4be71640fb959ea861bccfa5980cb4ad9f92e30675",
+                "sha256:ba3b0bb41063c848d84d76a9fe3fb7711aaa0f2fe78708e8f3cd9714770e4eac"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==21.7.8"
+            "version": "==21.7.9"
         },
         "voluptuous": {
             "hashes": [

--- a/custom_components/truenas_ce/manifest.json
+++ b/custom_components/truenas_ce/manifest.json
@@ -12,10 +12,10 @@
     "issue_tracker": "https://github.com/kayl-codes/homeassistant-truenas/issues",
     "quality_scale": "platinum",
     "requirements": [
-        "aiotruenas>=1.5.1",
+        "aiotruenas>=1.5.2",
         "websockets>=15.0.1"
     ],
-    "version": "2.10.1",
+    "version": "2.10.2",
     "zeroconf": [
         "_http._tcp.local."
     ]


### PR DESCRIPTION
## Proposed change
Bumps the `aiotruenas` runtime dependency to 1.5.2 to fix #139: NVMe disk-temperature sensors logged a WARNING on every poll cycle even though nothing was wrong. TrueNAS's netdata `disktemp` graph can legitimately return zero samples for a poll (observed for NVMe drives on SCALE 25.10.x) even though the RPC itself succeeds, and the `disk.temperatures` API fallback already populated the temperature correctly — the warning was pure log noise.

`aiotruenas` 1.5.2 ([release notes](https://github.com/kayl-codes/aiotruenas/releases/tag/v1.5.2)):
- Demotes the expected-empty-graph case to a DEBUG trace instead of a WARNING.
- Adds a raw-sample fallback for one more empty-`aggregations` response shape.
- Still warns (once) on a genuinely malformed netdata payload, and clears stale failure state after a successful-but-empty poll.

No code changes in `truenas_ce` itself — the root cause was entirely in the `aiotruenas` domain layer (confirmed before filing this fix). This PR is a pure dependency bump + version package: `Pipfile`/`Pipfile.lock`/`manifest.json` updated, `CHANGELOG.md` entry added, packaged as v2.10.2.

Fixes #139.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
Thanks @ErikvO for reporting!

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the aiotruenas dependency and release the integration as 2.10.2 to eliminate misleading NVMe disk-temperature warnings.

Bug Fixes:
- Reduce recurring NVMe disk-temperature warning noise by updating aiotruenas to handle expected empty netdata samples while preserving warnings for malformed payloads.

Build:
- Bump the aiotruenas runtime dependency requirement to 1.5.2 and update the lockfile.

Documentation:
- Add release notes for version 2.10.2 and the disk-temperature logging fix.

Chores:
- Release the integration as version 2.10.2.