### PR TITLE
fix: dedupe TrueNAS connection-failure log spam

### DIFF
--- a/custom_components/truenas_ce/coordinator.py
+++ b/custom_components/truenas_ce/coordinator.py
@@ -457,6 +457,12 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # every 60s poll -- see issue #134.
         self._job_failing: set[str] = set()
 
+        # Whether the last _async_ensure_connected attempt failed, deduped
+        # the same way so a persistently unreachable host (e.g. deliberately
+        # powered off via truenas_ce.system_shutdown) logs one ERROR instead
+        # of one every 60s poll -- see issue #145.
+        self._connection_failing: bool = False
+
         # Orphaned recorder statistic_ids (no live entity) detected each poll.
         self.orphaned_statistics: list[str] = []
 
@@ -563,20 +569,51 @@ class TrueNASCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     #   _async_ensure_connected
     # ---------------------------
     async def _async_ensure_connected(self) -> None:
-        """Connect if needed, raising the appropriate coordinator error on failure."""
+        """Connect if needed, raising the appropriate coordinator error on failure.
+
+        For the common case where ``api.connect()`` returns False (e.g.
+        TrueNAS unreachable), deduped like ``_run_job``/``self._job_failing``:
+        a persistently unreachable host (e.g. deliberately powered off via
+        ``truenas_ce.system_shutdown``, see #145) logs one ERROR instead of
+        one every 60s poll, plus an INFO line once the connection recovers.
+        ``quiet`` is threaded into ``api.connect()`` on repeat failures so
+        its own ERROR-level traceback is deduped too, not just the shorter
+        follow-up line below. An unexpected exception from ``api.connect()``
+        itself (rather than a normal False return) bypasses this dedup and
+        relies on the DataUpdateCoordinator's own success/failure-transition
+        logging instead -- that path is rare enough not to warrant its own
+        bookkeeping here.
+        """
         if self.api.connected():
+            self._note_connection_recovered()
             return
 
         try:
-            connected = await self.api.connect()
+            connected = await self.api.connect(quiet=self._connection_failing)
         except Exception as e:
             raise UpdateFailed(f"Error connecting to TrueNAS: {e}") from e
 
-        if not connected:
-            if self.api.error == ERR_INVALID_KEY:
-                raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
+        if connected:
+            self._note_connection_recovered()
+            return
+
+        if self.api.error == ERR_INVALID_KEY:
+            raise ConfigEntryAuthFailed("Invalid TrueNAS API key")
+        if self._connection_failing:
+            _LOGGER.debug(
+                "TrueNAS connection still failing (error code: %s)",
+                self.api.error,
+            )
+        else:
             _LOGGER.error("TrueNAS connection failed (error code: %s)", self.api.error)
-            raise UpdateFailed(f"Error connecting to TrueNAS: {self.api.error}")
+            self._connection_failing = True
+        raise UpdateFailed(f"Error connecting to TrueNAS: {self.api.error}")
+
+    def _note_connection_recovered(self) -> None:
+        """Log recovery once and clear the dedup flag; see _async_ensure_connected."""
+        if self._connection_failing:
+            _LOGGER.info("TrueNAS connection recovered")
+            self._connection_failing = False
 
     # ---------------------------
     #   _run_job

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -79,6 +79,7 @@ def _bare_coordinator() -> TrueNASCoordinator:
     coord._poisoned_certificate_commons = set()
     coord._systemstats_stale_graphs_logged = frozenset()
     coord._job_failing = set()
+    coord._connection_failing = False
     return coord
 
 
@@ -1400,6 +1401,96 @@ async def test_async_ensure_connected_succeeds() -> None:
     coord.api.connected = MagicMock(return_value=False)
     coord.api.connect = AsyncMock(return_value=True)
     await coord._async_ensure_connected()  # must not raise
