### PR TITLE
chore: package v2.11.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
   indistinguishable from a genuine transient fetch failure under the new stale-data detection
   above. If this affects you, please open an issue so we can look at a more targeted fix.
 
+### Fixed
+- **Deliberately shutting down TrueNAS via the integration's own `truenas_ce.system_shutdown`
+  action logged a full ERROR traceback on every 60s poll while the host stayed down.** Connection
+  failures are now deduped the same way as the existing background-job failures: one ERROR on the
+  first failed reconnect, DEBUG on repeats, and an INFO line once the connection recovers. Thanks
+  @SpeedyQ for reporting! (#145)
+
 ### Notes
 - **UPS entities can all go unavailable together if a single UPS netdata graph gets permanently
   stuck failing after once succeeding** (e.g. issue #142's `upscurrent`) — `aiotruenas` folds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Minimum requirements throughout this fork: **Home Assistant 2025.8.0**, **TrueNA
 
 ### Fixed
 - **Deliberately shutting down TrueNAS via the integration's own `truenas_ce.system_shutdown`
-  action logged a full ERROR traceback on every 60s poll while the host stayed down.** Connection
+  action logged a full ERROR traceback on every poll while the host stayed down.** Connection
   failures are now deduped the same way as the existing background-job failures: one ERROR on the
   first failed reconnect, DEBUG on repeats, and an INFO line once the connection recovers. Thanks
   @SpeedyQ for reporting! (#145)

--- a/README.md
+++ b/README.md
@@ -422,10 +422,11 @@ integration.
 As of 2.11.0, entities also go `unavailable` when TrueNAS silently keeps serving stale data
 instead of outright failing a request — previously invisible from Home Assistant's side. This
 applies to Pools, Datasets, Directory Services, Alerts, SMB, UPS, Scrub, Network Interfaces,
-Services, Virtual Machines, System Info and App-stats entities. This is in addition to (not a
-replacement for) the pre-existing behavior of going unavailable when a background job outright
-fails. No action is needed — this makes an existing "stuck on last-known-good value" failure mode
-visible instead of introducing a new one.
+Services, Virtual Machines and System Info. App-stats entities become unavailable separately, when
+their `app.stats` event subscription cannot be established or re-established. This is in addition
+to (not a replacement for) the pre-existing behavior of going unavailable when a background job
+outright fails. No action is needed — this makes an existing "stuck on last-known-good value"
+failure mode visible instead of introducing a new one.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,16 @@ TrueNAS notification and enter a new API key — the integration reconnects imme
 existing entities, history and statistics are preserved. No need to remove and re-add the
 integration.
 
+## Entity Availability
+
+As of 2.11.0, entities also go `unavailable` when TrueNAS silently keeps serving stale data
+instead of outright failing a request — previously invisible from Home Assistant's side. This
+applies to Pools, Datasets, Directory Services, Alerts, SMB, UPS, Scrub, Network Interfaces,
+Services, Virtual Machines, System Info and App-stats entities. This is in addition to (not a
+replacement for) the pre-existing behavior of going unavailable when a background job outright
+fails. No action is needed — this makes an existing "stuck on last-known-good value" failure mode
+visible instead of introducing a new one.
+
 ## Options
 
 After setup you can fine-tune the integration via **Settings → Devices & Services → TrueNAS → Configure**. Saving the options reloads the integration so changes take effect immediately.
@@ -464,6 +474,11 @@ After setup you can fine-tune the integration via **Settings → Devices & Servi
   sub-type), so VMs, apps, pool-health and network-link sensors also show up as pickable targets in
   the UI even though only container sensors are actually supported. Picking a non-container target
   fails at call time with a clear error.
+* **A UPS can have all its entities go `unavailable` together if a single netdata graph gets
+  permanently stuck failing after once succeeding** (e.g. a UPS/NUT driver that never reports one
+  particular metric). `aiotruenas` folds per-graph UPS staleness into the same signal the
+  [Entity Availability](#entity-availability) detection relies on, so this is a known, accepted
+  side effect rather than a bug.
 
 ## Removing the integration
 


### PR DESCRIPTION
## Proposed change
Packages the v2.11.0 release: adds the connection-error log-spam dedup (#145, PR #147) to the
already-drafted 2.11.0 CHANGELOG entry (from PR #146's entity-unavailable work), and documents the
new entity-unavailable stale-data detection behavior in the README (new "Entity Availability"
section + a "Known Limitations" bullet for the UPS-graph side effect). No code changes — `manifest.json` was already bumped to `2.11.0` as part of PR #146.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information
This is docs-only: CHANGELOG.md and README.md. Version stays at the already-set `2.11.0` (minor
bump correctly reflects the new entity-unavailable feature merged via PR #146; the #145 log-spam
fix merged via PR #147 is a fix, bundled into the same not-yet-released version per the project's
"fix → extend → package" workflow rather than warranting its own release).

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted and linted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
- [ ] Tested against the latest Home Assistant version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Package the v2.11.0 release documentation with connection-error logging fixes and entity availability behavior.

Bug Fixes:
- Document the bundled connection-error log deduplication fix in the v2.11.0 changelog.

Enhancements:
- Document stale-data entity availability behavior across supported TrueNAS entities and app-stat subscriptions.

Documentation:
- Add v2.11.0 entity availability guidance and explain the known UPS graph side effect in the README.