+
+
+async def test_async_ensure_connected_logs_error_once_then_debug_then_recovers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """First failed connect logs an ERROR, repeat failures only log at DEBUG
+    (no spam every 60s poll while e.g. deliberately shut down), and
+    recovery logs one INFO line -- see #145.
+    """
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.connect = AsyncMock(return_value=False)
+    coord.api.error = "ERR_LOST_QUERY"
+    coord.host = "truenas.local"
+
+    with caplog.at_level("DEBUG", logger=coordinator_module.__name__):
+        with pytest.raises(coordinator_module.UpdateFailed):
+            await coord._async_ensure_connected()
+        assert any(
+            r.levelname == "ERROR" and "connection failed" in r.message
+            for r in caplog.records
+        )
+        assert coord._connection_failing is True
+        coord.api.connect.assert_awaited_with(quiet=False)
+
+        caplog.clear()
+        with pytest.raises(coordinator_module.UpdateFailed):
+            await coord._async_ensure_connected()
+        assert not any(r.levelname == "ERROR" for r in caplog.records)
+        assert any(
+            r.levelname == "DEBUG" and "still failing" in r.message
+            for r in caplog.records
+        )
+        assert coord._connection_failing is True
+        coord.api.connect.assert_awaited_with(quiet=True)
+
+        caplog.clear()
+        coord.api.connected = MagicMock(return_value=True)
+        await coord._async_ensure_connected()  # must not raise
+        assert any(
+            r.levelname == "INFO" and "recovered" in r.message for r in caplog.records
+        )
+        assert coord._connection_failing is False
+
+
+async def test_async_ensure_connected_recovers_via_reconnect_without_flapping(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A host that never reports connected() == True between polls (e.g.
+    reconnecting fresh every cycle) but whose connect() call succeeds must
+    still clear _connection_failing and log recovery -- otherwise a later,
+    genuinely new failure would be silently deduped to DEBUG forever.
+    """
+    coord = _bare_coordinator()
+    coord.api = MagicMock()
+    coord.api.connected = MagicMock(return_value=False)
+    coord.api.connect = AsyncMock(return_value=False)
+    coord.api.error = "ERR_LOST_QUERY"
+    coord.host = "truenas.local"
+
+    with caplog.at_level("DEBUG", logger=coordinator_module.__name__):
+        with pytest.raises(coordinator_module.UpdateFailed):
+            await coord._async_ensure_connected()
+        assert coord._connection_failing is True
+        coord.api.connect.assert_awaited_with(quiet=False)
+
+        # connect() itself succeeds now, but connected() is still False on
+        # entry (e.g. the client reconnects fresh every poll).
+        coord.api.connect = AsyncMock(return_value=True)
+        caplog.clear()
+        await coord._async_ensure_connected()  # must not raise
+        assert any(
+            r.levelname == "INFO" and "recovered" in r.message for r in caplog.records
+        )
+        assert coord._connection_failing is False
+
+        # A subsequent, genuinely new failure must log ERROR again, not be
+        # swallowed by a stale dedup flag.
+        coord.api.connect = AsyncMock(return_value=False)
+        coord.api.error = "ERR_LOST_LOGIN"
+        caplog.clear()
+        with pytest.raises(coordinator_module.UpdateFailed):
+            await coord._async_ensure_connected()
+        coord.api.connect.assert_awaited_with(quiet=False)
+        assert any(
+            r.levelname == "ERROR" and "connection failed" in r.message
+            for r in caplog.records
+        )
+        assert coord._connection_failing is True
 
 
 # ---------------------------


### PR DESCRIPTION
## Proposed change

Fixes #145. `_async_ensure_connected()` logged a full `ERROR` line on
*every* failed reconnect attempt — e.g. every 60s poll while TrueNAS is
deliberately powered off via `truenas_ce.system_shutdown` — instead of
degrading gracefully like every other job-failure path in the coordinator.

Applies the same ERROR-once / DEBUG-repeat / INFO-recovery dedup pattern
already established for `_run_job`/`self._job_failing` (#134):
- New `self._connection_failing` flag, mirroring `self._job_failing`.
- First failed connect logs `ERROR`; repeated failures log only `DEBUG`;
  recovery logs one `INFO` line — from *either* success path (already
  `connected()`, or a fresh `connect()` success), via a shared
  `_note_connection_recovered()` helper.
- `quiet=self._connection_failing` is threaded into `api.connect()` on
  repeat failures so its own `ERROR`-level traceback in `api.py` is
  deduped too, not just the coordinator's shorter follow-up line.

## Type of change

- [x] Bugfix

## Additional information

Two local review passes (code-reviewer + silent-failure-hunter, run in
parallel per project convention) both independently caught the same bug
in an earlier draft: the flag was only cleared in the `api.connected()`
fast path, not on a fresh `connect()` success — a flapping connection
could leave `_connection_failing` stuck `True` forever, silently
downgrading a later, genuinely new failure to `DEBUG`. Fixed before this
PR was opened; a regression test (`test_async_ensure_connected_recovers_via_reconnect_without_flapping`)
covers exactly that scenario.

Verified locally: sync'd to a live Home Assistant instance, restarted,
confirmed the integration loads cleanly and TrueNAS sensors report normal
live data with no new log noise.

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
- [x] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent repeated TrueNAS connection failures from flooding logs while preserving clear failure and recovery notifications.

Bug Fixes:
- Deduplicate recurring TrueNAS connection-failure logs by emitting one ERROR, DEBUG messages for subsequent failures, and one INFO message upon recovery.
- Ensure connection-failure state is reset and recovery is logged for both already-connected and newly successful reconnect paths.

Tests:
- Add coverage for connection-failure log deduplication, recovery, quiet reconnects, and subsequent failures after reconnecting.